### PR TITLE
fix: clean README excerpts in Library preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.2",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@typescript-eslint/eslint-plugin": "^8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.19)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.2
       '@types/react':
         specifier: ^19.0.8
         version: 19.2.14

--- a/src/components/ui/hero-section-with-smooth-bg-shader.tsx
+++ b/src/components/ui/hero-section-with-smooth-bg-shader.tsx
@@ -32,7 +32,6 @@ export function HeroSection({
   maxWidth = "max-w-7xl",
   fontFamily = "var(--font-display)",
   fontWeight = 600,
-  reducedMotion: _reducedMotion = false,
   renderContent = true,
   children,
 }: HeroSectionProps) {

--- a/src/pages/app/LibraryPage.tsx
+++ b/src/pages/app/LibraryPage.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { getLocalDatabase } from "@/db/client";
 import type { RepoRecord } from "@/db/types";
 import { useAuth } from "@/auth/useAuth";
-import SafeMarkdown from "@/components/SafeMarkdown";
+import { getReadmeDisplayExcerpt, summarizeReadmeDisplayHealth } from "@/readme/displayExcerpt";
 
 function matchesRepo(repo: RepoRecord, query: string) {
   if (!query) return true;
@@ -46,6 +46,17 @@ export default function LibraryPage() {
     };
   }, [accessToken, searchParams]);
 
