### PR TITLE
Encrypt stored LLM API key, clear settings on logout, add CSP for remote providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ VITE_EMBEDDING_BACKEND_PREFERRED=webgpu
 # - worker batch size is clamped to 1..32
 VITE_EMBEDDING_POOL_SIZE=2
 VITE_EMBEDDING_WORKER_BATCH_SIZE=8
+
+# Optional: key used to encrypt the stored LLM API key in localStorage (e.g. 32-byte hex or base64).
+# If set, the remote provider API key is stored encrypted (bound to session + this key); if unset, the API key is not persisted.
+# Note: this value is embedded in the client bundle; it protects against casual exfiltrators that only read localStorage, not against attackers with access to the app source.
+# VITE_LLM_SETTINGS_ENCRYPTION_KEY=

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -11,6 +11,7 @@ import {
 } from "./githubOAuth";
 import { AuthContext } from "./auth-context";
 import type { AuthContextValue, AuthMethod, OAuthCallbackInput } from "./auth-types";
+import { clearSettings } from "@/lib/settings";
 
 function normalizeTokenInput(raw: string): string {
   let token = raw.trim();
@@ -61,9 +62,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
   }, []);
 
   const logout = useCallback(() => {
+    clearSettings(accessToken);
     setAccessToken(null);
     setAuthMethod(null);
-  }, []);
+  }, [accessToken]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -10,6 +10,7 @@ export type LLMProviderSettings = {
 };
 
 const STORAGE_KEY_PREFIX = "gitstarrecall.llm.settings.";
