### PR TITLE
Restrict GitHub access to public read-only repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
-<p align="center">
-  <img src="./static/gitstarrecall-logo.png" width="220" alt="GitStarRecall logo">
-</p>
 
-<h1 align="center">GitStarRecall</h1>
 
-<p align="center">
-  <strong>Find your starred repos by memory, not by name.</strong>
-</p>
+# GitStarRecall
 
-<p align="center">
-  <a href="https://deepwiki.com/Abhinandan-Khurana/GitStarRecall"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-  <a href="./docs/Usage.md"><img alt="Usage Guide" src="https://img.shields.io/badge/docs-Usage_Guide-0ea5e9"></a>
-  <a href="./docs/changelogs.md"><img alt="Changelogs" src="https://img.shields.io/badge/docs-Changelogs-1d4ed8"></a>
-  <a href="./CODE_OF_CONDUCT.md"><img alt="Code of Conduct" src="https://img.shields.io/badge/community-Code_of_Conduct-15803d"></a>
-  <a href="./SECURITY.md"><img alt="Security Policy" src="https://img.shields.io/badge/security-Policy-166534"></a>
-  <a href="./docs/security-review-stride.md"><img alt="Security Review" src="https://img.shields.io/badge/security-STRIDE_Reviewed-059669"></a>
-</p>
+**Find your starred repos by memory, not by name.**
+
+
 
 **GitStarRecall** is a local-first web app that turns your GitHub stars into a searchable memory system.
 
@@ -27,6 +16,7 @@
 ***TIP: add specific details for better results.***
 
 ### LLM chat
+
 - "Recommend the best-fit repos for my use case."
 
 > **This project exists because starred repos are great until your brain says, "I know what it does, but not what it is called."**
@@ -44,13 +34,15 @@ Later, they remember functionality, not names.
 GitHub search is good, but semantic memory search is better for this exact problem.
 
 GitStarRecall solves this by:
-- Fetching your starred repositories (including private stars if token scope allows).
+
+- Fetching your starred public repositories.
 - Pulling README content and metadata.
 - Chunking and embedding content locally.
 - Letting you search in natural language.
 - Optionally generating an LLM answer from the top local matches.
 
 Full usage instructions:
+
 - [Usage Docs](./docs/Usage.md)
 
 ---
@@ -69,6 +61,7 @@ Full usage instructions:
 GitStarRecall is designed to keep your data in the browser unless you explicitly opt into remote LLM usage.
 
 What stays local by default:
+
 - GitHub star metadata.
 - README content.
 - Chunks and embeddings.
@@ -76,17 +69,20 @@ What stays local by default:
 - GitHub-account-scoped local databases and settings, so one GitHub identity does not silently reuse another identity's local index.
 
 What can go remote (opt-in only):
+
 - Prompt context sent to a remote LLM provider when you enable it.
 
 Built-in security posture:
+
 - Strict CSP with explicit allowlist.
 - OAuth code exchange via backend endpoint to avoid exposing client secret.
-- Public landing now spells out that OAuth and PAT are both read-only paths for reading authorized public/private repositories.
+- Public landing now spells out that OAuth and PAT are both read-only paths for reading authorized public repositories.
 - PAT fallback supported for power users who want a manual access path.
 - Local data delete flow for cleanup/reset.
 - Threat-model-driven docs in `docs/`.
 
 Read more:
+
 - [Architecture and PRD](./docs/tech-stack-architecture-security-prd.md)
 - [STRIDE Review](./docs/threat-modeling-stride.md)
 - [DFD diagram](./docs/dfd-diagrams.md)
@@ -99,7 +95,7 @@ Read more:
   - shader-backed background,
   - animated post-login workspace walkthrough,
   - lower `Connect your stars` section reached from `Get started`,
-  - explicit OAuth/PAT read-only access messaging for authorized public/private repositories.
+  - explicit OAuth/PAT read-only access messaging for authorized public repositories.
 - GitHub OAuth and PAT authentication paths.
 - Route-based workspace with dedicated `Setup`, `Recall`, `Library`, `Sessions`, and `Settings` surfaces.
 - Persistent app shell with workspace health, keyboard navigation, and command palette (`Cmd/Ctrl+K`).