+  useEffect(() => {
+    if (!import.meta.env.DEV || repos.length === 0) {
+      return;
+    }
+
+    const summary = summarizeReadmeDisplayHealth(repos);
+    if (summary["empty-display"] > 0 || summary.missing > 0) {
+      console.debug("[library-readme-preview] display health", summary);
+    }
+  }, [repos]);
+
   const filteredRepos = useMemo(() => {
     return repos.filter((repo) => {
       if (!matchesRepo(repo, query)) {
@@ -66,6 +77,10 @@ export default function LibraryPage() {
     });
   }, [query, repos, savedView]);
   const selectedRepo = filteredRepos.find((repo) => repo.id === selectedRepoId) ?? repos.find((repo) => repo.id === selectedRepoId) ?? null;
+  const selectedReadmeExcerpt = useMemo(
+    () => getReadmeDisplayExcerpt(selectedRepo?.readmeText),
+    [selectedRepo?.readmeText],
+  );
 
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
@@ -208,11 +223,12 @@ export default function LibraryPage() {
               <div>
                 <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">README excerpt</p>
                 <div className="mt-2 rounded-md border border-border/60 bg-background/70 p-4 text-sm text-muted-foreground">
-                  {selectedRepo.readmeText ? (
-                    <SafeMarkdown
-                      className="max-h-72 overflow-auto whitespace-pre-wrap break-words [&_code]:break-all [&_pre]:overflow-x-auto"
-                      content={selectedRepo.readmeText.slice(0, 1600)}
-                    />
+                  {selectedReadmeExcerpt.kind === "ready" ? (
+                    <p className="max-h-72 overflow-auto whitespace-pre-wrap break-words">
+                      {selectedReadmeExcerpt.text}
+                    </p>
+                  ) : selectedReadmeExcerpt.kind === "empty-display" ? (
+                    "README indexed, but no displayable preview text was found."
                   ) : (
                     "README content has not been indexed yet."
                   )}

--- a/src/readme/displayExcerpt.test.ts
+++ b/src/readme/displayExcerpt.test.ts
@@ -1,0 +1,90 @@
+import { getReadmeDisplayExcerpt, summarizeReadmeDisplayHealth } from "./displayExcerpt";
+
+describe("README display excerpts", () => {
+  test("returns missing when README is null", () => {
+    expect(getReadmeDisplayExcerpt(null)).toEqual({
+      kind: "missing",
+      text: null,
+    });
+  });
+
+  test("extracts visible text from HTML-heavy README prefixes", () => {
+    const readme = `
+      <p align="center">
+        <img src="banner.png" alt="ZeroClaw" />
+      </p>
+
+      <h1 align="center">ZeroClaw — Personal AI Assistant</h1>
+
+      <p align="center">
+        <strong>You own the agent. You own the data.</strong>
+      </p>
+    `;
+
+    const result = getReadmeDisplayExcerpt(readme);
+
+    expect(result.kind).toBe("ready");
+    expect(result.text).toContain("ZeroClaw");
+    expect(result.text).toContain("Personal AI Assistant");
+    expect(result.text).toContain("You own the agent");
+    expect(result.text).not.toContain("<p");
+    expect(result.text).not.toContain("<img");
+  });
+
+  test("skips badge and image noise while keeping meaningful markdown text", () => {
+    const readme = `
+      ![CI](https://img.shields.io/badge/ci-pass-green)
+      ![npm](https://img.shields.io/badge/npm-v1-blue)
+
+      # Project Name
+
+      A useful project description for local-first search.
+    `;
+
+    const result = getReadmeDisplayExcerpt(readme);
+
+    expect(result.kind).toBe("ready");
+    expect(result.text).toContain("Project Name");
+    expect(result.text).toContain("useful project description");
+    expect(result.text).not.toContain("shields.io");
+  });
+
+  test("returns empty-display when README exists but has no displayable text", () => {
+    const readme = `
+      <p align="center">
+        <img src="logo.png" />
+      </p>
+
+      ![badge](https://img.shields.io/badge/test-ok-green)
+    `;
+
+    const result = getReadmeDisplayExcerpt(readme);
+
+    expect(result.kind).toBe("empty-display");
+    expect(result.text).toBeNull();
+  });
+
+  test("truncates at a word boundary", () => {
+    const readme = `# Title\n\n${"word ".repeat(1000)}`;
+
+    const result = getReadmeDisplayExcerpt(readme, 120);
+
+    expect(result.kind).toBe("ready");
+    expect(result.text?.length).toBeLessThanOrEqual(121);
+    expect(result.text).toMatch(/…$/);
+  });
+
+  test("summarizes display health for diagnostics", () => {
+    const summary = summarizeReadmeDisplayHealth([
+      { readmeText: "# Visible" },
+      { readmeText: null },
+      { readmeText: '<img src="logo.png" />' },
+    ]);
+
+    expect(summary).toEqual({
+      ready: 1,
+      missing: 1,
+      "empty-display": 1,
+    });
+  });
+});

--- a/src/readme/displayExcerpt.ts
+++ b/src/readme/displayExcerpt.ts
@@ -1,0 +1,113 @@
+export type ReadmeDisplayExcerpt =
+  | {
+      kind: "missing";
+      text: null;
+    }
+  | {
+      kind: "empty-display";
+      text: null;
+      rawLength: number;
+    }
+  | {
+      kind: "ready";
+      text: string;
+      rawLength: number;
+    };
+
+type ReadmeDisplayHealthSummary = Record<ReadmeDisplayExcerpt["kind"], number>;
+
+type RepoWithReadmeText = {
+  readmeText: string | null | undefined;
+};
+
+function normalizeReadmeForDisplay(raw: string): string {
+  let text = raw.replace(/\r\n/g, "\n");
+
+  text = text.replace(/<svg[\s\S]*?<\/svg>/gi, " ");
+  text = text.replace(/<picture[\s\S]*?<\/picture>/gi, " ");
+  text = text.replace(/<img\b[^>]*>/gi, " ");
+
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+  text = text.replace(/<\/(p|div|h[1-6]|li|tr)>/gi, "\n");
+  text = text.replace(/<[^>]+>/g, " ");
+
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  text = text.replace(/https?:\/\/img\.shields\.io\/[^\s)]+/gi, " ");
+  text = text.replace(/https?:\/\/badge\.fury\.io\/[^\s)]+/gi, " ");
+
+  text = text.replace(/```[\s\S]*?```/g, " ");
+  text = text.replace(/`([^`]+)`/g, "$1");
+
+  text = text.replace(/^#{1,6}\s+/gm, "");
+  text = text.replace(/[*_~]{1,3}/g, "");
+  text = text.replace(/^>\s?/gm, "");
+  text = text.replace(/^[\s]*[-*+]\s+/gm, "");
+  text = text.replace(/^[\s]*\d+\.\s+/gm, "");
+  text = text.replace(/^\s*\|?[\s:|-]{3,}\|?[\s:|-|]*$/gm, " ");
+
+  text = text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function truncateAtWordBoundary(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(" ");
+
+  if (lastSpace < Math.floor(maxLength * 0.7)) {
+    return `${slice.trim()}…`;
+  }
+
+  return `${slice.slice(0, lastSpace).trim()}…`;
+}
+
+export function getReadmeDisplayExcerpt(
+  readmeText: string | null | undefined,
+  maxLength = 1600,
+): ReadmeDisplayExcerpt {
+  if (!readmeText) {
+    return { kind: "missing", text: null };
+  }
+
+  const normalized = normalizeReadmeForDisplay(readmeText);
+  if (!normalized) {
+    return {
+      kind: "empty-display",
+      text: null,
+      rawLength: readmeText.length,
+    };
+  }
+
+  return {
+    kind: "ready",
+    text: truncateAtWordBoundary(normalized, maxLength),
+    rawLength: readmeText.length,
+  };
+}
+
+export function summarizeReadmeDisplayHealth(repos: RepoWithReadmeText[]): ReadmeDisplayHealthSummary {
+  return repos.reduce<ReadmeDisplayHealthSummary>(
+    (summary, repo) => {
+      const excerpt = getReadmeDisplayExcerpt(repo.readmeText);
+      summary[excerpt.kind] += 1;
+      return summary;
+    },
+    {
+      ready: 0,
+      missing: 0,
+      "empty-display": 0,
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Closes #41.

- Add a small display-only README excerpt helper that strips HTML/image/badge/markdown noise and returns explicit preview states.
- Update Library repo preview to render cleaned plain text instead of raw `readmeText.slice(0, 1600)` through markdown.
- Add dev-only display-health diagnostics to distinguish missing README content from empty display excerpts.
- Declare `@eslint/js` because `eslint.config.js` imports it directly, and remove one existing unused prop alias so `pnpm lint` exits cleanly.

## Test Plan

- [x] `pnpm exec eslint src/readme/displayExcerpt.ts src/readme/displayExcerpt.test.ts src/pages/app/LibraryPage.tsx`
- [x] `pnpm lint` — passes with two existing Fast Refresh warnings in shadcn UI component files
- [x] `pnpm test` — 155 tests passed
- [x] `pnpm build` — passed; existing large chunk warning remains

## Notes

- Raw README storage is unchanged.
- Semantic search/chunking/retrieval behavior is unchanged.
- The Library preview now uses escaped React text, not raw HTML rendering, avoiding extra sanitization/XSS surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * README previews now intelligently extract and display content excerpts, removing HTML markup and unnecessary elements for cleaner presentation in the library view.

* **Tests**
  * Added test coverage for README excerpt extraction and display health diagnostics.

* **Chores**
  * Updated development dependencies for code quality tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abhinandan-Khurana/GitStarRecall/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->