+const GCM_IV_LENGTH = 12;
 
 function getStorageKey(token: string): string {
   // Use a hash of the token to avoid storing sensitive data in plain text
@@ -17,27 +18,131 @@ function getStorageKey(token: string): string {
   return `${STORAGE_KEY_PREFIX}${Math.abs(hash)}`;
 }
 
+function getEncryptionKeyEnv(): string {
+  const v = import.meta.env.VITE_LLM_SETTINGS_ENCRYPTION_KEY;
+  return typeof v === "string" ? v : "";
+}
+
+async function deriveKey(sessionToken: string, envSecret: string): Promise<CryptoKey> {
+  const combined = new TextEncoder().encode(sessionToken + envSecret);
+  const hash = await crypto.subtle.digest("SHA-256", combined);
+  return crypto.subtle.importKey("raw", hash, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+async function encrypt(plaintext: string, key: CryptoKey): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_LENGTH));
+  const encoded = new TextEncoder().encode(plaintext);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    encoded,
+  );
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+  return btoa(String.fromCharCode(...combined));
+}
+
+async function decrypt(ciphertextBase64: string, key: CryptoKey): Promise<string> {
+  const combined = Uint8Array.from(atob(ciphertextBase64), (c) => c.charCodeAt(0));
+  const iv = combined.slice(0, GCM_IV_LENGTH);
+  const data = combined.slice(GCM_IV_LENGTH);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data,
+  );
+  return new TextDecoder().decode(decrypted);
+}
+
+type StoredSettings = Omit<LLMProviderSettings, "apiKey"> & {
+  apiKey?: string;
+  apiKeyEncrypted?: string;
+};
+
+function isValidStoredShape(parsed: unknown): parsed is StoredSettings {
+  if (parsed == null || typeof parsed !== "object") return false;
+  const p = parsed as Record<string, unknown>;
+  return (
+    typeof p.providerId === "string" &&
+    typeof p.baseUrl === "string" &&
+    typeof p.model === "string" &&
+    typeof p.allowRemoteProvider === "boolean" &&
+    typeof p.allowLocalProvider === "boolean" &&
+    (p.apiKey === undefined || typeof p.apiKey === "string") &&
+    (p.apiKeyEncrypted === undefined || typeof p.apiKeyEncrypted === "string")
+  );
+}
+
 export function loadSettings(token: string | null): LLMProviderSettings | null {
   if (!token) return null;
-  
+
   try {
     const key = getStorageKey(token);
     const stored = localStorage.getItem(key);
     if (!stored) return null;
-    
-    const parsed = JSON.parse(stored);
-    // Validate the structure
-    if (
-      typeof parsed.providerId === "string" &&
-      typeof parsed.baseUrl === "string" &&
-      typeof parsed.model === "string" &&
-      typeof parsed.apiKey === "string" &&
-      typeof parsed.allowRemoteProvider === "boolean" &&
-      typeof parsed.allowLocalProvider === "boolean"
-    ) {
-      return parsed as LLMProviderSettings;
+
+    const parsed = JSON.parse(stored) as unknown;
+    if (!isValidStoredShape(parsed)) return null;
+
+    const base: Omit<LLMProviderSettings, "apiKey"> = {
+      providerId: parsed.providerId as LLMProviderId,
+      baseUrl: parsed.baseUrl,
+      model: parsed.model,
+      allowRemoteProvider: parsed.allowRemoteProvider,
+      allowLocalProvider: parsed.allowLocalProvider,
+    };
+
+    if (typeof parsed.apiKeyEncrypted === "string") {
+      return null;
     }
+
+    if (typeof parsed.apiKey === "string") {
+      return { ...base, apiKey: parsed.apiKey };
+    }
+
+    return { ...base, apiKey: "" };
+  } catch {
     return null;
+  }
+}
+
+export async function loadSettingsAsync(token: string | null): Promise<LLMProviderSettings | null> {
+  if (!token) return null;
+
+  try {
+    const key = getStorageKey(token);
+    const stored = localStorage.getItem(key);
+    if (!stored) return null;
+
+    const parsed = JSON.parse(stored) as unknown;
+    if (!isValidStoredShape(parsed)) return null;
+
+    const base: Omit<LLMProviderSettings, "apiKey"> = {
+      providerId: parsed.providerId as LLMProviderId,
+      baseUrl: parsed.baseUrl,
+      model: parsed.model,
+      allowRemoteProvider: parsed.allowRemoteProvider,
+      allowLocalProvider: parsed.allowLocalProvider,
+    };
+
+    if (typeof parsed.apiKeyEncrypted === "string") {
+      const envSecret = getEncryptionKeyEnv();
+      if (!envSecret) return { ...base, apiKey: "" };
+      try {
+        const cryptoKey = await deriveKey(token, envSecret);
+        const apiKey = await decrypt(parsed.apiKeyEncrypted as string, cryptoKey);
+        return { ...base, apiKey };
+      } catch {
+        return { ...base, apiKey: "" };
+      }
+    }
+
+    if (typeof parsed.apiKey === "string") {
+      return { ...base, apiKey: parsed.apiKey };
+    }
+
+    return { ...base, apiKey: "" };
   } catch {
     return null;
   }
@@ -45,19 +150,55 @@ export function loadSettings(token: string | null): LLMProviderSettings | null {
 
 export function saveSettings(token: string | null, settings: LLMProviderSettings): void {
   if (!token) return;
-  
+
+  const envSecret = getEncryptionKeyEnv();
+  const hasApiKey = Boolean(settings.apiKey && settings.apiKey.trim());
+
+  const toStore: StoredSettings = {
+    providerId: settings.providerId,
+    baseUrl: settings.baseUrl,
+    model: settings.model,
+    allowRemoteProvider: settings.allowRemoteProvider,
+    allowLocalProvider: settings.allowLocalProvider,
+  };
+
+  if (hasApiKey && envSecret && typeof crypto !== "undefined" && crypto.subtle) {
+    deriveKey(token, envSecret)
+      .then((cryptoKey) => encrypt(settings.apiKey.trim(), cryptoKey))
+      .then((apiKeyEncrypted) => {
+        try {
+          const key = getStorageKey(token);
+          localStorage.setItem(key, JSON.stringify({ ...toStore, apiKeyEncrypted }));
+        } catch {
+          console.warn("Failed to save LLM settings to localStorage");
+        }
+      })
+      .catch(() => {
+        try {
+          const key = getStorageKey(token);
+          localStorage.setItem(key, JSON.stringify({ ...toStore }));
+        } catch {
+          console.warn("Failed to save LLM settings to localStorage");
+        }
+      });
+    return;
+  }
+
   try {
     const key = getStorageKey(token);
-    localStorage.setItem(key, JSON.stringify(settings));
+    if (!hasApiKey) {
+      localStorage.setItem(key, JSON.stringify({ ...toStore, apiKey: "" }));
+    } else {
+      localStorage.setItem(key, JSON.stringify(toStore));
+    }
   } catch {
-    // Storage might be full or disabled
     console.warn("Failed to save LLM settings to localStorage");
   }
 }
 
 export function clearSettings(token: string | null): void {
   if (!token) return;
-  
+
   try {
     const key = getStorageKey(token);
     localStorage.removeItem(key);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,13 +21,13 @@ const BASE_CSP_DIRECTIVES = [
 
 const DEV_CSP = [
   "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-  "connect-src 'self' ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:* https://api.github.com https://api.openai.com https://huggingface.co https://*.huggingface.co https://hf.co https://*.hf.co https://xethub.hf.co https://*.xethub.hf.co https://cdn-lfs.huggingface.co https://cdn.jsdelivr.net",
+  "connect-src 'self' ws://localhost:* ws://127.0.0.1:* http://localhost:* http://127.0.0.1:* https://api.github.com https://api.openai.com https://api.anthropic.com https://api.deepseek.com https://api.moonshot.cn https://api.moonshot.ai https://api.z.ai https://open.bigmodel.cn https://bigmodel.cn https://huggingface.co https://*.huggingface.co https://hf.co https://*.hf.co https://xethub.hf.co https://*.xethub.hf.co https://cdn-lfs.huggingface.co https://cdn.jsdelivr.net",
   ...BASE_CSP_DIRECTIVES,
 ].join("; ");
 
 const PROD_CSP = [
   "script-src 'self' 'unsafe-eval'",
-  "connect-src 'self' https://api.github.com https://api.openai.com https://huggingface.co https://*.huggingface.co https://hf.co https://*.hf.co https://xethub.hf.co https://*.xethub.hf.co https://cdn-lfs.huggingface.co https://cdn.jsdelivr.net http://localhost:11434 http://localhost:1234 http://localhost:3001",
+  "connect-src 'self' https://api.github.com https://api.openai.com https://api.anthropic.com https://api.deepseek.com https://api.moonshot.cn https://api.moonshot.ai https://api.z.ai https://open.bigmodel.cn https://bigmodel.cn https://huggingface.co https://*.huggingface.co https://hf.co https://*.hf.co https://xethub.hf.co https://*.xethub.hf.co https://cdn-lfs.huggingface.co https://cdn.jsdelivr.net http://localhost:11434 http://localhost:1234 http://localhost:3001",
   ...BASE_CSP_DIRECTIVES,
 ].join("; ");
 


### PR DESCRIPTION
## Summary
Addresses security issues from the review of commit 55898716: API key stored in plain text in localStorage, settings not cleared on logout, and CSP blocking custom remote LLM base URLs.

## Changes

- **Encrypt stored LLM API key**  
  When `VITE_LLM_SETTINGS_ENCRYPTION_KEY` is set, the remote provider API key is encrypted (AES-GCM) using a key derived from the session token + env secret before being written to localStorage. Plaintext API keys are no longer persisted; if encryption is unavailable, only non-secret provider settings are saved. Added `loadSettingsAsync()` for loading encrypted settings; existing plaintext settings continue to work.

- **Clear LLM settings on logout**  
  `logout()` in `AuthContext` now calls `clearSettings(accessToken)` before clearing the token so the current profile’s LLM settings (including any stored API key) are removed from localStorage on sign-out.

- **CSP allowlist for remote LLM providers**  
  Extended `connect-src` in both dev and prod CSP with the official API origins for: Claude (Anthropic), DeepSeek, Kimi (Moonshot CN/AI), Zai, and GLM (Zhipu). Users can use “OpenAI-compatible” with these base URLs without CSP blocking requests.