@@ -148,7 +144,10 @@ flowchart LR
     F --> R[Remote OpenAI-Compatible - opt-in]
 ```
 
+
+
 Notes:
+
 - Star sync is user-triggered via `Fetch Stars`; search runs on existing local embeddings.
 - Vector data is stored as Float32 blobs in local SQLite tables.
 - Retrieval/search is local; no server-side vector index is required.
@@ -182,6 +181,7 @@ cp .env.example .env
 ```
 
 Then follow the complete setup and environment guide:
+
 - `docs/Usage.md`
 
 ### Run dev server
@@ -212,6 +212,7 @@ pnpm preview
 ## Usage Guide
 
 For full setup, auth, deployment, runtime modes, tuning, and troubleshooting:
+
 - `docs/Usage.md`
 
 ---
@@ -234,6 +235,7 @@ For full setup, auth, deployment, runtime modes, tuning, and troubleshooting:
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
 We prioritize:
+
 - security correctness,
 - local-first behavior,
 - deterministic tests,
@@ -250,3 +252,4 @@ We prioritize:
 ## Author
 
 - Made with <3 by [Abhinandan-Khurana](https://github.com/Abhinandan-Khurana)
+

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -115,15 +115,16 @@ The public landing page now uses a parallax-first narrative flow:
 ## 7.1 OAuth (recommended)
 
 - Click `Get started` or continue directly from the lower OAuth card and complete the GitHub OAuth flow.
-- OAuth should be treated as a read-only access path for reading the public and private repositories that the authorized account/token can access.
+- OAuth is a read-only access path for reading your starred public repositories.
+- OAuth authorization requests only the `read:user` scope.
 - Token is held in memory; not persisted as raw token storage.
 - Browser-local data scope is derived from the authenticated GitHub account, so re-login with a refreshed OAuth token keeps the same local workspace.
 
 ## 7.2 PAT fallback
 
 - Paste the token directly. Header-style prefixes such as `Bearer ` / `token `, surrounding quotes, and extra whitespace are normalized automatically before use.
-- Use a token with read access to `/user/starred` and the public/private repositories you want indexed.
-- Ensure PAT scopes can read `/user/starred` and the repositories you want indexed.
+- Use a token with read access to `/user/starred` and the public repositories you want indexed.
+- Ensure PAT scopes can read `/user/starred` and the public repositories you want indexed.
 - Browser-local data scope is derived from the authenticated GitHub account, so re-entering a different PAT for the same account keeps the same local workspace.
 
 ## 8) Daily Usage Flow
@@ -268,7 +269,7 @@ Reset actions in UI:
 
 - The app normalizes common pasted wrappers (`Bearer `, `token `, surrounding quotes, whitespace), but the underlying token still must be valid.
 - Most 401s come from invalid, expired, revoked, or incorrectly pasted tokens rather than missing extra scopes.
-- Verify the token can read `/user/starred` and any repositories you expect to import.
+- Verify the token can read `/user/starred` and any public repositories you expect to import.
 
 ## 12.2 OAuth callback 404
 

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -1,5 +1,13 @@
 # Changelogs
 
+## 2026-04-07 (Public-Repo-Only Access Policy)
+
+- Removed private-repository access across OAuth behavior, runtime sync, and product messaging.
+- OAuth now requests only `read:user` (removed `repo` scope from authorize configuration).
+- Star sync now enforces public-only ingestion by filtering out private repositories before indexing and README fetch.
+- Updated landing/auth copy and security/product docs to consistently describe public-repo read-only behavior.
+- Added OAuth scope regression coverage and public-filtering test coverage in GitHub client tests.
+
 ## 2026-03-09 (Migration Recovery Edge Cases)
 
 - Hardened the stable-scope migration paths for two low-frequency but high-impact recovery cases.
@@ -51,7 +59,7 @@
   - recorded the shipped remote-provider disclosure and local-data reset semantics, including WebLLM/model cache cleanup.
 - Aligned related user-facing docs with the current auth behavior:
   - `docs/Usage.md` now explains PAT wrapper normalization and current 401 troubleshooting guidance,
-  - `README.md` now describes OAuth/PAT as read-only access paths for authorized public/private repositories.
+  - `README.md` now describes OAuth/PAT as read-only access paths for authorized public repositories.
 
 ## 2026-03-09 (SessionChat provider label button fix)
 
@@ -60,7 +68,7 @@
 ## 2026-03-08 (GitHub Auth 401 Fix and Token Normalization)
 
 - Hardened GitHub auth token handling for both OAuth tokens and pasted PATs:
-  - shared token normalization now strips accidental `Bearer ` / `token ` prefixes, surrounding quotes, and extra whitespace before the token is stored or reused,
+  - shared token normalization now strips accidental `Bearer`  / `token`  prefixes, surrounding quotes, and extra whitespace before the token is stored or reused,
   - reduces avoidable authorization failures when users paste tokens copied from shells, headers, or quoted env values.
 - Standardized GitHub API authorization behavior around normalized raw tokens and `Bearer` request headers so login/import flows consistently send the expected credential format.
 - Improved the GitHub 401 error guidance shown to users:
@@ -223,7 +231,7 @@
   - queries use `Instruct: ...` + `Query: ...`,
   - passages/documents are embedded as raw text (no `passage:` prefix).
 - Lexical broad sampling now targets the corpus interior slice first (excluding oldest/newest windows) to reduce overlap and improve unique lexical candidate coverage.
-- Curated embedding warning logic now matches retrieval-profile model families (for example `mxbai-embed*`, `nomic-embed*`) to avoid false custom-model warnings on valid variants.
+- Curated embedding warning logic now matches retrieval-profile model families (for example `mxbai-embed`*, `nomic-embed`*) to avoid false custom-model warnings on valid variants.
 - `Rebuild Embeddings` now requires explicit user confirmation before clearing and regenerating the embedding index.
 - README section splitting for large-readme chunking is now code-fence-aware, so heading-like lines inside fenced code blocks do not create artificial section boundaries.
 - Chunk budgeting for large READMEs now intentionally under-fills when fewer than 120 windows clear the quality floor (no low-quality padding fallback).

--- a/docs/security-review-stride.md
+++ b/docs/security-review-stride.md
@@ -69,7 +69,7 @@ Security posture notes:
   - collapses extra whitespace before in-memory use.
 - Standardized GitHub API authorization around normalized raw tokens plus `Authorization: Bearer <token>` request headers.
 - Updated 401 guidance to focus on invalid, expired, revoked, or incorrectly pasted tokens instead of implying extra scopes are usually required.
-- Public auth/login copy now consistently frames OAuth and PAT as read-only access paths for starred public and private repositories when the authorized token can read them.
+- Public auth/login copy now consistently frames OAuth and PAT as read-only access paths for starred public repositories.
 - `Delete local data` now clears scoped database state, chat backup state, and browser cache entries associated with WebLLM/model runtime artifacts.
 - Legacy encrypted provider API-key migration now fails closed if `VITE_LLM_SETTINGS_ENCRYPTION_KEY` or Web Crypto support is unavailable, preserving the old record instead of silently orphaning ciphertext under the new account scope.
 - Malformed legacy provider-settings JSON is now treated as unreadable historical data and discarded during one-time migration so the same parse failure does not block every future login.
@@ -158,11 +158,11 @@ No material gaps identified for DoS mitigations.
 
 | Mitigation | Status | Evidence / Gap |
 |------------|--------|-----------------|
-| Minimal GitHub scopes / fine-grained PAT | **Context** | OAuth uses `["read:user", "repo"]` in `getOAuthConfig()`. “repo” is broad (full repo access). For “starred repos + READMEs” the threat model recommends minimal scopes or fine-grained PAT. |
+| Minimal GitHub scopes / fine-grained PAT | **Done** | OAuth now uses `["read:user"]` in `getOAuthConfig()`, and runtime sync filters private repositories before indexing so the app remains public-repo read-only. |
 | Local endpoints clearly labeled; explicit opt-in | **Done** | Local provider is labeled “Local (Ollama)” in SessionChat; base URL is user-editable in the same panel; use requires `allowLocalProvider`. |
 | Browser embedding path default; local Ollama explicit | **Done** | Default embedding flow is in-browser worker embedding; optional Ollama embedding is explicit and localhost-restricted. Browser WebLLM LLM path is feature-flagged and consent-gated. |
 
-**Recommendation:** Document that OAuth scope `repo` is used for starred repos and README access, and that users using PAT should prefer a fine-grained PAT with minimal permissions (e.g. read-only for repos they need). Consider, if GitHub API allows, narrowing OAuth scopes in the future.
+**Recommendation:** Keep docs and landing copy aligned with the public-repo-only policy and continue to steer PAT users toward minimal read-only permissions.
 
 ---
 
@@ -175,7 +175,7 @@ No material gaps identified for DoS mitigations.
 | **R** Repudiation | Aligned | Keep disclosure/audit copy aligned as new provider surfaces are added. |
 | **I** Information Disclosure | Mostly aligned | Keep sensitive material out of error messages because local/prod logging persists message text. |
 | **D** Denial of Service | Aligned | — |
-| **E** Elevation of Privilege | Aligned | Document OAuth scope; recommend fine-grained PAT where applicable. |
+| **E** Elevation of Privilege | Aligned | Keep OAuth scope at `read:user` and enforce public-repo-only indexing behavior. |
 
 ---
 
@@ -183,7 +183,7 @@ No material gaps identified for DoS mitigations.
 
 1. **Medium:** Document CSP (and `unsafe-eval`) and ensure CSP is applied in all deployment modes (e.g. static host).
 2. **Medium:** Add embedding reconciliation (e.g. `chunks_pending + embeddings_created`) for integrity.
-3. **Low:** Document OAuth scopes and fine-grained PAT guidance for users who use PAT.
+3. **Low:** Add regression checks that keep docs/copy synchronized with `read:user` + public-only behavior.
 4. **Low:** Keep error-message construction free of sensitive content because production/local observability stores message-only diagnostics.
 
 This review is based on the codebase and [threat-modeling-stride.md](./threat-modeling-stride.md) as of the review date. Re-do after significant auth, LLM, or storage changes.

--- a/docs/tech-stack-architecture-security-prd.md
+++ b/docs/tech-stack-architecture-security-prd.md
@@ -104,7 +104,7 @@ WebLLM model policy:
   - `GET /repos/{owner}/{repo}/readme` for README
   - `GET /repos/{owner}/{repo}` for repo metadata (if needed)
 - Auth: OAuth (PKCE) or fine-grained PAT
-- Permissions: `Starring` + `Contents` read for private repos (or full `repo` scope)
+- Permissions: read-only access for starred public repositories (`read:user` OAuth scope + public-repo filtering at runtime)
 
 ### 1.8 Cross-Platform Compute Compatibility
 Browser-only (default local-first path):
@@ -135,7 +135,7 @@ Reference:
 1. User authenticates with GitHub OAuth or provides a PAT.
 2. `/app` routes the user to `Setup` until repos and embeddings exist, then defaults to `Recall`.
 3. App fetches all starred repositories via GitHub REST API (paginated).
-4. For each repo, fetch README and metadata.
+4. For each public repo, fetch README and metadata.
 5. Chunk README + metadata.
 6. Embedding orchestrator schedules micro-batches to worker pool (preferred backend `webgpu`, fallback `wasm`).
 7. Store embeddings and repo metadata in SQLite WASM and build vector index.
@@ -438,7 +438,7 @@ Reference:
 - Respect GitHub rate limit headers
 - Backoff and retry strategy on 403/429
 - Avoid heavy parallel requests
-- Handle GitHub edge cases: missing README, renamed/deleted repos, and private repo access errors
+- Handle GitHub edge cases: missing README and renamed/deleted repos
 
 ### 3.6 Embedding Runtime and Worker Safety
 - Cap worker pool size (default `2`) to prevent local resource exhaustion.
@@ -468,13 +468,13 @@ Reference:
 
 ### 4.1 Assets
 - GitHub tokens (OAuth or PAT)
-- Private repo README content
+- Public repo README content
 - Local embeddings and index
 - User query history
 
 ### 4.2 Threats
 1. Token exfiltration via XSS or dependency compromise
-2. Leakage of private repo content to external LLM providers
+2. Leakage of repository content to external LLM providers
 3. Local provider exposure: sending data to a local endpoint that is not trusted
 4. Malicious README content executing scripts
 5. SQLite WASM DB corruption or malicious injection

--- a/docs/threat-modeling-stride.md
+++ b/docs/threat-modeling-stride.md
@@ -8,7 +8,7 @@ This document maps risks using the STRIDE model and lists mitigations aligned wi
 
 In scope:
 - GitHub tokens (OAuth/PAT)
-- Starred repo metadata and README content (including private repos)
+- Starred public-repo metadata and README content
 - Embeddings and vector index
 - Embedding model artifacts downloaded at runtime (browser cache)
 - Embedding runtime selection state (`webgpu` / `wasm`) and performance diagnostics
@@ -80,10 +80,10 @@ Mitigations:
 
 ### I - Information Disclosure
 Threats:
-- Private README content sent to external LLM provider unintentionally.
+- README content sent to external LLM provider unintentionally.
 - Tokens leaked through logs or URL parameters.
 - Local DB accessed by other scripts via XSS.
-- Overly verbose debug logs expose private chunk text.
+- Overly verbose debug logs expose sensitive chunk text.
 - Local reset leaves browser-cached model/runtime artifacts behind after the user expects a full wipe.
 
 Mitigations:
@@ -169,7 +169,7 @@ Mapped requirements:
 ### 5.1 Data Categories
 - GitHub user identity (username, avatar, profile URL)
 - Starred repo metadata and README content
-- Private repo content (if authorized)
+- Public repo content
 - Chat session history and user queries
 - Local embeddings and vector index
 
@@ -246,7 +246,7 @@ New/changed components:
 
 - Shared `normalizeGitHubToken` helper for OAuth callback tokens and pasted PATs.
 - GitHub API requests standardized on normalized raw tokens plus `Authorization: Bearer <token>`.
-- Public auth/login surfaces now describe OAuth and PAT as read-only access paths for starred public/private repositories when authorized.
+- Public auth/login surfaces now describe OAuth and PAT as read-only access paths for starred public repositories.
 - Local data deletion clears scoped DB state, chat backups, and browser cache entries used for WebLLM/model artifacts.
 
 Threat notes:

--- a/src/auth/githubOAuth.test.ts
+++ b/src/auth/githubOAuth.test.ts
@@ -1,0 +1,52 @@
+import { buildGitHubAuthorizeUrl, getOAuthConfig } from "./githubOAuth";
+
+function createSessionStorageMock(): Storage {
+  const backing = new Map<string, string>();
+  return {
+    get length() {
+      return backing.size;
+    },
+    clear() {
+      backing.clear();
+    },
+    getItem(key: string) {
+      return backing.has(key) ? backing.get(key)! : null;
+    },
+    key(index: number) {
+      return [...backing.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      backing.delete(key);
+    },
+    setItem(key: string, value: string) {
+      backing.set(key, value);
+    },
+  };
+}
+
+describe("github oauth scope policy", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "client-id-123");
+    vi.stubEnv("VITE_GITHUB_REDIRECT_URI", "http://localhost:5173/auth/callback");
+    vi.stubGlobal("window", { location: { origin: "http://localhost:5173" } });
+    vi.stubGlobal("sessionStorage", createSessionStorageMock());
+    vi.stubGlobal("btoa", (input: string) => Buffer.from(input, "binary").toString("base64"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  test("uses read:user as the only configured scope", () => {
+    expect(getOAuthConfig().scopes).toEqual(["read:user"]);
+  });
+
+  test("buildGitHubAuthorizeUrl serializes only read:user in scope query", async () => {
+    const url = await buildGitHubAuthorizeUrl();
+    const parsed = new URL(url);
+
+    expect(parsed.searchParams.get("scope")).toBe("read:user");
+    expect(parsed.searchParams.get("scope")).not.toContain("repo");
+  });
+});

--- a/src/auth/githubOAuth.ts
+++ b/src/auth/githubOAuth.ts
@@ -35,7 +35,7 @@ export function getOAuthConfig(): OAuthConfig {
   return {
     clientId: import.meta.env.VITE_GITHUB_CLIENT_ID ?? "",
     redirectUri,
-    scopes: ["read:user", "repo"],
+    scopes: ["read:user"],
   };
 }
 

--- a/src/components/landing/LandingConnectSection.tsx
+++ b/src/components/landing/LandingConnectSection.tsx
@@ -39,7 +39,7 @@ export function LandingConnectSection({
             Authentication
           </Badge>
           <h2 className="mt-4 font-display text-3xl font-semibold text-foreground sm:text-4xl">Connect your stars</h2>
-          <p className="mt-4 text-base leading-7 text-foreground/72">Choose OAuth for the fastest setup or use a PAT if you want manual control. Both paths only need read-only repo access.</p>
+          <p className="mt-4 text-base leading-7 text-foreground/72">Choose OAuth for the fastest setup or use a PAT if you want manual control. Both paths stay public-repo read-only.</p>
         </div>
 
         <div className="grid gap-6 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
@@ -58,7 +58,7 @@ export function LandingConnectSection({
                   <p className="text-sm text-foreground/60">No write permission is used.</p>
                 </div>
               </div>
-              <p className="mt-4 text-sm leading-7 text-foreground/72">OAuth and PAT only need read-only repo access to read your starred public and private repositories.</p>
+              <p className="mt-4 text-sm leading-7 text-foreground/72">OAuth and PAT only need read-only access to read your starred public repositories.</p>
             </div>
 
             <div className="rounded-[24px] border border-white/15 bg-white/35 p-5 dark:border-white/10 dark:bg-white/[0.04]">
@@ -102,7 +102,7 @@ export function LandingConnectSection({
                     <p className="text-xs text-foreground/55">Preferred path</p>
                   </div>
                 </div>
-                <p className="mt-4 text-sm leading-7 text-foreground/78">Read starred public and private repositories with GitHub read-only access. No write scope is used.</p>
+                <p className="mt-4 text-sm leading-7 text-foreground/78">Read starred public repositories with GitHub read-only access. No write scope is used.</p>
                 <Button onClick={onPrimaryAction} className="mt-6 w-full rounded-full shadow-[0_18px_48px_rgba(184,83,138,0.24)]">
                   <Github className="mr-2 h-4 w-4" />
                   {primaryLabel}
@@ -119,7 +119,7 @@ export function LandingConnectSection({
                     <p className="text-xs text-foreground/55">Manual fallback</p>
                   </div>
                 </div>
-                <p className="mt-4 text-sm leading-7 text-foreground/78">Use a read-only token with repo access to read your starred public and private repositories. The token stays local to this session.</p>
+                <p className="mt-4 text-sm leading-7 text-foreground/78">Use a read-only token with repo access to read your starred public repositories. The token stays local to this session.</p>
 
                 <div className="mt-5 space-y-2">
                   <Label htmlFor="landing-pat-token" className="text-xs uppercase tracking-[0.22em] text-foreground/50">

--- a/src/components/landing/LandingHero.tsx
+++ b/src/components/landing/LandingHero.tsx
@@ -21,7 +21,7 @@ const PREVIEW_ITEMS = [
   "Read stars by memory",
   "Explicit context",
   "Local-first index",
-  "Private repos supported",
+  "Public repos only",
 ] as const;
 
 function HeroCard({
@@ -134,7 +134,7 @@ export function LandingHero({
                         <Lock className="h-5 w-5" />
                       </div>
                       <p className="text-sm leading-7 text-foreground/78">
-                        GitHub OAuth uses read-only access so GitStarRecall can read your public repositories. Personal Access Tokens should use the same read-only repository scope for reading public repositories.
+                        GitHub OAuth requests public-repo read-only access, and PAT fallback should use equivalent read-only repository access. GitStarRecall never asks for write access.
                       </p>
                     </div>
                   </HeroCard>
@@ -200,7 +200,7 @@ export function LandingHero({
                           <Lock className="h-5 w-5" />
                         </div>
                         <p className="text-base leading-7 text-foreground/78">
-                          OAuth and PAT only need read-only repo access to import your starred public and private repositories. GitStarRecall never asks for write access.
+                          OAuth and PAT only need read-only access for your starred public repositories. GitStarRecall never asks for write access.
                         </p>
                       </div>
                       <div className="mt-5 flex flex-wrap gap-2 text-xs text-foreground/72">

--- a/src/components/landing/LandingWorkspaceFlow.tsx
+++ b/src/components/landing/LandingWorkspaceFlow.tsx
@@ -5,7 +5,7 @@ import { useParallaxProgress } from "@/components/landing/useParallaxProgress";
 const FLOW_STEPS = [
   {
     title: "Connect GitHub",
-    body: "Read your starred repositories with explicit read-only permissions, whether you use OAuth or a PAT.",
+    body: "Read your starred public repositories with explicit read-only permissions, whether you use OAuth or a PAT.",
     icon: Github,
   },
   {

--- a/src/github/client.test.ts
+++ b/src/github/client.test.ts
@@ -1,13 +1,13 @@
 import { createGitHubApiClient } from "./client";
 import type { GitHubStarredRepo } from "./types";
 
-function makeRepo(id: number): GitHubStarredRepo {
+function makeRepo(id: number, isPrivate = false): GitHubStarredRepo {
   return {
     id,
     node_id: `node-${id}`,
     name: `repo-${id}`,
     full_name: `owner/repo-${id}`,
-    private: false,
+    private: isPrivate,
     html_url: `https://github.com/owner/repo-${id}`,
     description: `repo ${id}`,
     stargazers_count: id,
@@ -94,6 +94,36 @@ describe("github client integration", () => {
     expect(result.fetchedPages).toBe(2);
     expect(result.repos).toHaveLength(120);
     expect(result.removedRepoIds).toEqual([9999]);
+  });
+
+  test("fetchAllStarredRepos excludes private repositories from results", async () => {
+    const fetchImpl: typeof fetch = vi.fn(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const parsed = new URL(url);
+      const page = parsed.searchParams.get("page");
+
+      if (page === "1") {
+        return jsonResponse([makeRepo(1, false), makeRepo(2, true), makeRepo(3, false)]);
+      }
+
+      return jsonResponse([], { status: 404 });
+    }) as typeof fetch;
+
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      logger: {
+        debug: () => undefined,
+        warn: () => undefined,
+      },
+    });
+
+    const result = await client.fetchAllStarredRepos({
+      previousRepoIds: [1, 2, 3],
+    });
+
+    expect(result.repos.map((repo) => repo.id)).toEqual([1, 3]);
+    expect(result.removedRepoIds).toEqual([2]);
   });
 
   test("fetchReadmes handles success, missing README, and failed responses", async () => {

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -378,18 +378,21 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
       lastRateLimit = parseRateLimit(response.headers);
       const payload = (await response.json()) as unknown;
       assertJsonArray(payload);
+      const publicRepos = payload.filter((repo) => !repo.private);
+      const filteredPrivateCount = payload.length - publicRepos.length;
 
-      repos.push(...payload);
+      repos.push(...publicRepos);
       fetchedPages += 1;
       options.onProgress?.({
         fetchedPages,
         totalReposSoFar: repos.length,
-        latestPageCount: payload.length,
+        latestPageCount: publicRepos.length,
       });
 
       logger.debug("fetched stars page", {
         page: fetchedPages,
-        count: payload.length,
+        count: publicRepos.length,
+        filteredPrivateCount,
         total: repos.length,
         remaining: lastRateLimit.remaining,
       });


### PR DESCRIPTION
## Summary
- Narrow GitHub OAuth scope to `read:user` only.
- Enforce public-only starred-repo ingestion by filtering out private repos before README/indexing.
- Align landing copy, README, and security/product docs with public-repo read-only behavior.

## Problem
The app previously requested broad OAuth `repo` scope and could ingest private starred repositories when token capabilities allowed it. That conflicted with the goal of removing private-repo access entirely.

## Solution
- Updated OAuth config to request only `read:user`.
- Added runtime filtering in GitHub client star sync (`repo.private === false`) so downstream README fetch/indexing only processes public repos.
- Added/updated tests for OAuth scope serialization and private-repo exclusion behavior.
- Updated user-facing and security docs to remove private-repo support references and document the new access model.

## Security Impact
- [ ] No change
- [x] Change (describe below)

Reduced token privilege and data exposure by removing broad `repo` scope usage and preventing private repository ingestion paths.

## Performance Impact
- [x] No change
- [ ] Improved
- [ ] Regressed (explain)

## Testing
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`

## Documentation
- [x] Updated relevant docs
- [ ] Not needed (explain)

## Threat / Data-Flow Notes
- [ ] Not applicable
- [x] Included in this PR description

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub OAuth and PAT permission guidance to clarify that access is limited to public repositories only

* **Security & Access**
  * Reduced GitHub OAuth permission scope to minimal read-only requirements
  * Added filtering to exclude private repositories from syncing and content indexing

* **Tests**
  * Added OAuth permission scope verification to prevent regressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->