### PR TITLE
fix: preserve sync, settings, and OAuth integrity

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@ dist
 
 # Remove this legacy-file exemption during the planned UsagePage refactor.
 src/pages/UsagePage.tsx
+
+# Remove this legacy-file exemption when LocalDatabase is intentionally normalized or refactored.
+src/db/client.ts

--- a/src/auth/githubOAuth.test.ts
+++ b/src/auth/githubOAuth.test.ts
@@ -1,4 +1,4 @@
-import { buildGitHubAuthorizeUrl, getOAuthConfig } from "./githubOAuth";
+import { buildGitHubAuthorizeUrl, exchangeOAuthCode, getOAuthConfig } from "./githubOAuth";
 
 function createSessionStorageMock(): Storage {
   const backing = new Map<string, string>();
@@ -24,13 +24,38 @@ function createSessionStorageMock(): Storage {
   };
 }
 
+function oauthResponse(
+  status = 200,
+  payload: unknown = { access_token: "issued-token" },
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+async function createOAuthSession(): Promise<{ state: string; verifier: string }> {
+  const authorizeUrl = new URL(await buildGitHubAuthorizeUrl());
+  const state = authorizeUrl.searchParams.get("state");
+  const verifier = sessionStorage.getItem("gitstarrecall.oauth.verifier");
+
+  if (!state || !verifier) {
+    throw new Error("OAuth test session was not created");
+  }
+
+  return { state, verifier };
+}
+
 describe("github oauth scope policy", () => {
   beforeEach(() => {
     vi.stubEnv("VITE_GITHUB_CLIENT_ID", "client-id-123");
     vi.stubEnv("VITE_GITHUB_REDIRECT_URI", "http://localhost:5173/auth/callback");
+    vi.stubEnv("VITE_GITHUB_OAUTH_EXCHANGE_URL", "/api/github/oauth/exchange");
     vi.stubGlobal("window", { location: { origin: "http://localhost:5173" } });
     vi.stubGlobal("sessionStorage", createSessionStorageMock());
     vi.stubGlobal("btoa", (input: string) => Buffer.from(input, "binary").toString("base64"));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(oauthResponse()));
   });
 
   afterEach(() => {
@@ -48,5 +73,128 @@ describe("github oauth scope policy", () => {
 
     expect(parsed.searchParams.get("scope")).toBe("read:user");
     expect(parsed.searchParams.get("scope")).not.toContain("repo");
+  });
+
+  test("deduplicates an in-flight exchange for the same callback payload", async () => {
+    const { state } = await createOAuthSession();
+    let resolveFetch!: (response: Response) => void;
+    vi.mocked(fetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const first = exchangeOAuthCode({ code: "callback-code", state });
+    const second = exchangeOAuthCode({ code: "callback-code", state });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    resolveFetch(oauthResponse());
+    await expect(Promise.all([first, second])).resolves.toEqual(["issued-token", "issued-token"]);
+  });
+
+  test("retains PKCE state across a transient network failure and retries directly", async () => {
+    const { state, verifier } = await createOAuthSession();
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError("network unavailable"))
+      .mockResolvedValueOnce(oauthResponse());
+
+    const firstAttempt = exchangeOAuthCode({ code: "callback-code", state });
+    await expect(firstAttempt).rejects.toMatchObject({ retryable: true });
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBe(state);
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).resolves.toBe("issued-token");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(fetch).mock.calls.map(([, options]) => JSON.parse(String(options?.body))),
+    ).toEqual([
+      expect.objectContaining({ codeVerifier: verifier }),
+      expect.objectContaining({ codeVerifier: verifier }),
+    ]);
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+  });
+
+  test.each([429, 503])("retains PKCE state after retryable HTTP %s", async (status) => {
+    const { state, verifier } = await createOAuthSession();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(oauthResponse(status))
+      .mockResolvedValueOnce(oauthResponse());
+
+    const attempt = exchangeOAuthCode({ code: "callback-code", state });
+    await expect(attempt).rejects.toMatchObject({ retryable: true });
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBe(state);
+    expect(sessionStorage.getItem("gitstarrecall.oauth.verifier")).toBe(verifier);
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).resolves.toBe("issued-token");
+  });
+
+  test("retains PKCE state when a success response contains invalid JSON", async () => {
+    const { state, verifier } = await createOAuthSession();
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ...oauthResponse(),
+      json: vi.fn().mockRejectedValue(new SyntaxError("invalid JSON")),
+    });
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).rejects.toMatchObject({
+      retryable: true,
+      message: "OAuth token exchange returned an invalid response",
+    });
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBe(state);
+    expect(sessionStorage.getItem("gitstarrecall.oauth.verifier")).toBe(verifier);
+  });
+
+  test("clears PKCE state when a success response omits the access token", async () => {
+    const { state } = await createOAuthSession();
+    vi.mocked(fetch).mockResolvedValueOnce(oauthResponse(200, {}));
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).rejects.toThrow(
+      "OAuth exchange did not return access_token",
+    );
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+  });
+
+  test("clears PKCE state after terminal rejection and rejects replay", async () => {
+    const { state } = await createOAuthSession();
+    vi.mocked(fetch).mockResolvedValueOnce(oauthResponse(400));
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).rejects.toThrow(
+      "OAuth token exchange failed (400)",
+    );
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).rejects.toThrow(
+      "OAuth session was not found",
+    );
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  test("clears PKCE state on mismatch", async () => {
+    const { state } = await createOAuthSession();
+
+    await expect(
+      exchangeOAuthCode({ code: "callback-code", state: `${state}-wrong` }),
+    ).rejects.toThrow("OAuth state mismatch");
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("expires abandoned PKCE state after ten minutes", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const { state } = await createOAuthSession();
+    vi.mocked(Date.now).mockReturnValue(now + 10 * 60 * 1000 + 1);
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).rejects.toThrow(
+      "OAuth session expired",
+    );
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("clears PKCE state after success so the callback cannot be replayed", async () => {
+    const { state } = await createOAuthSession();
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).resolves.toBe("issued-token");
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).rejects.toThrow(
+      "OAuth session was not found",
+    );
+    expect(fetch).toHaveBeenCalledOnce();
   });
 });

--- a/src/auth/githubOAuth.test.ts
+++ b/src/auth/githubOAuth.test.ts
@@ -151,6 +151,45 @@ describe("github oauth scope policy", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  test("times out a stalled response body and permits a fresh retry", async () => {
+    vi.useFakeTimers();
+    const { state, verifier } = await createOAuthSession();
+    let firstSignal: AbortSignal | undefined;
+
+    vi.mocked(fetch)
+      .mockImplementationOnce((_input, options) => {
+        firstSignal = options?.signal ?? undefined;
+        return Promise.resolve({
+          ...oauthResponse(),
+          json: () =>
+            new Promise((_resolve, reject) => {
+              firstSignal?.addEventListener("abort", () => {
+                reject(new DOMException("Aborted", "AbortError"));
+              });
+            }),
+        } as Response);
+      })
+      .mockResolvedValueOnce(oauthResponse());
+
+    const stalledAttempt = exchangeOAuthCode({ code: "callback-code", state });
+    const timeoutRejection = expect(stalledAttempt).rejects.toMatchObject({
+      retryable: true,
+      message: "OAuth token exchange timed out",
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(firstSignal).toBeDefined();
+    await vi.advanceTimersByTimeAsync(10_000);
+    await timeoutRejection;
+    expect(firstSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(sessionStorage.getItem("gitstarrecall.oauth.verifier")).toBe(verifier);
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).resolves.toBe("issued-token");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   test.each([429, 503])("retains PKCE state after retryable HTTP %s", async (status) => {
     const { state, verifier } = await createOAuthSession();
     vi.mocked(fetch)

--- a/src/auth/githubOAuth.test.ts
+++ b/src/auth/githubOAuth.test.ts
@@ -59,6 +59,7 @@ describe("github oauth scope policy", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
@@ -111,6 +112,43 @@ describe("github oauth scope policy", () => {
       expect.objectContaining({ codeVerifier: verifier }),
     ]);
     expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+  });
+
+  test("times out a stalled exchange and permits a fresh retry", async () => {
+    vi.useFakeTimers();
+    const { state, verifier } = await createOAuthSession();
+    let firstSignal: AbortSignal | undefined;
+
+    vi.mocked(fetch)
+      .mockImplementationOnce((_input, options) => {
+        firstSignal = options?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          firstSignal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      })
+      .mockResolvedValueOnce(oauthResponse());
+
+    const stalledAttempt = exchangeOAuthCode({ code: "callback-code", state });
+    const duplicateAttempt = exchangeOAuthCode({ code: "callback-code", state });
+
+    expect(stalledAttempt).toBe(duplicateAttempt);
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(firstSignal).toBeDefined();
+    const timeoutRejection = expect(stalledAttempt).rejects.toMatchObject({
+      retryable: true,
+      message: "OAuth token exchange timed out",
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    await timeoutRejection;
+    expect(firstSignal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(sessionStorage.getItem("gitstarrecall.oauth.verifier")).toBe(verifier);
+
+    await expect(exchangeOAuthCode({ code: "callback-code", state })).resolves.toBe("issued-token");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   test.each([429, 503])("retains PKCE state after retryable HTTP %s", async (status) => {

--- a/src/auth/githubOAuth.ts
+++ b/src/auth/githubOAuth.ts
@@ -2,6 +2,7 @@ const AUTH_STATE_KEY = "gitstarrecall.oauth.state";
 const AUTH_VERIFIER_KEY = "gitstarrecall.oauth.verifier";
 const AUTH_ISSUED_AT_KEY = "gitstarrecall.oauth.issued-at";
 const AUTH_SESSION_TTL_MS = 10 * 60 * 1000;
+const OAUTH_EXCHANGE_TIMEOUT_MS = 10_000;
 const inFlightExchanges = new Map<string, Promise<string>>();
 
 function base64UrlEncode(bytes: Uint8Array): string {
@@ -124,53 +125,63 @@ async function performOAuthCodeExchange(args: { code: string; state: string }): 
 
   const verifier = readOAuthSession(args.state);
   const config = getOAuthConfig();
-  let response: Response;
-  try {
-    response = await fetch(exchangeUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        code: args.code,
-        codeVerifier: verifier,
-        redirectUri: config.redirectUri,
-        clientId: config.clientId,
-      }),
-    });
-  } catch (error) {
-    throw new OAuthExchangeError("OAuth token exchange is temporarily unavailable", true, {
-      cause: error,
-    });
-  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OAUTH_EXCHANGE_TIMEOUT_MS);
 
-  if (!response.ok) {
-    if (response.status === 429 || response.status >= 500) {
-      throw new OAuthExchangeError(
-        `OAuth token exchange is temporarily unavailable (${response.status})`,
-        true,
-      );
+  try {
+    let response: Response;
+    try {
+      response = await fetch(exchangeUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          code: args.code,
+          codeVerifier: verifier,
+          redirectUri: config.redirectUri,
+          clientId: config.clientId,
+        }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const message = controller.signal.aborted
+        ? "OAuth token exchange timed out"
+        : "OAuth token exchange is temporarily unavailable";
+      throw new OAuthExchangeError(message, true, { cause: error });
     }
+
+    if (!response.ok) {
+      if (response.status === 429 || response.status >= 500) {
+        throw new OAuthExchangeError(
+          `OAuth token exchange is temporarily unavailable (${response.status})`,
+          true,
+        );
+      }
+      clearOAuthSession();
+      throw new Error(`OAuth token exchange failed (${response.status})`);
+    }
+
+    let payload: { access_token?: string };
+    try {
+      payload = (await response.json()) as { access_token?: string };
+    } catch (error) {
+      const message = controller.signal.aborted
+        ? "OAuth token exchange timed out"
+        : "OAuth token exchange returned an invalid response";
+      throw new OAuthExchangeError(message, true, { cause: error });
+    }
+
+    if (!payload.access_token) {
+      clearOAuthSession();
+      throw new Error("OAuth exchange did not return access_token");
+    }
+
     clearOAuthSession();
-    throw new Error(`OAuth token exchange failed (${response.status})`);
+    return payload.access_token;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  let payload: { access_token?: string };
-  try {
-    payload = (await response.json()) as { access_token?: string };
-  } catch (error) {
-    throw new OAuthExchangeError("OAuth token exchange returned an invalid response", true, {
-      cause: error,
-    });
-  }
-
-  if (!payload.access_token) {
-    clearOAuthSession();
-    throw new Error("OAuth exchange did not return access_token");
-  }
-
-  clearOAuthSession();
-  return payload.access_token;
 }
 
 export function exchangeOAuthCode(args: { code: string; state: string }): Promise<string> {

--- a/src/auth/githubOAuth.ts
+++ b/src/auth/githubOAuth.ts
@@ -1,5 +1,8 @@
 const AUTH_STATE_KEY = "gitstarrecall.oauth.state";
 const AUTH_VERIFIER_KEY = "gitstarrecall.oauth.verifier";
+const AUTH_ISSUED_AT_KEY = "gitstarrecall.oauth.issued-at";
+const AUTH_SESSION_TTL_MS = 10 * 60 * 1000;
+const inFlightExchanges = new Map<string, Promise<string>>();
 
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
@@ -28,6 +31,20 @@ export type OAuthConfig = {
   scopes: string[];
 };
 
+export class OAuthExchangeError extends Error {
+  readonly retryable: boolean;
+
+  constructor(message: string, retryable: boolean, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "OAuthExchangeError";
+    this.retryable = retryable;
+  }
+}
+
+export function isRetryableOAuthError(error: unknown): error is OAuthExchangeError {
+  return error instanceof OAuthExchangeError && error.retryable;
+}
+
 export function getOAuthConfig(): OAuthConfig {
   const redirectUri =
     import.meta.env.VITE_GITHUB_REDIRECT_URI ?? `${window.location.origin}/auth/callback`;
@@ -52,6 +69,7 @@ export async function buildGitHubAuthorizeUrl(): Promise<string> {
 
   sessionStorage.setItem(AUTH_STATE_KEY, state);
   sessionStorage.setItem(AUTH_VERIFIER_KEY, verifier);
+  sessionStorage.setItem(AUTH_ISSUED_AT_KEY, String(Date.now()));
 
   const params = new URLSearchParams({
     client_id: config.clientId,
@@ -66,58 +84,105 @@ export async function buildGitHubAuthorizeUrl(): Promise<string> {
   return `https://github.com/login/oauth/authorize?${params.toString()}`;
 }
 
-export function consumeOAuthSession(expectedState: string): string {
-  const storedState = sessionStorage.getItem(AUTH_STATE_KEY);
-  const verifier = sessionStorage.getItem(AUTH_VERIFIER_KEY);
-
+export function clearOAuthSession(): void {
   sessionStorage.removeItem(AUTH_STATE_KEY);
   sessionStorage.removeItem(AUTH_VERIFIER_KEY);
+  sessionStorage.removeItem(AUTH_ISSUED_AT_KEY);
+}
 
-  if (!storedState || !verifier) {
+function readOAuthSession(expectedState: string): string {
+  const storedState = sessionStorage.getItem(AUTH_STATE_KEY);
+  const verifier = sessionStorage.getItem(AUTH_VERIFIER_KEY);
+  const issuedAtRaw = sessionStorage.getItem(AUTH_ISSUED_AT_KEY);
+
+  if (!storedState || !verifier || !issuedAtRaw) {
+    clearOAuthSession();
     throw new Error("OAuth session was not found. Start login again.");
   }
 
   if (storedState !== expectedState) {
+    clearOAuthSession();
     throw new Error("OAuth state mismatch. Start login again.");
+  }
+
+  const issuedAt = Number(issuedAtRaw);
+  const age = Date.now() - issuedAt;
+  if (!Number.isFinite(issuedAt) || age < 0 || age > AUTH_SESSION_TTL_MS) {
+    clearOAuthSession();
+    throw new Error("OAuth session expired. Start login again.");
   }
 
   return verifier;
 }
 
-export async function exchangeOAuthCode(args: {
-  code: string;
-  state: string;
-}): Promise<string> {
-  const verifier = consumeOAuthSession(args.state);
+async function performOAuthCodeExchange(args: { code: string; state: string }): Promise<string> {
   const exchangeUrl = import.meta.env.VITE_GITHUB_OAUTH_EXCHANGE_URL ?? "";
 
   if (!exchangeUrl) {
     throw new Error("Missing VITE_GITHUB_OAUTH_EXCHANGE_URL");
   }
 
+  const verifier = readOAuthSession(args.state);
   const config = getOAuthConfig();
-  const response = await fetch(exchangeUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      code: args.code,
-      codeVerifier: verifier,
-      redirectUri: config.redirectUri,
-      clientId: config.clientId,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch(exchangeUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        code: args.code,
+        codeVerifier: verifier,
+        redirectUri: config.redirectUri,
+        clientId: config.clientId,
+      }),
+    });
+  } catch (error) {
+    throw new OAuthExchangeError("OAuth token exchange is temporarily unavailable", true, {
+      cause: error,
+    });
+  }
 
   if (!response.ok) {
+    if (response.status === 429 || response.status >= 500) {
+      throw new OAuthExchangeError(
+        `OAuth token exchange is temporarily unavailable (${response.status})`,
+        true,
+      );
+    }
+    clearOAuthSession();
     throw new Error(`OAuth token exchange failed (${response.status})`);
   }
 
-  const payload = (await response.json()) as { access_token?: string };
+  let payload: { access_token?: string };
+  try {
+    payload = (await response.json()) as { access_token?: string };
+  } catch (error) {
+    throw new OAuthExchangeError("OAuth token exchange returned an invalid response", true, {
+      cause: error,
+    });
+  }
 
   if (!payload.access_token) {
+    clearOAuthSession();
     throw new Error("OAuth exchange did not return access_token");
   }
 
+  clearOAuthSession();
   return payload.access_token;
+}
+
+export function exchangeOAuthCode(args: { code: string; state: string }): Promise<string> {
+  const requestKey = `${args.code}\u0000${args.state}`;
+  const existing = inFlightExchanges.get(requestKey);
+  if (existing) {
+    return existing;
+  }
+
+  const exchange = performOAuthCodeExchange(args).finally(() => {
+    inFlightExchanges.delete(requestKey);
+  });
+  inFlightExchanges.set(requestKey, exchange);
+  return exchange;
 }

--- a/src/components/ProviderSettingsStatus.test.tsx
+++ b/src/components/ProviderSettingsStatus.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { ProviderSettingsStatus } from "./ProviderSettingsStatus";
+
+describe("ProviderSettingsStatus", () => {
+  test("announces save errors with destructive styling", () => {
+    render(<ProviderSettingsStatus saveState="error" message="Provider settings not saved" />);
+
+    const status = screen.getByText("Provider settings not saved");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveClass("text-destructive");
+  });
+
+  test("announces non-error save state without destructive styling", () => {
+    render(<ProviderSettingsStatus saveState="saved" message="Provider settings saved." />);
+
+    const status = screen.getByText("Provider settings saved.");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveClass("text-muted-foreground");
+    expect(status).not.toHaveClass("text-destructive");
+  });
+});

--- a/src/components/ProviderSettingsStatus.tsx
+++ b/src/components/ProviderSettingsStatus.tsx
@@ -1,0 +1,20 @@
+import type { ProviderSettingsSaveState } from "../lib/settings";
+
+type ProviderSettingsStatusProps = {
+  saveState: ProviderSettingsSaveState;
+  message: string;
+};
+
+export function ProviderSettingsStatus({
+  saveState,
+  message,
+}: Readonly<ProviderSettingsStatusProps>) {
+  return (
+    <p
+      aria-live="polite"
+      className={`text-xs ${saveState === "error" ? "text-destructive" : "text-muted-foreground"}`}
+    >
+      {message}
+    </p>
+  );
+}

--- a/src/db/client.scope.test.ts
+++ b/src/db/client.scope.test.ts
@@ -99,6 +99,35 @@ function encodeBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+function createSchemaFailureSnapshot(): Uint8Array {
+  const rawDb = new SQL.Database();
+  rawDb.run("CREATE VIEW repos AS SELECT 1 AS id;");
+  const bytes = rawDb.export();
+  rawDb.close();
+  return bytes;
+}
+
+function createHealthySnapshot(repoId: number): Uint8Array {
+  const rawDb = new SQL.Database();
+  runSchema(rawDb);
+  rawDb.run(
+    `INSERT INTO repos (
+      id, full_name, name, topics_json, html_url, stars, forks, updated_at,
+      checksum, readme_retry_required, last_synced_at
+    ) VALUES (?, ?, ?, '[]', ?, 0, 0, '2026-07-26T00:00:00Z', ?, 0, 1);`,
+    [
+      repoId,
+      `owner/repo-${repoId}`,
+      `repo-${repoId}`,
+      `https://github.com/owner/repo-${repoId}`,
+      `checksum-${repoId}`,
+    ],
+  );
+  const bytes = rawDb.export();
+  rawDb.close();
+  return bytes;
+}
+
 async function seedRepoDatabase(args: {
   scopeKey: string;
   storageMode: "opfs" | "local-storage";
@@ -178,7 +207,9 @@ describe("database scope naming", () => {
 
   it("sanitizes authenticated scope keys", () => {
     expect(getScopedDatabaseFileName("auth:abc/123")).toBe("gitstarrecall.auth:abc_123.sqlite");
-    expect(getScopedDatabaseStorageKey("auth:abc/123")).toBe("gitstarrecall.sqlite.base64.auth:abc_123");
+    expect(getScopedDatabaseStorageKey("auth:abc/123")).toBe(
+      "gitstarrecall.sqlite.base64.auth:abc_123",
+    );
   });
 
   it("migrates legacy token-scoped local data into the stable auth scope", async () => {
@@ -279,8 +310,14 @@ describe("database scope naming", () => {
     const legacyScope = "token:legacy";
     const nextScope = "auth:github:42";
 
-    localStorage.setItem(getScopedDatabaseStorageKey(legacyScope), encodeBase64(new Uint8Array([1, 2, 3])));
-    localStorage.setItem(getScopedDatabaseStorageKey(nextScope), encodeBase64(new Uint8Array([4, 5, 6])));
+    localStorage.setItem(
+      getScopedDatabaseStorageKey(legacyScope),
+      encodeBase64(new Uint8Array([1, 2, 3])),
+    );
+    localStorage.setItem(
+      getScopedDatabaseStorageKey(nextScope),
+      encodeBase64(new Uint8Array([4, 5, 6])),
+    );
 
     const migrated = await migrateLocalDatabaseScope({
       fromScopeKey: legacyScope,
@@ -296,7 +333,10 @@ describe("database scope naming", () => {
     const legacyScope = "token:broken";
     const nextScope = "auth:github:42";
 
-    localStorage.setItem(getScopedDatabaseStorageKey(legacyScope), encodeBase64(new Uint8Array([1, 2, 3])));
+    localStorage.setItem(
+      getScopedDatabaseStorageKey(legacyScope),
+      encodeBase64(new Uint8Array([1, 2, 3])),
+    );
 
     const migrated = await migrateLocalDatabaseScope({
       fromScopeKey: legacyScope,
@@ -341,5 +381,49 @@ describe("database scope naming", () => {
 
     expect(database.listRepos().map((repo) => repo.id)).toEqual([2]);
     nowSpy.mockRestore();
+  });
+
+  it("preserves a local-storage snapshot when schema initialization fails and retries later", async () => {
+    const scopeKey = "auth:github:migration-failure-local";
+    const storageKey = getScopedDatabaseStorageKey(scopeKey);
+    const originalEncoded = encodeBase64(createSchemaFailureSnapshot());
+    localStorage.setItem(storageKey, originalEncoded);
+    setLocalDatabaseScope(scopeKey);
+
+    await expect(getLocalDatabase()).rejects.toThrow(
+      "Failed to open or migrate the local database. Stored data was preserved",
+    );
+    expect(localStorage.getItem(storageKey)).toBe(originalEncoded);
+
+    localStorage.setItem(storageKey, encodeBase64(createHealthySnapshot(91)));
+    const recovered = await getLocalDatabase();
+    expect(recovered.listRepos().map((repo) => repo.id)).toEqual([91]);
+  });
+
+  it("preserves an OPFS snapshot when schema initialization fails", async () => {
+    const scopeKey = "auth:github:migration-failure-opfs";
+    const opfsRoot = new MemoryOpfsRoot();
+    Object.defineProperty(globalThis, "navigator", {
+      value: {
+        storage: {
+          getDirectory: async () => opfsRoot,
+        },
+      },
+      configurable: true,
+    });
+    const originalBytes = createSchemaFailureSnapshot();
+    const handle = await opfsRoot.getFileHandle(getScopedDatabaseFileName(scopeKey), {
+      create: true,
+    });
+    const writable = await handle.createWritable();
+    await writable.write(originalBytes);
+    await writable.close();
+    setLocalDatabaseScope(scopeKey);
+
+    await expect(getLocalDatabase()).rejects.toThrow(
+      "Failed to open or migrate the local database. Stored data was preserved",
+    );
+    const preserved = new Uint8Array(await (await handle.getFile()).arrayBuffer());
+    expect(preserved).toEqual(originalBytes);
   });
 });

--- a/src/db/client.sync.test.ts
+++ b/src/db/client.sync.test.ts
@@ -1,0 +1,126 @@
+import initSqlJs, { type Database, type SqlJsStatic } from "sql.js";
+import { beforeAll, describe, expect, it } from "vitest";
+import { LocalDatabase, runSchema } from "./client";
+
+let SQL: SqlJsStatic;
+
+beforeAll(async () => {
+  SQL = await initSqlJs({
+    locateFile: (file) => `node_modules/sql.js/dist/${file}`,
+  });
+});
+
+function localDatabase(rawDb: Database): LocalDatabase {
+  return new LocalDatabase({ sql: SQL, db: rawDb, storageMode: "memory" });
+}
+
+describe("LocalDatabase sync state", () => {
+  it("adds retry state to an existing database without replacing repository data", () => {
+    const rawDb = new SQL.Database();
+    rawDb.run(`
+      CREATE TABLE repos (
+        id INTEGER PRIMARY KEY,
+        full_name TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        topics_json TEXT NOT NULL DEFAULT '[]',
+        language TEXT,
+        html_url TEXT NOT NULL,
+        stars INTEGER NOT NULL DEFAULT 0,
+        forks INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL,
+        readme_url TEXT,
+        readme_text TEXT,
+        readme_etag TEXT,
+        readme_last_modified TEXT,
+        checksum TEXT,
+        last_synced_at INTEGER NOT NULL
+      );
+      INSERT INTO repos VALUES (
+        1, 'owner/repo', 'repo', 'description', '["sync"]', 'TypeScript',
+        'https://github.com/owner/repo', 7, 3, '2026-01-01T00:00:00Z',
+        'https://github.com/owner/repo/blob/main/README.md', 'known README',
+        '"etag"', 'Mon, 23 Feb 2026 00:00:00 GMT', 'known-checksum', 123
+      );
+    `);
+
+    runSchema(rawDb);
+    runSchema(rawDb);
+
+    const columns = rawDb.exec("PRAGMA table_info(repos);")[0]?.values ?? [];
+    expect(columns.filter((row) => row[1] === "readme_retry_required")).toHaveLength(1);
+    expect(localDatabase(rawDb).listRepos()[0]).toMatchObject({
+      readmeText: "known README",
+      checksum: "known-checksum",
+      readmeRetryRequired: false,
+    });
+  });
+
+  it("preserves known README fields while recording metadata and retry state", async () => {
+    const rawDb = new SQL.Database();
+    runSchema(rawDb);
+    const database = localDatabase(rawDb);
+    await database.upsertRepos([
+      {
+        id: 1,
+        fullName: "owner/repo",
+        name: "repo",
+        description: "old description",
+        topics: ["sync"],
+        language: "TypeScript",
+        htmlUrl: "https://github.com/owner/repo",
+        stars: 7,
+        forks: 3,
+        updatedAt: "2026-01-01T00:00:00Z",
+        readmeUrl: "https://github.com/owner/repo/blob/main/README.md",
+        readmeText: "known README",
+        readmeEtag: '"etag"',
+        readmeLastModified: "Mon, 23 Feb 2026 00:00:00 GMT",
+        checksum: "known-checksum",
+        readmeRetryRequired: false,
+        lastSyncedAt: 123,
+      },
+    ]);
+
+    await database.upsertRepos([
+      {
+        id: 1,
+        fullName: "owner/repo",
+        name: "repo",
+        description: "new description",
+        topics: ["sync"],
+        language: "TypeScript",
+        htmlUrl: "https://github.com/owner/repo",
+        stars: 8,
+        forks: 4,
+        updatedAt: "2026-02-01T00:00:00Z",
+        readmeUrl: null,
+        readmeText: null,
+        readmeEtag: null,
+        readmeLastModified: null,
+        checksum: null,
+        readmeRetryRequired: true,
+        lastSyncedAt: 456,
+      },
+    ]);
+
+    expect(database.listRepos()[0]).toMatchObject({
+      description: "new description",
+      stars: 8,
+      forks: 4,
+      updatedAt: "2026-02-01T00:00:00Z",
+      readmeUrl: "https://github.com/owner/repo/blob/main/README.md",
+      readmeText: "known README",
+      readmeEtag: '"etag"',
+      readmeLastModified: "Mon, 23 Feb 2026 00:00:00 GMT",
+      checksum: "known-checksum",
+      readmeRetryRequired: true,
+    });
+    expect(database.listRepoSyncState()[0]).toMatchObject({
+      stars: 8,
+      forks: 4,
+      readmeRetryRequired: true,
+      readmeText: "known README",
+    });
+  });
+});

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -655,6 +655,9 @@ export function runSchema(database: Database): void {
   if (!repoColumns.has("readme_last_modified")) {
     database.run("ALTER TABLE repos ADD COLUMN readme_last_modified TEXT;");
   }
+  if (!repoColumns.has("readme_retry_required")) {
+    database.run("ALTER TABLE repos ADD COLUMN readme_retry_required INTEGER NOT NULL DEFAULT 0;");
+  }
 
   ensureChatSchema(database);
 
@@ -1402,8 +1405,9 @@ export class LocalDatabase {
     const statement = this.db.prepare(`
       INSERT INTO repos (
         id, full_name, name, description, topics_json, language, html_url, stars, forks,
-        updated_at, readme_url, readme_text, readme_etag, readme_last_modified, checksum, last_synced_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        updated_at, readme_url, readme_text, readme_etag, readme_last_modified, checksum,
+        readme_retry_required, last_synced_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         full_name = excluded.full_name,
         name = excluded.name,
@@ -1414,11 +1418,12 @@ export class LocalDatabase {
         stars = excluded.stars,
         forks = excluded.forks,
         updated_at = excluded.updated_at,
-        readme_url = excluded.readme_url,
-        readme_text = excluded.readme_text,
-        readme_etag = excluded.readme_etag,
-        readme_last_modified = excluded.readme_last_modified,
-        checksum = excluded.checksum,
+        readme_url = CASE WHEN excluded.readme_retry_required = 1 THEN repos.readme_url ELSE excluded.readme_url END,
+        readme_text = CASE WHEN excluded.readme_retry_required = 1 THEN repos.readme_text ELSE excluded.readme_text END,
+        readme_etag = CASE WHEN excluded.readme_retry_required = 1 THEN repos.readme_etag ELSE excluded.readme_etag END,
+        readme_last_modified = CASE WHEN excluded.readme_retry_required = 1 THEN repos.readme_last_modified ELSE excluded.readme_last_modified END,
+        checksum = CASE WHEN excluded.readme_retry_required = 1 THEN repos.checksum ELSE excluded.checksum END,
+        readme_retry_required = excluded.readme_retry_required,
         last_synced_at = excluded.last_synced_at;
     `);
 
@@ -1442,6 +1447,7 @@ export class LocalDatabase {
           repo.readmeEtag ?? null,
           repo.readmeLastModified ?? null,
           repo.checksum,
+          repo.readmeRetryRequired ? 1 : 0,
           repo.lastSyncedAt,
         ]);
       });
@@ -1461,7 +1467,8 @@ export class LocalDatabase {
     const result = this.db.exec(`
       SELECT
         id, full_name, name, description, topics_json, language, html_url, stars, forks,
-        updated_at, readme_url, readme_text, readme_etag, readme_last_modified, checksum, last_synced_at
+        updated_at, readme_url, readme_text, readme_etag, readme_last_modified, checksum,
+        readme_retry_required, last_synced_at
       FROM repos
       ORDER BY id ASC;
     `);
@@ -1487,13 +1494,15 @@ export class LocalDatabase {
       readmeEtag: row[12] == null ? null : String(row[12]),
       readmeLastModified: row[13] == null ? null : String(row[13]),
       checksum: row[14] == null ? null : String(row[14]),
-      lastSyncedAt: Number(row[15]),
+      readmeRetryRequired: Number(row[15]) === 1,
+      lastSyncedAt: Number(row[16]),
     }));
   }
 
   listRepoSyncState(): RepoSyncState[] {
     const result = this.db.exec(`
-      SELECT id, full_name, description, topics_json, language, updated_at, readme_etag, readme_last_modified, checksum
+      SELECT id, full_name, description, topics_json, language, updated_at, stars, forks,
+        readme_url, readme_text, readme_etag, readme_last_modified, checksum, readme_retry_required
       FROM repos
       ORDER BY id ASC;
     `);
@@ -1510,9 +1519,14 @@ export class LocalDatabase {
       topics: JSON.parse(String(row[3] ?? "[]")) as string[],
       language: row[4] == null ? null : String(row[4]),
       updatedAt: String(row[5]),
-      readmeEtag: row[6] == null ? null : String(row[6]),
-      readmeLastModified: row[7] == null ? null : String(row[7]),
-      checksum: row[8] == null ? null : String(row[8]),
+      stars: Number(row[6]),
+      forks: Number(row[7]),
+      readmeUrl: row[8] == null ? null : String(row[8]),
+      readmeText: row[9] == null ? null : String(row[9]),
+      readmeEtag: row[10] == null ? null : String(row[10]),
+      readmeLastModified: row[11] == null ? null : String(row[11]),
+      checksum: row[12] == null ? null : String(row[12]),
+      readmeRetryRequired: Number(row[13]) === 1,
     }));
   }
 
@@ -2494,8 +2508,9 @@ export async function getLocalDatabase(): Promise<LocalDatabase> {
 
       const persistedSnapshot = await readPersistedScopeSnapshot(scopeKey);
       if (persistedSnapshot) {
+        let db: Database | null = null;
         try {
-          const db = new sql.Database(persistedSnapshot.bytes);
+          db = new sql.Database(persistedSnapshot.bytes);
           runSchema(db);
           return new LocalDatabase({
             sql,
@@ -2504,13 +2519,12 @@ export async function getLocalDatabase(): Promise<LocalDatabase> {
             scopeKey,
             embeddingCheckpointPolicy,
           });
-        } catch {
-          if (persistedSnapshot.storageMode === "opfs") {
-            await clearOpfsFile(scopeKey);
-          } else {
-            clearLocalStorageBytes(scopeKey);
-          }
-          return createFreshDatabase();
+        } catch (error) {
+          db?.close();
+          throw new Error(
+            `Failed to open or migrate the local database. Stored data was preserved: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
+          );
         }
       }
 
@@ -2518,5 +2532,12 @@ export async function getLocalDatabase(): Promise<LocalDatabase> {
     })();
 
   dbPromiseByScope.set(scopeKey, promise);
-  return promise;
+  try {
+    return await promise;
+  } catch (error) {
+    if (dbPromiseByScope.get(scopeKey) === promise) {
+      dbPromiseByScope.delete(scopeKey);
+    }
+    throw error;
+  }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS repos (
   readme_etag TEXT,
   readme_last_modified TEXT,
   checksum TEXT,
+  readme_retry_required INTEGER NOT NULL DEFAULT 0,
   last_synced_at INTEGER NOT NULL
 );
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -14,6 +14,7 @@ export type RepoRecord = {
   readmeEtag?: string | null;
   readmeLastModified?: string | null;
   checksum: string | null;
+  readmeRetryRequired?: boolean;
   lastSyncedAt: number;
 };
 
@@ -24,9 +25,14 @@ export type RepoSyncState = {
   topics: string[];
   language: string | null;
   updatedAt: string;
+  stars?: number;
+  forks?: number;
+  readmeUrl?: string | null;
+  readmeText?: string | null;
   readmeEtag?: string | null;
   readmeLastModified?: string | null;
   checksum: string | null;
+  readmeRetryRequired?: boolean;
 };
 
 export type ChunkRecord = {

--- a/src/github/client.test.ts
+++ b/src/github/client.test.ts
@@ -150,6 +150,7 @@ describe("github client integration", () => {
     const client = createGitHubApiClient({
       accessToken: "token",
       fetchImpl,
+      maxRetries: 0,
       logger: {
         debug: () => undefined,
         warn: () => undefined,
@@ -161,9 +162,307 @@ describe("github client integration", () => {
     expect(result.missingCount).toBe(1);
     expect(result.failedCount).toBe(1);
     expect(result.records.some((record) => (record.readmeText ?? "").includes("hello"))).toBe(true);
-    expect(result.records.filter((record) => record.missingReadme)).toHaveLength(2);
+    expect(result.records.filter((record) => record.missingReadme)).toHaveLength(1);
     expect(result.records.every((record) => record.notModified === false)).toBe(true);
     expect(result.records.every((record) => "readmeEtag" in record)).toBe(true);
+    expect(
+      Object.fromEntries(result.records.map((record) => [record.repoId, record.outcome])),
+    ).toEqual({
+      1: "success",
+      2: "not_found",
+      3: "transient_failure",
+    });
+  });
+
+  test("fetchReadmes retries a transient server failure and honors Retry-After", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ message: "Unavailable" }, { status: 503, headers: { "retry-after": "0" } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: btoa("recovered"),
+          encoding: "base64",
+          html_url: "https://github.com/owner/repo-20/blob/main/README.md",
+        }),
+      );
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      maxRetries: 1,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    const result = await client.fetchReadmes([makeRepo(20)], {
+      concurrency: 1,
+      minConcurrency: 1,
+      maxConcurrency: 1,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.records[0]?.outcome).toBe("success");
+    expect(result.records[0]?.readmeText).toBe("recovered");
+  });
+
+  test("fetchReadmes honors an HTTP-date Retry-After value", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      const warn = vi.fn();
+      const retryAt = new Date(Date.now() + 2_000).toUTCString();
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { message: "Unavailable" },
+            { status: 503, headers: { "retry-after": retryAt } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            content: btoa("date retry recovered"),
+            encoding: "base64",
+            html_url: "https://github.com/owner/repo-25/blob/main/README.md",
+          }),
+        );
+      const client = createGitHubApiClient({
+        accessToken: "token",
+        fetchImpl,
+        maxRetries: 1,
+        logger: { debug: () => undefined, warn },
+      });
+
+      const resultPromise = client.fetchReadmes([makeRepo(25)]);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(warn).toHaveBeenCalledWith(
+        "transient GitHub response, backing off",
+        expect.objectContaining({ waitMs: 2_000 }),
+      );
+      expect(result.records[0]?.outcome).toBe("success");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("fetchReadmes honors the rate-limit reset header when Retry-After is absent", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      const warn = vi.fn();
+      const resetSeconds = Math.floor((Date.now() + 2_000) / 1_000);
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { message: "Unavailable" },
+            { status: 503, headers: { "x-ratelimit-reset": String(resetSeconds) } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            content: btoa("rate reset recovered"),
+            encoding: "base64",
+            html_url: "https://github.com/owner/repo-26/blob/main/README.md",
+          }),
+        );
+      const client = createGitHubApiClient({
+        accessToken: "token",
+        fetchImpl,
+        maxRetries: 1,
+        logger: { debug: () => undefined, warn },
+      });
+
+      const resultPromise = client.fetchReadmes([makeRepo(26)]);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(warn).toHaveBeenCalledWith(
+        "transient GitHub response, backing off",
+        expect.objectContaining({ waitMs: 2_500 }),
+      );
+      expect(result.records[0]?.outcome).toBe("success");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("fetchReadmes preserves previous README state after transient retry exhaustion", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ message: "Unavailable" }, { status: 503 }));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      maxRetries: 0,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    const result = await client.fetchReadmes([makeRepo(21)], {
+      previousSyncStateByRepoId: new Map([
+        [
+          21,
+          {
+            checksum: "known-checksum",
+            readmeUrl: "https://github.com/owner/repo-21/blob/main/README.md",
+            readmeText: "known-good README",
+            readmeEtag: '"known-etag"',
+            readmeLastModified: "Mon, 23 Feb 2026 00:00:00 GMT",
+          },
+        ],
+      ]),
+    });
+
+    expect(result.failedCount).toBe(1);
+    expect(result.missingCount).toBe(0);
+    expect(result.records[0]).toMatchObject({
+      outcome: "transient_failure",
+      readmeUrl: "https://github.com/owner/repo-21/blob/main/README.md",
+      readmeText: "known-good README",
+      readmeEtag: '"known-etag"',
+      readmeLastModified: "Mon, 23 Feb 2026 00:00:00 GMT",
+      checksum: "known-checksum",
+      missingReadme: false,
+    });
+  });
+
+  test("fetchReadmes turns a 404 into stable known-empty state", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ message: "Not Found" }, { status: 404 }));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      maxRetries: 0,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    const result = await client.fetchReadmes([makeRepo(24)], {
+      previousSyncStateByRepoId: new Map([
+        [
+          24,
+          {
+            checksum: "old-checksum",
+            readmeUrl: "https://github.com/owner/repo-24/blob/main/README.md",
+            readmeText: "removed README",
+            readmeEtag: '"old-etag"',
+            readmeLastModified: "Mon, 23 Feb 2026 00:00:00 GMT",
+          },
+        ],
+      ]),
+    });
+
+    expect(result.missingCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    expect(result.records[0]).toMatchObject({
+      outcome: "not_found",
+      readmeUrl: null,
+      readmeText: null,
+      readmeEtag: null,
+      readmeLastModified: null,
+      missingReadme: true,
+      notModified: false,
+    });
+    expect(result.records[0]?.checksum).not.toBe("old-checksum");
+  });
+
+  test("fetchReadmes treats a malformed success payload as transient and preserves prior data", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ message: "unexpected" }));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      maxRetries: 0,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    const result = await client.fetchReadmes([makeRepo(23)], {
+      previousSyncStateByRepoId: new Map([
+        [
+          23,
+          {
+            checksum: "known-checksum",
+            readmeUrl: "https://github.com/owner/repo-23/blob/main/README.md",
+            readmeText: "known-good README",
+            readmeEtag: '"known-etag"',
+            readmeLastModified: "Mon, 23 Feb 2026 00:00:00 GMT",
+          },
+        ],
+      ]),
+    });
+
+    expect(result.failedCount).toBe(1);
+    expect(result.records[0]).toMatchObject({
+      outcome: "transient_failure",
+      readmeText: "known-good README",
+      checksum: "known-checksum",
+    });
+  });
+
+  test("fetchReadmes retries a transient network failure within the configured bound", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockRejectedValueOnce(new TypeError("connection reset"))
+        .mockResolvedValueOnce(
+          jsonResponse({
+            content: btoa("network recovered"),
+            encoding: "base64",
+            html_url: "https://github.com/owner/repo-22/blob/main/README.md",
+          }),
+        );
+      const client = createGitHubApiClient({
+        accessToken: "token",
+        fetchImpl,
+        maxRetries: 1,
+        logger: { debug: () => undefined, warn: () => undefined },
+      });
+
+      const resultPromise = client.fetchReadmes([makeRepo(22)]);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(result.records[0]?.outcome).toBe("success");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("fetchReadmes preserves prior data when a network failure exhausts retries", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("connection reset"));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      maxRetries: 0,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    const result = await client.fetchReadmes([makeRepo(27)], {
+      previousSyncStateByRepoId: new Map([
+        [
+          27,
+          {
+            checksum: "known-checksum",
+            readmeUrl: "https://github.com/owner/repo-27/blob/main/README.md",
+            readmeText: "known-good README",
+            readmeEtag: '"known-etag"',
+            readmeLastModified: "Thu, 01 Jan 2026 00:00:00 GMT",
+          },
+        ],
+      ]),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.records[0]).toMatchObject({
+      outcome: "transient_failure",
+      checksum: "known-checksum",
+      readmeText: "known-good README",
+    });
   });
 
   test("fetchReadmes supports conditional revalidation and batch callbacks", async () => {
@@ -215,6 +514,8 @@ describe("github client integration", () => {
           10,
           {
             checksum: "previous-checksum",
+            readmeUrl: "https://github.com/owner/repo-10/blob/main/README.md",
+            readmeText: "previous readme",
             readmeEtag: '"etag-10"',
             readmeLastModified: "Mon, 22 Feb 2026 00:00:00 GMT",
           },
@@ -230,9 +531,12 @@ describe("github client integration", () => {
     const notModified = result.records.find((record) => record.repoId === 10);
     expect(notModified?.notModified).toBe(true);
     expect(notModified?.checksum).toBe("previous-checksum");
+    expect(notModified?.outcome).toBe("not_modified");
+    expect(notModified?.readmeText).toBe("previous readme");
     expect(notModified?.readmeEtag).toBe('"etag-10"');
     const modified = result.records.find((record) => record.repoId === 11);
     expect(modified?.notModified).toBe(false);
+    expect(modified?.outcome).toBe("success");
     expect(modified?.readmeText).toContain("fresh readme");
   });
 });

--- a/src/github/client.test.ts
+++ b/src/github/client.test.ts
@@ -249,6 +249,97 @@ describe("github client integration", () => {
     }
   });
 
+  test("fetchReadmes aborts a long server-directed retry wait without retrying", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { message: "Rate limited" },
+            { status: 429, headers: { "retry-after": "3600" } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            content: btoa("should not be fetched"),
+            encoding: "base64",
+          }),
+        );
+      const client = createGitHubApiClient({
+        accessToken: "token",
+        fetchImpl,
+        maxRetries: 1,
+        logger: { debug: () => undefined, warn: () => undefined },
+      });
+
+      const resultPromise = client.fetchReadmes([makeRepo(29)], {
+        signal: controller.signal,
+        concurrency: 1,
+        minConcurrency: 1,
+        maxConcurrency: 1,
+      });
+      const rejection = expect(resultPromise).rejects.toMatchObject({ name: "AbortError" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      controller.abort();
+      await rejection;
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("fetchReadmes aborts the shared adaptive cooldown before starting another request", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          jsonResponse(
+            { message: "Rate limited" },
+            { status: 429, headers: { "retry-after": "0" } },
+          ),
+        );
+      const client = createGitHubApiClient({
+        accessToken: "token",
+        fetchImpl,
+        maxRetries: 1,
+        logger: { debug: () => undefined, warn: () => undefined },
+      });
+
+      const resultPromise = client.fetchReadmes(
+        [makeRepo(30), makeRepo(31), makeRepo(32), makeRepo(33)],
+        {
+          signal: controller.signal,
+          concurrency: 1,
+          minConcurrency: 1,
+          maxConcurrency: 1,
+        },
+      );
+      for (let attempt = 0; attempt < 30 && fetchImpl.mock.calls.length < 6; attempt += 1) {
+        await vi.runOnlyPendingTimersAsync();
+      }
+      expect(fetchImpl).toHaveBeenCalledTimes(6);
+
+      const rejection = expect(resultPromise).rejects.toMatchObject({ name: "AbortError" });
+      controller.abort();
+      await rejection;
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      expect(fetchImpl).toHaveBeenCalledTimes(6);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("fetchReadmes honors the rate-limit reset header when Retry-After is absent", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));

--- a/src/github/client.test.ts
+++ b/src/github/client.test.ts
@@ -295,6 +295,31 @@ describe("github client integration", () => {
     }
   });
 
+  test("fetchReadmes does not retry when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(null);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ message: "Unavailable" }, { status: 503 }));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      maxRetries: 1,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    await expect(
+      client.fetchReadmes([makeRepo(34)], {
+        signal: controller.signal,
+        concurrency: 1,
+        minConcurrency: 1,
+        maxConcurrency: 1,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   test("fetchReadmes aborts the shared adaptive cooldown before starting another request", async () => {
     vi.useFakeTimers();
     try {
@@ -458,6 +483,34 @@ describe("github client integration", () => {
     expect(metadataChanged).toMatchObject({ outcome: "not_modified", readmeText });
     expect(metadataChanged?.checksum).not.toBe(initial?.checksum);
     expect(unchanged?.checksum).toBe(metadataChanged?.checksum);
+  });
+
+  test("fetchReadmes preserves a prior checksum on 304 when prior README bytes are unavailable", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 304 }));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+
+    const result = await client.fetchReadmes([makeRepo(35)], {
+      previousSyncStateByRepoId: new Map([
+        [
+          35,
+          {
+            checksum: "checksum-without-local-readme-bytes",
+            readmeEtag: '"etag-35"',
+            readmeLastModified: null,
+          },
+        ],
+      ]),
+    });
+
+    expect(result.records[0]).toMatchObject({
+      outcome: "not_modified",
+      checksum: "checksum-without-local-readme-bytes",
+      readmeText: null,
+    });
   });
 
   test("fetchReadmes preserves previous README state after transient retry exhaustion", async () => {

--- a/src/github/client.test.ts
+++ b/src/github/client.test.ts
@@ -205,12 +205,12 @@ describe("github client integration", () => {
     expect(result.records[0]?.readmeText).toBe("recovered");
   });
 
-  test("fetchReadmes honors an HTTP-date Retry-After value", async () => {
+  test("fetchReadmes honors an HTTP-date Retry-After beyond the fallback cap", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     try {
       const warn = vi.fn();
-      const retryAt = new Date(Date.now() + 2_000).toUTCString();
+      const retryAt = new Date(Date.now() + 120_000).toUTCString();
       const fetchImpl = vi
         .fn<typeof fetch>()
         .mockResolvedValueOnce(
@@ -234,12 +234,14 @@ describe("github client integration", () => {
       });
 
       const resultPromise = client.fetchReadmes([makeRepo(25)]);
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(90_000);
       const result = await resultPromise;
 
       expect(warn).toHaveBeenCalledWith(
         "transient GitHub response, backing off",
-        expect.objectContaining({ waitMs: 2_000 }),
+        expect.objectContaining({ waitMs: 120_000 }),
       );
       expect(result.records[0]?.outcome).toBe("success");
     } finally {
@@ -252,7 +254,7 @@ describe("github client integration", () => {
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     try {
       const warn = vi.fn();
-      const resetSeconds = Math.floor((Date.now() + 2_000) / 1_000);
+      const resetSeconds = Math.floor((Date.now() + 120_000) / 1_000);
       const fetchImpl = vi
         .fn<typeof fetch>()
         .mockResolvedValueOnce(
@@ -276,17 +278,95 @@ describe("github client integration", () => {
       });
 
       const resultPromise = client.fetchReadmes([makeRepo(26)]);
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(90_500);
       const result = await resultPromise;
 
       expect(warn).toHaveBeenCalledWith(
         "transient GitHub response, backing off",
-        expect.objectContaining({ waitMs: 2_500 }),
+        expect.objectContaining({ waitMs: 120_500 }),
       );
       expect(result.records[0]?.outcome).toBe("success");
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test("fetchReadmes caps client-chosen exponential backoff at 30 seconds", async () => {
+    vi.useFakeTimers();
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.999);
+    try {
+      const warn = vi.fn();
+      const fetchImpl = vi.fn<typeof fetch>();
+      for (let attempt = 0; attempt < 6; attempt += 1) {
+        fetchImpl.mockResolvedValueOnce(jsonResponse({ message: "Unavailable" }, { status: 503 }));
+      }
+      fetchImpl.mockResolvedValueOnce(
+        jsonResponse({
+          content: btoa("fallback recovered"),
+          encoding: "base64",
+          html_url: "https://github.com/owner/repo-27/blob/main/README.md",
+        }),
+      );
+      const client = createGitHubApiClient({
+        accessToken: "token",
+        fetchImpl,
+        maxRetries: 6,
+        logger: { debug: () => undefined, warn },
+      });
+
+      const resultPromise = client.fetchReadmes([makeRepo(27)]);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+      const waits = warn.mock.calls.map(([, meta]) => Number(meta?.waitMs));
+
+      expect(waits).toHaveLength(6);
+      expect(Math.max(...waits)).toBe(30_000);
+      expect(waits.at(-1)).toBe(30_000);
+      expect(result.records[0]?.outcome).toBe("success");
+    } finally {
+      random.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  test("fetchReadmes recomputes a 304 checksum from current metadata and preserved bytes", async () => {
+    const readmeText = "preserved README";
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: btoa(readmeText),
+          encoding: "base64",
+          html_url: "https://github.com/owner/repo-28/blob/main/README.md",
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 304 }))
+      .mockResolvedValueOnce(new Response(null, { status: 304 }));
+    const client = createGitHubApiClient({
+      accessToken: "token",
+      fetchImpl,
+      logger: { debug: () => undefined, warn: () => undefined },
+    });
+    const before = { ...makeRepo(28), description: "before" };
+    const after = { ...before, description: "after" };
+    const initial = (await client.fetchReadmes([before])).records[0];
+
+    const metadataChanged = (
+      await client.fetchReadmes([after], {
+        previousSyncStateByRepoId: new Map([[28, initial!]]),
+      })
+    ).records[0];
+    const unchanged = (
+      await client.fetchReadmes([after], {
+        previousSyncStateByRepoId: new Map([[28, metadataChanged!]]),
+      })
+    ).records[0];
+
+    expect(metadataChanged).toMatchObject({ outcome: "not_modified", readmeText });
+    expect(metadataChanged?.checksum).not.toBe(initial?.checksum);
+    expect(unchanged?.checksum).toBe(metadataChanged?.checksum);
   });
 
   test("fetchReadmes preserves previous README state after transient retry exhaustion", async () => {
@@ -530,7 +610,7 @@ describe("github client integration", () => {
     expect(capturedHeaders).toContain('"etag-10"');
     const notModified = result.records.find((record) => record.repoId === 10);
     expect(notModified?.notModified).toBe(true);
-    expect(notModified?.checksum).toBe("previous-checksum");
+    expect(notModified?.checksum).not.toBe("previous-checksum");
     expect(notModified?.outcome).toBe("not_modified");
     expect(notModified?.readmeText).toBe("previous readme");
     expect(notModified?.readmeEtag).toBe('"etag-10"');

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -665,7 +665,7 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
           return { record, latencyMs, failed: false, rateLimited };
         }
 
-        const payload = (await response.json()) as GitHubReadmePayload;
+        const payload = (await response.json()) as unknown;
         assertReadmePayload(payload);
         const readmeText = decodeBase64Utf8(payload.content);
         const readmeSha256 = await sha256Hex(readmeText);

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -40,7 +40,13 @@ type FetchReadmesOptions = {
   batchSize?: number;
   previousSyncStateByRepoId?: Map<
     number,
-    { checksum: string | null; readmeEtag: string | null; readmeLastModified: string | null }
+    {
+      checksum: string | null;
+      readmeUrl?: string | null;
+      readmeText?: string | null;
+      readmeEtag: string | null;
+      readmeLastModified: string | null;
+    }
   >;
   onProgress?: (progress: ReadmeFetchProgress) => void;
   onBatch?: (
@@ -54,6 +60,7 @@ const API_BASE_URL = "https://api.github.com";
 const DEFAULT_PER_PAGE = 100;
 const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_README_CONCURRENCY = 6;
+const MAX_RETRY_DELAY_MS = 30_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -73,32 +80,41 @@ function parseRateLimit(headers: Headers): GitHubRateLimit {
   };
 }
 
-function getRetryDelayMs(response: Response, attempt: number): number {
-  const retryAfter = response.headers.get("retry-after");
+function getRetryDelayMs(response: Response | null, attempt: number): number {
+  const retryAfter = response?.headers.get("retry-after");
 
   if (retryAfter) {
     const parsed = Number(retryAfter);
 
     if (Number.isFinite(parsed) && parsed >= 0) {
-      return parsed * 1000;
+      return Math.min(parsed * 1000, MAX_RETRY_DELAY_MS);
+    }
+
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isFinite(retryAt)) {
+      return Math.min(Math.max(retryAt - Date.now(), 0), MAX_RETRY_DELAY_MS);
     }
   }
 
-  const reset = response.headers.get("x-ratelimit-reset");
+  const reset = response?.headers.get("x-ratelimit-reset");
   if (reset) {
     const resetMs = Number(reset) * 1000;
 
     if (Number.isFinite(resetMs)) {
-      return Math.max(resetMs - Date.now() + 500, 1000);
+      return Math.min(Math.max(resetMs - Date.now() + 500, 1000), MAX_RETRY_DELAY_MS);
     }
   }
 
   // bounded exponential backoff with jitter
   const base = Math.min(2 ** attempt * 1000, 30000);
-  return Math.floor(base + Math.random() * 300);
+  return Math.min(Math.floor(base + Math.random() * 300), MAX_RETRY_DELAY_MS);
 }
 
 function shouldRetry(response: Response): boolean {
+  if (response.status >= 500 && response.status <= 599) {
+    return true;
+  }
+
   if (response.status === 429) {
     return true;
   }
@@ -208,19 +224,28 @@ function assertAuthenticatedUser(payload: unknown): asserts payload is GitHubAut
   }
 
   const candidate = payload as Partial<GitHubAuthenticatedUser>;
-  if (!Number.isFinite(candidate.id) || typeof candidate.login !== "string" || !candidate.login.trim()) {
+  if (
+    !Number.isFinite(candidate.id) ||
+    typeof candidate.login !== "string" ||
+    !candidate.login.trim()
+  ) {
     throw new Error("GitHub user response was missing id/login");
   }
 }
 
 type GitHubReadmePayload = {
-  content?: string;
-  encoding?: string;
+  content: string;
+  encoding: "base64";
   html_url?: string | null;
 };
 
 function assertReadmePayload(payload: unknown): asserts payload is GitHubReadmePayload {
   if (!payload || typeof payload !== "object") {
+    throw new Error("GitHub README response had unexpected payload");
+  }
+
+  const candidate = payload as Partial<GitHubReadmePayload>;
+  if (typeof candidate.content !== "string" || candidate.encoding !== "base64") {
     throw new Error("GitHub README response had unexpected payload");
   }
 }
@@ -245,21 +270,48 @@ async function requestWithBackoff(args: {
   logger: Logger;
   maxRetries: number;
   headers?: Record<string, string>;
-  onRetry?: (meta: { status: number; waitMs: number; attempt: number; rateLimited: boolean }) => void;
+  onRetry?: (meta: {
+    status: number;
+    waitMs: number;
+    attempt: number;
+    rateLimited: boolean;
+  }) => void;
 }): Promise<Response> {
   let attempt = 0;
 
   while (true) {
-    const response = await args.fetchImpl(args.url, {
-      method: "GET",
-      signal: args.signal,
-      headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        Authorization: `Bearer ${args.accessToken}`,
-        ...(args.headers ?? {}),
-      },
-    });
+    let response: Response;
+    try {
+      response = await args.fetchImpl(args.url, {
+        method: "GET",
+        signal: args.signal,
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          Authorization: `Bearer ${args.accessToken}`,
+          ...(args.headers ?? {}),
+        },
+      });
+    } catch (error) {
+      if (args.signal?.aborted || attempt >= args.maxRetries) {
+        throw error;
+      }
+
+      const waitMs = getRetryDelayMs(null, attempt);
+      args.logger.warn("transient network failure, backing off", {
+        attempt: attempt + 1,
+        waitMs,
+      });
+      args.onRetry?.({
+        status: 0,
+        waitMs,
+        attempt: attempt + 1,
+        rateLimited: false,
+      });
+      await sleep(waitMs);
+      attempt += 1;
+      continue;
+    }
 
     if (response.ok || response.status === 304 || response.status === 404) {
       return response;
@@ -277,7 +329,7 @@ async function requestWithBackoff(args: {
 
     const waitMs = getRetryDelayMs(response, attempt);
 
-    args.logger.warn("rate-limited, backing off", {
+    args.logger.warn("transient GitHub response, backing off", {
       attempt: attempt + 1,
       status: response.status,
       waitMs,
@@ -346,7 +398,9 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
     };
   }
 
-  async function fetchAllStarredRepos(options: FetchStarredOptions = {}): Promise<FetchStarredResult> {
+  async function fetchAllStarredRepos(
+    options: FetchStarredOptions = {},
+  ): Promise<FetchStarredResult> {
     const repos: GitHubStarredRepo[] = [];
     let nextUrl: string | null = `${API_BASE_URL}/user/starred?per_page=${perPage}&page=1`;
     let fetchedPages = 0;
@@ -509,17 +563,16 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
       checksum: string | null;
       missingReadme: boolean;
       notModified: boolean;
+      outcome: RepoReadmeRecord["outcome"];
     }): Promise<RepoReadmeRecord> => {
-      const resolvedChecksum =
-        params.checksum ??
-        (await sha256Hex(canonicalChecksumInput(params.repo, await sha256Hex(params.readmeText ?? ""))));
       return {
         repoId: params.repo.id,
+        outcome: params.outcome,
         readmeUrl: params.readmeUrl,
         readmeText: params.readmeText,
         readmeEtag: params.readmeEtag,
         readmeLastModified: params.readmeLastModified,
-        checksum: resolvedChecksum,
+        checksum: params.checksum,
         missingReadme: params.missingReadme,
         notModified: params.notModified,
       };
@@ -567,11 +620,12 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
             repo,
             readmeText: null,
             readmeUrl: null,
-            readmeEtag: readmeEtag ?? previous?.readmeEtag ?? null,
-            readmeLastModified: readmeLastModified ?? previous?.readmeLastModified ?? null,
+            readmeEtag: null,
+            readmeLastModified: null,
             checksum,
             missingReadme: true,
             notModified: false,
+            outcome: "not_found",
           });
           return { record, latencyMs, failed: false, rateLimited };
         }
@@ -579,38 +633,22 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
         if (response.status === 304) {
           const record = await buildReadmeRecord({
             repo,
-            readmeText: null,
-            readmeUrl: null,
+            readmeText: previous?.readmeText ?? null,
+            readmeUrl: previous?.readmeUrl ?? null,
             readmeEtag: readmeEtag ?? previous?.readmeEtag ?? null,
             readmeLastModified: readmeLastModified ?? previous?.readmeLastModified ?? null,
             checksum: previous?.checksum ?? null,
             missingReadme: false,
             notModified: true,
+            outcome: "not_modified",
           });
           return { record, latencyMs, failed: false, rateLimited };
         }
 
-        if (!response.ok) {
-          const emptyHash = await sha256Hex("");
-          const checksum = await sha256Hex(canonicalChecksumInput(repo, emptyHash));
-          const record = await buildReadmeRecord({
-            repo,
-            readmeText: null,
-            readmeUrl: null,
-            readmeEtag: readmeEtag ?? previous?.readmeEtag ?? null,
-            readmeLastModified: readmeLastModified ?? previous?.readmeLastModified ?? null,
-            checksum,
-            missingReadme: true,
-            notModified: false,
-          });
-          return { record, latencyMs, failed: true, rateLimited };
-        }
-
         const payload = (await response.json()) as GitHubReadmePayload;
         assertReadmePayload(payload);
-        const readmeText =
-          payload.content && payload.encoding === "base64" ? decodeBase64Utf8(payload.content) : null;
-        const readmeSha256 = await sha256Hex(readmeText ?? "");
+        const readmeText = decodeBase64Utf8(payload.content);
+        const readmeSha256 = await sha256Hex(readmeText);
         const checksum = await sha256Hex(canonicalChecksumInput(repo, readmeSha256));
         const record = await buildReadmeRecord({
           repo,
@@ -619,8 +657,9 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
           readmeEtag,
           readmeLastModified,
           checksum,
-          missingReadme: readmeText == null,
+          missingReadme: false,
           notModified: false,
+          outcome: "success",
         });
         return { record, latencyMs, failed: false, rateLimited };
       } catch (err) {
@@ -633,17 +672,16 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
           error: err instanceof Error ? err.message : String(err),
         });
         const latencyMs = performance.now() - startedAt;
-        const emptyHash = await sha256Hex("");
-        const checksum = await sha256Hex(canonicalChecksumInput(repo, emptyHash));
         const record = await buildReadmeRecord({
           repo,
-          readmeText: null,
-          readmeUrl: null,
+          readmeText: previous?.readmeText ?? null,
+          readmeUrl: previous?.readmeUrl ?? null,
           readmeEtag: previous?.readmeEtag ?? null,
           readmeLastModified: previous?.readmeLastModified ?? null,
-          checksum,
-          missingReadme: true,
+          checksum: previous?.checksum ?? null,
+          missingReadme: false,
           notModified: false,
+          outcome: "transient_failure",
         });
         return { record, latencyMs, failed: readmeFailed, rateLimited };
       }
@@ -661,10 +699,10 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
       completed += 1;
       windowCompleted += 1;
 
-      if (result.record.notModified || !result.record.missingReadme) {
+      if (result.record.outcome === "success" || result.record.outcome === "not_modified") {
         succeeded += 1;
       }
-      if (result.record.missingReadme && !result.failed) {
+      if (result.record.outcome === "not_found") {
         missingCount += 1;
       }
       if (result.failed) {

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -60,7 +60,8 @@ const API_BASE_URL = "https://api.github.com";
 const DEFAULT_PER_PAGE = 100;
 const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_README_CONCURRENCY = 6;
-const MAX_RETRY_DELAY_MS = 30_000;
+const MAX_FALLBACK_RETRY_DELAY_MS = 30_000;
+const MAX_SERVER_RETRY_DELAY_MS = 60 * 60 * 1000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -87,12 +88,12 @@ function getRetryDelayMs(response: Response | null, attempt: number): number {
     const parsed = Number(retryAfter);
 
     if (Number.isFinite(parsed) && parsed >= 0) {
-      return Math.min(parsed * 1000, MAX_RETRY_DELAY_MS);
+      return Math.min(parsed * 1000, MAX_SERVER_RETRY_DELAY_MS);
     }
 
     const retryAt = Date.parse(retryAfter);
     if (Number.isFinite(retryAt)) {
-      return Math.min(Math.max(retryAt - Date.now(), 0), MAX_RETRY_DELAY_MS);
+      return Math.min(Math.max(retryAt - Date.now(), 0), MAX_SERVER_RETRY_DELAY_MS);
     }
   }
 
@@ -101,13 +102,13 @@ function getRetryDelayMs(response: Response | null, attempt: number): number {
     const resetMs = Number(reset) * 1000;
 
     if (Number.isFinite(resetMs)) {
-      return Math.min(Math.max(resetMs - Date.now() + 500, 1000), MAX_RETRY_DELAY_MS);
+      return Math.min(Math.max(resetMs - Date.now() + 500, 1000), MAX_SERVER_RETRY_DELAY_MS);
     }
   }
 
   // bounded exponential backoff with jitter
   const base = Math.min(2 ** attempt * 1000, 30000);
-  return Math.min(Math.floor(base + Math.random() * 300), MAX_RETRY_DELAY_MS);
+  return Math.min(Math.floor(base + Math.random() * 300), MAX_FALLBACK_RETRY_DELAY_MS);
 }
 
 function shouldRetry(response: Response): boolean {
@@ -631,13 +632,17 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
         }
 
         if (response.status === 304) {
+          const checksum =
+            typeof previous?.readmeText === "string"
+              ? await sha256Hex(canonicalChecksumInput(repo, await sha256Hex(previous.readmeText)))
+              : (previous?.checksum ?? null);
           const record = await buildReadmeRecord({
             repo,
             readmeText: previous?.readmeText ?? null,
             readmeUrl: previous?.readmeUrl ?? null,
             readmeEtag: readmeEtag ?? previous?.readmeEtag ?? null,
             readmeLastModified: readmeLastModified ?? previous?.readmeLastModified ?? null,
-            checksum: previous?.checksum ?? null,
+            checksum,
             missingReadme: false,
             notModified: true,
             outcome: "not_modified",

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -63,9 +63,24 @@ const DEFAULT_README_CONCURRENCY = 6;
 const MAX_FALLBACK_RETRY_DELAY_MS = 30_000;
 const MAX_SERVER_RETRY_DELAY_MS = 60 * 60 * 1000;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      signal.reason ?? new DOMException("The operation was aborted", "AbortError"),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", onAbort);
+      reject(signal?.reason ?? new DOMException("The operation was aborted", "AbortError"));
+    };
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
 
@@ -309,7 +324,7 @@ async function requestWithBackoff(args: {
         attempt: attempt + 1,
         rateLimited: false,
       });
-      await sleep(waitMs);
+      await sleep(waitMs, args.signal);
       attempt += 1;
       continue;
     }
@@ -342,7 +357,7 @@ async function requestWithBackoff(args: {
       rateLimited: isRateLimitedResponse(response),
     });
 
-    await sleep(waitMs);
+    await sleep(waitMs, args.signal);
     attempt += 1;
   }
 }
@@ -694,7 +709,7 @@ export function createGitHubApiClient(args: CreateGitHubApiClientArgs) {
 
     const processRepo = async (repo: GitHubStarredRepo) => {
       if (cooldownUntil > Date.now()) {
-        await sleep(cooldownUntil - Date.now());
+        await sleep(cooldownUntil - Date.now(), options.signal);
       }
 
       const result = await fetchSingleReadme(repo);

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -41,13 +41,16 @@ export type FetchStarsProgress = {
   latestPageCount: number;
 };
 
+export type RepoReadmeFetchOutcome = "success" | "not_modified" | "not_found" | "transient_failure";
+
 export type RepoReadmeRecord = {
   repoId: number;
+  outcome: RepoReadmeFetchOutcome;
   readmeUrl: string | null;
   readmeText: string | null;
   readmeEtag: string | null;
   readmeLastModified: string | null;
-  checksum: string;
+  checksum: string | null;
   missingReadme: boolean;
   notModified: boolean;
 };

--- a/src/hooks/useProviderSettingsPersistence.test.tsx
+++ b/src/hooks/useProviderSettingsPersistence.test.tsx
@@ -116,20 +116,36 @@ describe("useProviderSettingsPersistence", () => {
     expect(emptyScope.result.current).toMatchObject({
       providerId: "webllm",
       providerModel: "primary-web-model",
-      hydrationState: "loading",
+      hydrationState: "ready",
       saveState: "idle",
+      statusMessage: "Provider settings save automatically.",
     });
     expect(store.hydrate).not.toHaveBeenCalled();
     expect(store.save).not.toHaveBeenCalled();
     emptyScope.unmount();
 
+    vi.mocked(store.hydrate).mockResolvedValueOnce(settings());
     const hydrated = renderPersistence(store);
     await waitFor(() => expect(hydrated.result.current.hydrationState).toBe("ready"));
     expect(hydrated.result.current).toMatchObject({
-      providerId: "webllm",
-      providerModel: "primary-web-model",
-      providerApiKey: "",
+      providerId: "openai-compatible",
+      providerModel: "saved-model",
+      providerApiKey: "sk-saved",
     });
+    await waitFor(() => expect(hydrated.result.current.saveState).toBe("saved"));
+    const saveCountBeforeLogout = vi.mocked(store.save).mock.calls.length;
+
+    hydrated.rerender({ scope: null });
+    await waitFor(() =>
+      expect(hydrated.result.current).toMatchObject({
+        providerId: "webllm",
+        providerModel: "primary-web-model",
+        providerApiKey: "",
+        hydrationState: "ready",
+        saveState: "idle",
+      }),
+    );
+    expect(store.save).toHaveBeenCalledTimes(saveCountBeforeLogout);
   });
 
   it("surfaces hydration and latest-save failures without throwing", async () => {

--- a/src/hooks/useProviderSettingsPersistence.test.tsx
+++ b/src/hooks/useProviderSettingsPersistence.test.tsx
@@ -102,9 +102,48 @@ describe("useProviderSettingsPersistence", () => {
       "github:1",
       expect.objectContaining({
         ...settings(),
-        webllmPreferredModel: "recommended-web-model",
+        webllmPreferredModel: "",
       }),
     );
+
+    act(() => {
+      result.current.setWebllmSelectedModel("manual-web-model");
+      result.current.setWebllmModelManuallySet(true);
+    });
+    await waitFor(() =>
+      expect(store.save).toHaveBeenLastCalledWith(
+        "github:1",
+        expect.objectContaining({ webllmPreferredModel: "manual-web-model" }),
+      ),
+    );
+  });
+
+  it("does not rehydrate when equivalent provider definitions receive a new array identity", async () => {
+    const store: ProviderSettingsStore = {
+      hydrate: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const onPersistenceError = vi.fn();
+    const hook = renderHook(
+      ({ definitions }) =>
+        useProviderSettingsPersistence({
+          scopeIdentity: "github:1",
+          webLLMEnabled: true,
+          webLLMPrimaryModel: "primary-web-model",
+          providerDefinitions: definitions,
+          store,
+          onPersistenceError,
+        }),
+      { initialProps: { definitions: providerDefinitions } },
+    );
+    await waitFor(() => expect(hook.result.current.saveState).toBe("saved"));
+
+    hook.rerender({ definitions: providerDefinitions.map((definition) => ({ ...definition })) });
+    await waitFor(() => expect(hook.result.current.saveState).toBe("saved"));
+
+    expect(store.hydrate).toHaveBeenCalledOnce();
+    expect(store.save).toHaveBeenCalledOnce();
+    expect(onPersistenceError).not.toHaveBeenCalled();
   });
 
   it("uses clean defaults for an empty scope and never saves without an identity", async () => {

--- a/src/hooks/useProviderSettingsPersistence.test.tsx
+++ b/src/hooks/useProviderSettingsPersistence.test.tsx
@@ -146,6 +146,70 @@ describe("useProviderSettingsPersistence", () => {
     expect(onPersistenceError).not.toHaveBeenCalled();
   });
 
+  it("rehydrates and saves when provider defaults change semantically", async () => {
+    const store: ProviderSettingsStore = {
+      hydrate: vi.fn().mockResolvedValue(
+        settings({
+          providerId: "ollama",
+          baseUrl: "",
+          model: "",
+          ollamaPreferredModel: "",
+          apiKey: "",
+        }),
+      ),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const onPersistenceError = vi.fn();
+    const hook = renderHook(
+      ({ definitions }) =>
+        useProviderSettingsPersistence({
+          scopeIdentity: "github:1",
+          webLLMEnabled: true,
+          webLLMPrimaryModel: "primary-web-model",
+          providerDefinitions: definitions,
+          store,
+          onPersistenceError,
+        }),
+      { initialProps: { definitions: providerDefinitions } },
+    );
+    await waitFor(() =>
+      expect(hook.result.current).toMatchObject({
+        providerId: "ollama",
+        providerBaseUrl: "http://localhost:11434",
+        providerModel: "llama3.1:8b",
+        saveState: "saved",
+      }),
+    );
+
+    const changedDefinitions = providerDefinitions.map((definition) =>
+      definition.id === "ollama"
+        ? {
+            ...definition,
+            defaultBaseUrl: "http://127.0.0.1:22434",
+            defaultModel: "qwen3:8b",
+          }
+        : definition,
+    );
+    hook.rerender({ definitions: changedDefinitions });
+
+    await waitFor(() =>
+      expect(hook.result.current).toMatchObject({
+        providerId: "ollama",
+        providerBaseUrl: "http://127.0.0.1:22434",
+        providerModel: "qwen3:8b",
+        saveState: "saved",
+      }),
+    );
+    expect(store.save).toHaveBeenLastCalledWith(
+      "github:1",
+      expect.objectContaining({
+        providerId: "ollama",
+        baseUrl: "http://127.0.0.1:22434",
+        model: "qwen3:8b",
+      }),
+    );
+  });
+
   it("uses clean defaults for an empty scope and never saves without an identity", async () => {
     const store: ProviderSettingsStore = {
       hydrate: vi.fn().mockResolvedValue(null),

--- a/src/hooks/useProviderSettingsPersistence.test.tsx
+++ b/src/hooks/useProviderSettingsPersistence.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { LLMProviderDefinition } from "../llm/types";
+import type { LLMProviderSettings, ProviderSettingsStore } from "../lib/settings";
+import { useProviderSettingsPersistence } from "./useProviderSettingsPersistence";
+
+const providerDefinitions: LLMProviderDefinition[] = [
+  {
+    id: "openai-compatible",
+    label: "OpenAI compatible",
+    kind: "remote",
+    defaultBaseUrl: "https://api.openai.com",
+    defaultModel: "gpt-4o-mini",
+    requiresApiKey: true,
+  },
+  {
+    id: "ollama",
+    label: "Ollama",
+    kind: "local",
+    defaultBaseUrl: "http://localhost:11434",
+    defaultModel: "llama3.1:8b",
+    requiresApiKey: false,
+  },
+  {
+    id: "webllm",
+    label: "WebLLM",
+    kind: "local",
+    defaultBaseUrl: "",
+    defaultModel: "primary-web-model",
+    requiresApiKey: false,
+  },
+];
+
+function settings(overrides: Partial<LLMProviderSettings> = {}): LLMProviderSettings {
+  return {
+    providerId: "openai-compatible",
+    baseUrl: "https://example.test/v1",
+    model: "saved-model",
+    ollamaPreferredModel: "saved-ollama",
+    apiKey: "sk-saved",
+    allowRemoteProvider: true,
+    allowLocalProvider: false,
+    webllmConsent: false,
+    webllmPreferredModel: "",
+    webllmLastRecommendedModel: "recommended-web-model",
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderPersistence(
+  store: ProviderSettingsStore,
+  onPersistenceError = vi.fn(),
+  scopeIdentity: string | null = "github:1",
+) {
+  return renderHook(
+    ({ scope }) =>
+      useProviderSettingsPersistence({
+        scopeIdentity: scope,
+        webLLMEnabled: true,
+        webLLMPrimaryModel: "primary-web-model",
+        providerDefinitions,
+        store,
+        onPersistenceError,
+      }),
+    { initialProps: { scope: scopeIdentity } },
+  );
+}
+
+describe("useProviderSettingsPersistence", () => {
+  it("hydrates saved settings before enabling serialized persistence", async () => {
+    const store: ProviderSettingsStore = {
+      hydrate: vi.fn().mockResolvedValue(settings()),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const { result } = renderPersistence(store);
+
+    expect(result.current.hydrationState).toBe("loading");
+    await waitFor(() => expect(result.current.hydrationState).toBe("ready"));
+    expect(result.current).toMatchObject({
+      providerId: "openai-compatible",
+      providerBaseUrl: "https://example.test/v1",
+      providerModel: "saved-model",
+      providerApiKey: "sk-saved",
+      ollamaPreferredChatModel: "saved-ollama",
+      allowRemoteProvider: true,
+      webllmSelectedModel: "recommended-web-model",
+    });
+    await waitFor(() => expect(result.current.saveState).toBe("saved"));
+    expect(store.save).toHaveBeenCalledWith(
+      "github:1",
+      expect.objectContaining({
+        ...settings(),
+        webllmPreferredModel: "recommended-web-model",
+      }),
+    );
+  });
+
+  it("uses clean defaults for an empty scope and never saves without an identity", async () => {
+    const store: ProviderSettingsStore = {
+      hydrate: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const emptyScope = renderPersistence(store, vi.fn(), null);
+    expect(emptyScope.result.current).toMatchObject({
+      providerId: "webllm",
+      providerModel: "primary-web-model",
+      hydrationState: "loading",
+      saveState: "idle",
+    });
+    expect(store.hydrate).not.toHaveBeenCalled();
+    expect(store.save).not.toHaveBeenCalled();
+    emptyScope.unmount();
+
+    const hydrated = renderPersistence(store);
+    await waitFor(() => expect(hydrated.result.current.hydrationState).toBe("ready"));
+    expect(hydrated.result.current).toMatchObject({
+      providerId: "webllm",
+      providerModel: "primary-web-model",
+      providerApiKey: "",
+    });
+  });
+
+  it("surfaces hydration and latest-save failures without throwing", async () => {
+    const onPersistenceError = vi.fn();
+    const hydrationError = new Error("decrypt failed");
+    const failedHydration: ProviderSettingsStore = {
+      hydrate: vi.fn().mockRejectedValue(hydrationError),
+      save: vi.fn(),
+    };
+    const hydration = renderPersistence(failedHydration, onPersistenceError);
+    await waitFor(() => expect(hydration.result.current.hydrationState).toBe("error"));
+    expect(hydration.result.current).toMatchObject({
+      saveState: "error",
+      persistenceError: "decrypt failed",
+      statusMessage: "Provider settings not saved: decrypt failed",
+    });
+    expect(onPersistenceError).toHaveBeenCalledWith(
+      "provider_settings_hydration_failed",
+      hydrationError,
+    );
+    hydration.unmount();
+
+    const saveError = "storage unavailable";
+    const failedSave: ProviderSettingsStore = {
+      hydrate: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockRejectedValue(saveError),
+    };
+    const saving = renderPersistence(failedSave, onPersistenceError);
+    await waitFor(() => expect(saving.result.current.saveState).toBe("error"));
+    expect(saving.result.current.persistenceError).toBe(saveError);
+    expect(onPersistenceError).toHaveBeenCalledWith("provider_settings_save_failed", saveError);
+  });
+
+  it("keeps the newest save status when older writes settle later", async () => {
+    const saves: Array<ReturnType<typeof deferred<void>>> = [];
+    const store: ProviderSettingsStore = {
+      hydrate: vi.fn().mockResolvedValue(settings({ apiKey: "" })),
+      save: vi.fn().mockImplementation(() => {
+        const operation = deferred<void>();
+        saves.push(operation);
+        return operation.promise;
+      }),
+    };
+    const { result } = renderPersistence(store);
+    await waitFor(() => expect(saves).toHaveLength(1));
+    act(() => saves[0].resolve());
+    await waitFor(() => expect(result.current.saveState).toBe("saved"));
+
+    act(() => result.current.setProviderModel("model-two"));
+    await waitFor(() => expect(saves).toHaveLength(2));
+    act(() => result.current.setProviderModel("model-three"));
+    await waitFor(() => expect(saves).toHaveLength(3));
+
+    act(() => saves[2].resolve());
+    await waitFor(() => expect(result.current.saveState).toBe("saved"));
+    act(() => saves[1].reject(new Error("stale failure")));
+    await waitFor(() => expect(result.current.saveState).toBe("saved"));
+    expect(result.current.persistenceError).toBeNull();
+    expect(store.save).toHaveBeenLastCalledWith(
+      "github:1",
+      expect.objectContaining({ model: "model-three" }),
+    );
+  });
+
+  it("ignores stale hydration after a scope change and after cleanup", async () => {
+    const accountA = deferred<LLMProviderSettings | null>();
+    const accountB = deferred<LLMProviderSettings | null>();
+    const store: ProviderSettingsStore = {
+      hydrate: vi
+        .fn()
+        .mockImplementation((scope) =>
+          scope === "github:a" ? accountA.promise : accountB.promise,
+        ),
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const hook = renderPersistence(store, vi.fn(), "github:a");
+    act(() => accountA.resolve(settings({ model: "account-a", apiKey: "sk-account-a" })));
+    await waitFor(() => expect(hook.result.current.providerModel).toBe("account-a"));
+    await waitFor(() => expect(store.save).toHaveBeenCalledTimes(1));
+    hook.rerender({ scope: "github:b" });
+    await waitFor(() =>
+      expect(hook.result.current).toMatchObject({
+        providerModel: "primary-web-model",
+        providerApiKey: "",
+        hydrationState: "loading",
+      }),
+    );
+    expect(store.save).toHaveBeenCalledTimes(1);
+    act(() => accountB.resolve(settings({ model: "account-b" })));
+    await waitFor(() => expect(hook.result.current.providerModel).toBe("account-b"));
+    await waitFor(() => expect(store.save).toHaveBeenCalledTimes(2));
+    expect(store.save).toHaveBeenLastCalledWith(
+      "github:b",
+      expect.objectContaining({ model: "account-b" }),
+    );
+
+    const pending = deferred<LLMProviderSettings | null>();
+    const cleanupStore: ProviderSettingsStore = {
+      hydrate: vi.fn().mockReturnValue(pending.promise),
+      save: vi.fn(),
+    };
+    const cleanup = renderPersistence(cleanupStore);
+    cleanup.unmount();
+    act(() => pending.resolve(settings()));
+    await Promise.resolve();
+    expect(cleanupStore.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProviderSettingsPersistence.ts
+++ b/src/hooks/useProviderSettingsPersistence.ts
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import type { LLMProviderDefinition, LLMProviderId } from "../llm/types";
+import {
+  deriveHydratedProviderSettingsView,
+  getProviderSettingsStatusMessage,
+  providerSettingsStore,
+  type LLMProviderSettings,
+  type ProviderSettingsHydrationState,
+  type ProviderSettingsSaveState,
+  type ProviderSettingsStore,
+} from "../lib/settings";
+import { captureLocalError } from "../observability/localLog";
+
+type ProviderSettingsPersistenceOptions = {
+  scopeIdentity: string | null;
+  webLLMEnabled: boolean;
+  webLLMPrimaryModel: string;
+  providerDefinitions: LLMProviderDefinition[];
+  store?: ProviderSettingsStore;
+  onPersistenceError?: (event: string, error: unknown) => void;
+};
+
+export type ProviderSettingsPersistence = {
+  providerId: LLMProviderId;
+  setProviderId: Dispatch<SetStateAction<LLMProviderId>>;
+  providerBaseUrl: string;
+  setProviderBaseUrl: Dispatch<SetStateAction<string>>;
+  providerModel: string;
+  setProviderModel: Dispatch<SetStateAction<string>>;
+  providerApiKey: string;
+  setProviderApiKey: Dispatch<SetStateAction<string>>;
+  ollamaPreferredChatModel: string;
+  setOllamaPreferredChatModel: Dispatch<SetStateAction<string>>;
+  allowRemoteProvider: boolean;
+  setAllowRemoteProvider: Dispatch<SetStateAction<boolean>>;
+  allowLocalProvider: boolean;
+  setAllowLocalProvider: Dispatch<SetStateAction<boolean>>;
+  webllmConsent: boolean;
+  setWebllmConsent: Dispatch<SetStateAction<boolean>>;
+  webllmSelectedModel: string;
+  setWebllmSelectedModel: Dispatch<SetStateAction<string>>;
+  webllmModelManuallySet: boolean;
+  setWebllmModelManuallySet: Dispatch<SetStateAction<boolean>>;
+  webllmLastRecommendedModel: string;
+  setWebllmLastRecommendedModel: Dispatch<SetStateAction<string>>;
+  hydrationState: ProviderSettingsHydrationState;
+  saveState: ProviderSettingsSaveState;
+  persistenceError: string | null;
+  statusMessage: string;
+};
+
+export function useProviderSettingsPersistence({
+  scopeIdentity,
+  webLLMEnabled,
+  webLLMPrimaryModel,
+  providerDefinitions,
+  store = providerSettingsStore,
+  onPersistenceError = captureLocalError,
+}: ProviderSettingsPersistenceOptions): ProviderSettingsPersistence {
+  const initial = useMemo(
+    () =>
+      deriveHydratedProviderSettingsView({
+        saved: null,
+        webLLMEnabled,
+        webLLMPrimaryModel,
+        providerDefinitions,
+      }),
+    [providerDefinitions, webLLMEnabled, webLLMPrimaryModel],
+  );
+  const [providerId, setProviderId] = useState(initial.providerId);
+  const [providerBaseUrl, setProviderBaseUrl] = useState(initial.baseUrl);
+  const [providerModel, setProviderModel] = useState(initial.model);
+  const [providerApiKey, setProviderApiKey] = useState(initial.apiKey);
+  const [ollamaPreferredChatModel, setOllamaPreferredChatModel] = useState(
+    initial.ollamaPreferredModel,
+  );
+  const [allowRemoteProvider, setAllowRemoteProvider] = useState(initial.allowRemoteProvider);
+  const [allowLocalProvider, setAllowLocalProvider] = useState(initial.allowLocalProvider);
+  const [webllmConsent, setWebllmConsent] = useState(initial.webllmConsent);
+  const [webllmSelectedModel, setWebllmSelectedModel] = useState(initial.webllmSelectedModel);
+  const [webllmModelManuallySet, setWebllmModelManuallySet] = useState(
+    initial.webllmModelManuallySet,
+  );
+  const [webllmLastRecommendedModel, setWebllmLastRecommendedModel] = useState(
+    initial.webllmLastRecommendedModel,
+  );
+  const [hydrationState, setHydrationState] = useState<ProviderSettingsHydrationState>("loading");
+  const [saveState, setSaveState] = useState<ProviderSettingsSaveState>("idle");
+  const [persistenceError, setPersistenceError] = useState<string | null>(null);
+  const saveRevisionRef = useRef(0);
+  const hydratedScopeRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    saveRevisionRef.current += 1;
+    hydratedScopeRef.current = null;
+    setHydrationState("loading");
+    setSaveState("idle");
+    setPersistenceError(null);
+    setProviderId(initial.providerId);
+    setProviderBaseUrl(initial.baseUrl);
+    setProviderModel(initial.model);
+    setOllamaPreferredChatModel(initial.ollamaPreferredModel);
+    setProviderApiKey(initial.apiKey);
+    setAllowRemoteProvider(initial.allowRemoteProvider);
+    setAllowLocalProvider(initial.allowLocalProvider);
+    setWebllmConsent(initial.webllmConsent);
+    setWebllmSelectedModel(initial.webllmSelectedModel);
+    setWebllmModelManuallySet(initial.webllmModelManuallySet);
+    setWebllmLastRecommendedModel(initial.webllmLastRecommendedModel);
+    if (!scopeIdentity) return;
+
+    let cancelled = false;
+    void store
+      .hydrate(scopeIdentity)
+      .then((saved) => {
+        if (cancelled) return;
+        const hydrated = deriveHydratedProviderSettingsView({
+          saved,
+          webLLMEnabled,
+          webLLMPrimaryModel,
+          providerDefinitions,
+        });
+        setProviderId(hydrated.providerId);
+        setProviderBaseUrl(hydrated.baseUrl);
+        setProviderModel(hydrated.model);
+        setOllamaPreferredChatModel(hydrated.ollamaPreferredModel);
+        setProviderApiKey(hydrated.apiKey);
+        setAllowRemoteProvider(hydrated.allowRemoteProvider);
+        setAllowLocalProvider(hydrated.allowLocalProvider);
+        setWebllmConsent(hydrated.webllmConsent);
+        setWebllmSelectedModel(hydrated.webllmSelectedModel);
+        setWebllmModelManuallySet(hydrated.webllmModelManuallySet);
+        setWebllmLastRecommendedModel(hydrated.webllmLastRecommendedModel);
+        hydratedScopeRef.current = scopeIdentity;
+        setHydrationState("ready");
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setHydrationState("error");
+        setSaveState("error");
+        setPersistenceError(error instanceof Error ? error.message : String(error));
+        onPersistenceError("provider_settings_hydration_failed", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    initial,
+    onPersistenceError,
+    providerDefinitions,
+    scopeIdentity,
+    store,
+    webLLMEnabled,
+    webLLMPrimaryModel,
+  ]);
+
+  useEffect(() => {
+    if (!scopeIdentity || hydrationState !== "ready" || hydratedScopeRef.current !== scopeIdentity)
+      return;
+
+    const revision = saveRevisionRef.current + 1;
+    saveRevisionRef.current = revision;
+    const snapshot: LLMProviderSettings = {
+      providerId,
+      baseUrl: providerBaseUrl,
+      model: providerModel,
+      apiKey: providerApiKey,
+      allowRemoteProvider,
+      allowLocalProvider,
+      webllmConsent,
+      webllmPreferredModel: webllmSelectedModel,
+      webllmLastRecommendedModel,
+      ollamaPreferredModel: ollamaPreferredChatModel,
+    };
+    setSaveState("saving");
+    setPersistenceError(null);
+    void store
+      .save(scopeIdentity, snapshot)
+      .then(() => {
+        if (saveRevisionRef.current === revision) setSaveState("saved");
+      })
+      .catch((error: unknown) => {
+        if (saveRevisionRef.current !== revision) return;
+        setSaveState("error");
+        setPersistenceError(error instanceof Error ? error.message : String(error));
+        onPersistenceError("provider_settings_save_failed", error);
+      });
+  }, [
+    allowLocalProvider,
+    allowRemoteProvider,
+    hydrationState,
+    ollamaPreferredChatModel,
+    onPersistenceError,
+    providerApiKey,
+    providerBaseUrl,
+    providerId,
+    providerModel,
+    scopeIdentity,
+    store,
+    webllmConsent,
+    webllmLastRecommendedModel,
+    webllmSelectedModel,
+  ]);
+
+  return {
+    providerId,
+    setProviderId,
+    providerBaseUrl,
+    setProviderBaseUrl,
+    providerModel,
+    setProviderModel,
+    providerApiKey,
+    setProviderApiKey,
+    ollamaPreferredChatModel,
+    setOllamaPreferredChatModel,
+    allowRemoteProvider,
+    setAllowRemoteProvider,
+    allowLocalProvider,
+    setAllowLocalProvider,
+    webllmConsent,
+    setWebllmConsent,
+    webllmSelectedModel,
+    setWebllmSelectedModel,
+    webllmModelManuallySet,
+    setWebllmModelManuallySet,
+    webllmLastRecommendedModel,
+    setWebllmLastRecommendedModel,
+    hydrationState,
+    saveState,
+    persistenceError,
+    statusMessage: getProviderSettingsStatusMessage(hydrationState, saveState, persistenceError),
+  };
+}

--- a/src/hooks/useProviderSettingsPersistence.ts
+++ b/src/hooks/useProviderSettingsPersistence.ts
@@ -20,6 +20,12 @@ type ProviderSettingsPersistenceOptions = {
   onPersistenceError?: (event: string, error: unknown) => void;
 };
 
+function getProviderDefinitionsKey(definitions: LLMProviderDefinition[]): string {
+  return JSON.stringify(
+    definitions.map(({ id, defaultBaseUrl, defaultModel }) => [id, defaultBaseUrl, defaultModel]),
+  );
+}
+
 export type ProviderSettingsPersistence = {
   providerId: LLMProviderId;
   setProviderId: Dispatch<SetStateAction<LLMProviderId>>;
@@ -57,15 +63,27 @@ export function useProviderSettingsPersistence({
   store = providerSettingsStore,
   onPersistenceError = captureLocalError,
 }: ProviderSettingsPersistenceOptions): ProviderSettingsPersistence {
+  const providerDefinitionsKey = getProviderDefinitionsKey(providerDefinitions);
+  const providerDefinitionsCacheRef = useRef({
+    key: providerDefinitionsKey,
+    definitions: providerDefinitions,
+  });
+  if (providerDefinitionsCacheRef.current.key !== providerDefinitionsKey) {
+    providerDefinitionsCacheRef.current = {
+      key: providerDefinitionsKey,
+      definitions: providerDefinitions,
+    };
+  }
+  const stableProviderDefinitions = providerDefinitionsCacheRef.current.definitions;
   const initial = useMemo(
     () =>
       deriveHydratedProviderSettingsView({
         saved: null,
         webLLMEnabled,
         webLLMPrimaryModel,
-        providerDefinitions,
+        providerDefinitions: stableProviderDefinitions,
       }),
-    [providerDefinitions, webLLMEnabled, webLLMPrimaryModel],
+    [stableProviderDefinitions, webLLMEnabled, webLLMPrimaryModel],
   );
   const [providerId, setProviderId] = useState(initial.providerId);
   const [providerBaseUrl, setProviderBaseUrl] = useState(initial.baseUrl);
@@ -121,7 +139,7 @@ export function useProviderSettingsPersistence({
           saved,
           webLLMEnabled,
           webLLMPrimaryModel,
-          providerDefinitions,
+          providerDefinitions: stableProviderDefinitions,
         });
         setProviderId(hydrated.providerId);
         setProviderBaseUrl(hydrated.baseUrl);
@@ -150,8 +168,8 @@ export function useProviderSettingsPersistence({
   }, [
     initial,
     onPersistenceError,
-    providerDefinitions,
     scopeIdentity,
+    stableProviderDefinitions,
     store,
     webLLMEnabled,
     webLLMPrimaryModel,
@@ -171,7 +189,7 @@ export function useProviderSettingsPersistence({
       allowRemoteProvider,
       allowLocalProvider,
       webllmConsent,
-      webllmPreferredModel: webllmSelectedModel,
+      webllmPreferredModel: webllmModelManuallySet ? webllmSelectedModel : "",
       webllmLastRecommendedModel,
       ollamaPreferredModel: ollamaPreferredChatModel,
     };
@@ -202,6 +220,7 @@ export function useProviderSettingsPersistence({
     store,
     webllmConsent,
     webllmLastRecommendedModel,
+    webllmModelManuallySet,
     webllmSelectedModel,
   ]);
 

--- a/src/hooks/useProviderSettingsPersistence.ts
+++ b/src/hooks/useProviderSettingsPersistence.ts
@@ -107,7 +107,10 @@ export function useProviderSettingsPersistence({
     setWebllmSelectedModel(initial.webllmSelectedModel);
     setWebllmModelManuallySet(initial.webllmModelManuallySet);
     setWebllmLastRecommendedModel(initial.webllmLastRecommendedModel);
-    if (!scopeIdentity) return;
+    if (!scopeIdentity) {
+      setHydrationState("ready");
+      return;
+    }
 
     let cancelled = false;
     void store

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -228,7 +228,17 @@ describe("llm provider settings", () => {
   });
 
   it("defaults a missing legacy API key to blank", async () => {
-    const withoutApiKey = { ...makeSettings(), apiKey: undefined };
+    const withoutApiKey = {
+      providerId: "openai-compatible",
+      baseUrl: "https://api.openai.com",
+      model: "gpt-4o-mini",
+      ollamaPreferredModel: "llama3.1:8b",
+      allowRemoteProvider: true,
+      allowLocalProvider: false,
+      webllmConsent: false,
+      webllmPreferredModel: "",
+      webllmLastRecommendedModel: "",
+    };
     localStorage.setItem(scopeStorageKey(scopeIdentity), JSON.stringify(withoutApiKey));
 
     expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("");

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -7,6 +7,7 @@ import {
   loadSettingsAsync,
   migrateLegacySettingsScope,
   providerSettingsStore,
+  resetProviderSettingsStoreForTests,
   resolveHydratedProviderSettings,
   type LLMProviderSettings,
 } from "./settings";
@@ -129,6 +130,7 @@ describe("llm provider settings", () => {
 
   beforeEach(() => {
     vi.unstubAllEnvs();
+    resetProviderSettingsStoreForTests();
     originalLocalStorage = globalThis.localStorage;
     storage = new MemoryStorage();
     Object.defineProperty(globalThis, "localStorage", {
@@ -204,6 +206,16 @@ describe("llm provider settings", () => {
     );
 
     localStorage.setItem(scopeStorageKey(scopeIdentity), JSON.stringify({ providerId: "webllm" }));
+    await expect(loadSettingsAsync(scopeIdentity)).rejects.toThrow(
+      "Saved provider settings have an invalid shape",
+    );
+
+    localStorage.setItem(
+      scopeStorageKey(scopeIdentity),
+      JSON.stringify(
+        makeSettings({ providerId: "unknown-provider" as LLMProviderSettings["providerId"] }),
+      ),
+    );
     await expect(loadSettingsAsync(scopeIdentity)).rejects.toThrow(
       "Saved provider settings have an invalid shape",
     );
@@ -300,7 +312,7 @@ describe("llm provider settings", () => {
       providerDefinitions,
     });
     expect(unknownProvider).toMatchObject({
-      providerId: "unknown-provider",
+      providerId: "openai-compatible",
       baseUrl: "https://api.openai.com",
     });
 
@@ -383,6 +395,15 @@ describe("llm provider settings", () => {
 
     expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("sk-account-a");
     expect(await loadSettingsAsync(freshScopeIdentity)).toEqual(cleanDefaults);
+  });
+
+  it("resets singleton hydration state between isolated tests", async () => {
+    await providerSettingsStore.hydrate(scopeIdentity);
+    resetProviderSettingsStoreForTests();
+
+    await expect(providerSettingsStore.save(scopeIdentity, makeSettings())).rejects.toThrow(
+      "Provider settings are still loading",
+    );
   });
 
   it("does not let a pending encrypted save resurrect cleared settings", async () => {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearSettings,
-  loadSettings,
+  createDefaultProviderSettings,
+  deriveHydratedProviderSettingsView,
+  getProviderSettingsStatusMessage,
   loadSettingsAsync,
   migrateLegacySettingsScope,
-  saveSettings,
+  providerSettingsStore,
+  resolveHydratedProviderSettings,
   type LLMProviderSettings,
 } from "./settings";
+import type { LLMProviderDefinition } from "../llm/types";
 
 class MemoryStorage implements Storage {
   private entries = new Map<string, string>();
+  failNextSet = false;
 
   get length(): number {
     return this.entries.size;
@@ -32,13 +37,17 @@ class MemoryStorage implements Storage {
   }
 
   setItem(key: string, value: string): void {
+    if (this.failNextSet) {
+      this.failNextSet = false;
+      throw new Error("simulated storage failure");
+    }
     this.entries.set(key, value);
   }
 }
 
 function hashStorageKey(raw: string): string {
   return `gitstarrecall.llm.settings.${Math.abs(
-    raw.split("").reduce((acc, char) => ((acc << 5) - acc) + char.charCodeAt(0), 0),
+    raw.split("").reduce((acc, char) => (acc << 5) - acc + char.charCodeAt(0), 0),
   )}`;
 }
 
@@ -47,20 +56,23 @@ function scopeStorageKey(scopeIdentity: string): string {
 }
 
 function historicalScopeStorageKey(scopeIdentity: string): string {
-  const hash = scopeIdentity.split("").reduce((acc, char) => ((acc << 5) - acc) + char.charCodeAt(0), 0);
+  const hash = scopeIdentity
+    .split("")
+    .reduce((acc, char) => (acc << 5) - acc + char.charCodeAt(0), 0);
   return `gitstarrecall.llm.settings.${Math.abs(hash)}`;
 }
 
-async function encryptApiKey(scopeIdentity: string, envSecret: string, apiKey: string): Promise<string> {
+async function encryptApiKey(
+  scopeIdentity: string,
+  envSecret: string,
+  apiKey: string,
+): Promise<string> {
   const combined = new TextEncoder().encode(scopeIdentity + envSecret);
   const hash = await crypto.subtle.digest("SHA-256", combined);
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    hash,
-    { name: "AES-GCM" },
-    false,
-    ["encrypt", "decrypt"],
-  );
+  const cryptoKey = await crypto.subtle.importKey("raw", hash, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
   const iv = Uint8Array.from({ length: 12 }, (_, index) => index + 1);
   const encoded = new TextEncoder().encode(apiKey);
   const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, encoded);
@@ -70,16 +82,53 @@ async function encryptApiKey(scopeIdentity: string, envSecret: string, apiKey: s
   return btoa(String.fromCharCode(...combinedBytes));
 }
 
+function makeSettings(overrides: Partial<LLMProviderSettings> = {}): LLMProviderSettings {
+  return {
+    providerId: "openai-compatible",
+    baseUrl: "https://api.openai.com",
+    model: "gpt-4o-mini",
+    ollamaPreferredModel: "llama3.1:8b",
+    apiKey: "",
+    allowRemoteProvider: true,
+    allowLocalProvider: false,
+    webllmConsent: false,
+    webllmPreferredModel: "",
+    webllmLastRecommendedModel: "",
+    ...overrides,
+  };
+}
+
+const providerDefinitions: LLMProviderDefinition[] = [
+  {
+    id: "openai-compatible",
+    label: "OpenAI compatible",
+    kind: "remote",
+    defaultBaseUrl: "https://api.openai.com",
+    defaultModel: "gpt-4o-mini",
+    requiresApiKey: true,
+  },
+  {
+    id: "webllm",
+    label: "WebLLM",
+    kind: "local",
+    defaultBaseUrl: "",
+    defaultModel: "primary-web-model",
+    requiresApiKey: false,
+  },
+];
+
 describe("llm provider settings", () => {
   const scopeIdentity = "github:42";
   const legacyToken = "ghp_legacy_token";
   let originalLocalStorage: Storage | undefined;
+  let storage: MemoryStorage;
 
   beforeEach(() => {
     vi.unstubAllEnvs();
     originalLocalStorage = globalThis.localStorage;
+    storage = new MemoryStorage();
     Object.defineProperty(globalThis, "localStorage", {
-      value: new MemoryStorage(),
+      value: storage,
       configurable: true,
     });
   });
@@ -95,7 +144,7 @@ describe("llm provider settings", () => {
     });
   });
 
-  it("saves and loads webllm fields", () => {
+  it("saves and loads webllm fields", async () => {
     const settings: LLMProviderSettings = {
       providerId: "webllm",
       baseUrl: "",
@@ -109,8 +158,9 @@ describe("llm provider settings", () => {
       webllmLastRecommendedModel: "SmolLM2-360M-Instruct-q4f16_1-MLC",
     };
 
-    saveSettings(scopeIdentity, settings);
-    const loaded = loadSettings(scopeIdentity);
+    await providerSettingsStore.hydrate(scopeIdentity);
+    await providerSettingsStore.save(scopeIdentity, settings);
+    const loaded = await loadSettingsAsync(scopeIdentity);
 
     expect(loaded).not.toBeNull();
     expect(loaded?.providerId).toBe("webllm");
@@ -120,7 +170,7 @@ describe("llm provider settings", () => {
     expect(loaded?.ollamaPreferredModel).toBe("llama3.1:8b");
   });
 
-  it("supports legacy records without webllm fields", () => {
+  it("supports legacy records without webllm fields", async () => {
     const key = scopeStorageKey(scopeIdentity);
     localStorage.setItem(
       key,
@@ -134,7 +184,7 @@ describe("llm provider settings", () => {
       }),
     );
 
-    const loaded = loadSettings(scopeIdentity);
+    const loaded = await loadSettingsAsync(scopeIdentity);
     expect(loaded).not.toBeNull();
     expect(loaded?.providerId).toBe("openai-compatible");
     expect(loaded?.webllmConsent).toBe(false);
@@ -143,7 +193,148 @@ describe("llm provider settings", () => {
     expect(loaded?.ollamaPreferredModel).toBe("");
   });
 
-  it("clears settings for the scoped token", () => {
+  it("rejects malformed and invalid saved records explicitly", async () => {
+    localStorage.setItem(scopeStorageKey(scopeIdentity), "{not-json");
+    await expect(loadSettingsAsync(scopeIdentity)).rejects.toThrow(
+      "Saved provider settings are not valid JSON",
+    );
+
+    localStorage.setItem(scopeStorageKey(scopeIdentity), JSON.stringify({ providerId: "webllm" }));
+    await expect(loadSettingsAsync(scopeIdentity)).rejects.toThrow(
+      "Saved provider settings have an invalid shape",
+    );
+  });
+
+  it("requires encryption support to load or save API keys", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "");
+    localStorage.setItem(
+      scopeStorageKey(scopeIdentity),
+      JSON.stringify({
+        ...makeSettings({ apiKey: "" }),
+        apiKey: undefined,
+        apiKeyEncrypted: "ciphertext",
+      }),
+    );
+    await expect(loadSettingsAsync(scopeIdentity)).rejects.toThrow(
+      "Encrypted provider settings require VITE_LLM_SETTINGS_ENCRYPTION_KEY",
+    );
+
+    localStorage.clear();
+    await providerSettingsStore.hydrate(scopeIdentity);
+    await expect(
+      providerSettingsStore.save(scopeIdentity, makeSettings({ apiKey: "sk-secret" })),
+    ).rejects.toThrow("Provider API keys require VITE_LLM_SETTINGS_ENCRYPTION_KEY");
+    expect(localStorage.getItem(scopeStorageKey(scopeIdentity))).toBeNull();
+  });
+
+  it("defaults a missing legacy API key to blank", async () => {
+    const withoutApiKey = { ...makeSettings(), apiKey: undefined };
+    localStorage.setItem(scopeStorageKey(scopeIdentity), JSON.stringify(withoutApiKey));
+
+    expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("");
+  });
+
+  it("derives defaults, WebLLM fallback, model selection, and status copy", () => {
+    expect(createDefaultProviderSettings(false, "primary-web-model")).toMatchObject({
+      providerId: "openai-compatible",
+      baseUrl: "https://api.openai.com",
+      model: "gpt-4o-mini",
+    });
+    expect(createDefaultProviderSettings(true, "primary-web-model")).toMatchObject({
+      providerId: "webllm",
+      baseUrl: "",
+      model: "primary-web-model",
+    });
+
+    const defaults = deriveHydratedProviderSettingsView({
+      saved: null,
+      webLLMEnabled: true,
+      webLLMPrimaryModel: "primary-web-model",
+      providerDefinitions,
+    });
+    expect(defaults).toMatchObject({
+      providerId: "webllm",
+      model: "primary-web-model",
+      webllmSelectedModel: "primary-web-model",
+      webllmModelManuallySet: false,
+    });
+
+    const disabled = deriveHydratedProviderSettingsView({
+      saved: makeSettings({
+        providerId: "webllm",
+        baseUrl: "",
+        model: "",
+        ollamaPreferredModel: "",
+        webllmLastRecommendedModel: "recommended-web-model",
+      }),
+      webLLMEnabled: false,
+      webLLMPrimaryModel: "primary-web-model",
+      providerDefinitions,
+    });
+    expect(disabled).toMatchObject({
+      providerId: "openai-compatible",
+      baseUrl: "https://api.openai.com",
+      model: "gpt-4o-mini",
+      ollamaPreferredModel: "llama3.1:8b",
+      webllmSelectedModel: "recommended-web-model",
+    });
+
+    const unknownProvider = deriveHydratedProviderSettingsView({
+      saved: makeSettings({ providerId: "unknown-provider" as LLMProviderSettings["providerId"] }),
+      webLLMEnabled: true,
+      webLLMPrimaryModel: "primary-web-model",
+      providerDefinitions,
+    });
+    expect(unknownProvider).toMatchObject({
+      providerId: "unknown-provider",
+      baseUrl: "https://api.openai.com",
+    });
+
+    const remoteWithoutWebModel = deriveHydratedProviderSettingsView({
+      saved: makeSettings({ webllmPreferredModel: "", webllmLastRecommendedModel: "" }),
+      webLLMEnabled: true,
+      webLLMPrimaryModel: "primary-web-model",
+      providerDefinitions,
+    });
+    expect(remoteWithoutWebModel.webllmSelectedModel).toBe("primary-web-model");
+
+    const manual = deriveHydratedProviderSettingsView({
+      saved: makeSettings({
+        providerId: "webllm",
+        baseUrl: "",
+        model: "",
+        webllmPreferredModel: "manual-web-model",
+      }),
+      webLLMEnabled: true,
+      webLLMPrimaryModel: "primary-web-model",
+      providerDefinitions,
+    });
+    expect(manual).toMatchObject({
+      webllmSelectedModel: "manual-web-model",
+      webllmModelManuallySet: true,
+    });
+
+    expect(getProviderSettingsStatusMessage("loading", "idle", null)).toBe(
+      "Loading saved provider settings...",
+    );
+    expect(getProviderSettingsStatusMessage("ready", "saving", null)).toBe(
+      "Saving provider settings...",
+    );
+    expect(getProviderSettingsStatusMessage("ready", "saved", null)).toBe(
+      "Provider settings saved.",
+    );
+    expect(getProviderSettingsStatusMessage("ready", "error", "disk full")).toBe(
+      "Provider settings not saved: disk full",
+    );
+    expect(getProviderSettingsStatusMessage("error", "error", null)).toBe(
+      "Provider settings not saved: Unknown error",
+    );
+    expect(getProviderSettingsStatusMessage("ready", "idle", null)).toBe(
+      "Provider settings save automatically.",
+    );
+  });
+
+  it("clears settings for the scoped token", async () => {
     const settings: LLMProviderSettings = {
       providerId: "ollama",
       baseUrl: "http://localhost:11434",
@@ -157,10 +348,55 @@ describe("llm provider settings", () => {
       webllmLastRecommendedModel: "",
     };
 
-    saveSettings(scopeIdentity, settings);
-    expect(loadSettings(scopeIdentity)).not.toBeNull();
+    await providerSettingsStore.hydrate(scopeIdentity);
+    await providerSettingsStore.save(scopeIdentity, settings);
+    expect(await loadSettingsAsync(scopeIdentity)).not.toBeNull();
     clearSettings(scopeIdentity);
-    expect(loadSettings(scopeIdentity)).toBeNull();
+    expect(await loadSettingsAsync(scopeIdentity)).toBeNull();
+  });
+
+  it("uses clean defaults when a newly hydrated account has no saved settings", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "test-secret");
+    const freshScopeIdentity = "github:84";
+    const accountA = makeSettings({ apiKey: "sk-account-a", allowRemoteProvider: true });
+    const cleanDefaults = makeSettings({ apiKey: "", allowRemoteProvider: false });
+
+    await providerSettingsStore.hydrate(scopeIdentity);
+    await providerSettingsStore.save(scopeIdentity, accountA);
+    const freshSaved = await providerSettingsStore.hydrate(freshScopeIdentity);
+    const freshSettings = resolveHydratedProviderSettings(freshSaved, cleanDefaults);
+    await providerSettingsStore.save(freshScopeIdentity, freshSettings);
+
+    expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("sk-account-a");
+    expect(await loadSettingsAsync(freshScopeIdentity)).toEqual(cleanDefaults);
+  });
+
+  it("does not let a pending encrypted save resurrect cleared settings", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "test-secret");
+    await providerSettingsStore.hydrate(scopeIdentity);
+    const originalEncrypt = crypto.subtle.encrypt.bind(crypto.subtle);
+    let releaseEncryption: (() => void) | undefined;
+    const encryptionGate = new Promise<void>((resolve) => {
+      releaseEncryption = resolve;
+    });
+    vi.spyOn(crypto.subtle, "encrypt").mockImplementation(async (algorithm, key, data) => {
+      await encryptionGate;
+      return originalEncrypt(algorithm, key, data);
+    });
+
+    const pendingSave = providerSettingsStore.save(
+      scopeIdentity,
+      makeSettings({ apiKey: "sk-must-not-return" }),
+    );
+    await vi.waitFor(() => expect(crypto.subtle.encrypt).toHaveBeenCalledOnce());
+    clearSettings(scopeIdentity);
+    releaseEncryption?.();
+
+    await expect(pendingSave).resolves.toBeUndefined();
+    expect(await loadSettingsAsync(scopeIdentity)).toBeNull();
+    await expect(
+      providerSettingsStore.save(scopeIdentity, makeSettings({ apiKey: "sk-after-clear" })),
+    ).rejects.toThrow("Provider settings are still loading");
   });
 
   it("migrates legacy token-scoped records into the user scope", async () => {
@@ -184,7 +420,7 @@ describe("llm provider settings", () => {
     await migrateLegacySettingsScope(legacyToken, scopeIdentity);
 
     expect(localStorage.getItem(legacyKey)).toBeNull();
-    expect(loadSettings(scopeIdentity)?.providerId).toBe("ollama");
+    expect((await loadSettingsAsync(scopeIdentity))?.providerId).toBe("ollama");
   });
 
   it("discards malformed legacy records instead of blocking future logins", async () => {
@@ -197,7 +433,7 @@ describe("llm provider settings", () => {
     expect(localStorage.getItem(scopeStorageKey(scopeIdentity))).toBeNull();
   });
 
-  it("treats encrypted records as configured in sync loads", async () => {
+  it("hydrates encrypted records without substituting a blank API key", async () => {
     vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "test-secret");
     const key = scopeStorageKey(scopeIdentity);
     const apiKeyEncrypted = await encryptApiKey(scopeIdentity, "test-secret", "sk-live");
@@ -216,12 +452,12 @@ describe("llm provider settings", () => {
       }),
     );
 
-    expect(loadSettings(scopeIdentity)).toEqual({
+    expect(await loadSettingsAsync(scopeIdentity)).toEqual({
       providerId: "openai-compatible",
       baseUrl: "https://api.openai.com",
       model: "gpt-4o-mini",
       ollamaPreferredModel: "",
-      apiKey: "",
+      apiKey: "sk-live",
       allowRemoteProvider: true,
       allowLocalProvider: false,
       webllmConsent: false,
@@ -230,7 +466,7 @@ describe("llm provider settings", () => {
     });
   });
 
-  it("loads historical hashed stable-scope records and promotes them on save", () => {
+  it("loads historical hashed stable-scope records and promotes them on save", async () => {
     const historicalKey = historicalScopeStorageKey(scopeIdentity);
     localStorage.setItem(
       historicalKey,
@@ -244,9 +480,10 @@ describe("llm provider settings", () => {
       }),
     );
 
-    expect(loadSettings(scopeIdentity)?.providerId).toBe("ollama");
+    expect((await loadSettingsAsync(scopeIdentity))?.providerId).toBe("ollama");
 
-    saveSettings(scopeIdentity, {
+    await providerSettingsStore.hydrate(scopeIdentity);
+    await providerSettingsStore.save(scopeIdentity, {
       providerId: "ollama",
       baseUrl: "http://localhost:11434",
       model: "llama3.1:8b",
@@ -261,6 +498,103 @@ describe("llm provider settings", () => {
 
     expect(localStorage.getItem(historicalKey)).toBeNull();
     expect(localStorage.getItem(scopeStorageKey(scopeIdentity))).not.toBeNull();
+  });
+
+  it("serializes at least 100 delayed encrypted saves so the newest value is durable", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "test-secret");
+    await providerSettingsStore.hydrate(scopeIdentity);
+    const originalEncrypt = crypto.subtle.encrypt.bind(crypto.subtle);
+    let invocation = 0;
+    let activeEncryptions = 0;
+    let peakActiveEncryptions = 0;
+    vi.spyOn(crypto.subtle, "encrypt").mockImplementation(async (algorithm, key, data) => {
+      const current = invocation;
+      invocation += 1;
+      activeEncryptions += 1;
+      peakActiveEncryptions = Math.max(peakActiveEncryptions, activeEncryptions);
+      await new Promise((resolve) => setTimeout(resolve, (current * 37) % 5));
+      try {
+        return await originalEncrypt(algorithm, key, data);
+      } finally {
+        activeEncryptions -= 1;
+      }
+    });
+
+    const saves = Array.from({ length: 100 }, (_, index) =>
+      providerSettingsStore.save(scopeIdentity, makeSettings({ apiKey: `sk-${index}` })),
+    );
+    await Promise.all(saves);
+
+    expect(invocation).toBe(100);
+    expect(peakActiveEncryptions).toBe(1);
+    expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("sk-99");
+  });
+
+  it("reports a failed write without poisoning the next queued save", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "test-secret");
+    await providerSettingsStore.hydrate(scopeIdentity);
+    storage.failNextSet = true;
+
+    const failedSave = providerSettingsStore.save(
+      scopeIdentity,
+      makeSettings({ apiKey: "sk-failed" }),
+    );
+    const recoveredSave = providerSettingsStore.save(
+      scopeIdentity,
+      makeSettings({ apiKey: "sk-recovered" }),
+    );
+
+    await expect(failedSave).rejects.toThrow("simulated storage failure");
+    await expect(recoveredSave).resolves.toBeUndefined();
+    expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("sk-recovered");
+  });
+
+  it("preserves an encrypted record when hydration cannot decrypt it", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "wrong-secret");
+    const key = scopeStorageKey(scopeIdentity);
+    const apiKeyEncrypted = await encryptApiKey(scopeIdentity, "correct-secret", "sk-live");
+    const stored = JSON.stringify({
+      ...makeSettings({ apiKey: "" }),
+      apiKey: undefined,
+      apiKeyEncrypted,
+    });
+    localStorage.setItem(key, stored);
+
+    await expect(loadSettingsAsync(scopeIdentity)).rejects.toThrow(
+      "Encrypted provider settings could not be decrypted",
+    );
+    expect(localStorage.getItem(key)).toBe(stored);
+  });
+
+  it("rejects a pre-hydration save instead of replacing an encrypted key with blank state", async () => {
+    vi.stubEnv("VITE_LLM_SETTINGS_ENCRYPTION_KEY", "test-secret");
+    const key = scopeStorageKey(scopeIdentity);
+    const apiKeyEncrypted = await encryptApiKey(scopeIdentity, "test-secret", "sk-live");
+    const stored = JSON.stringify({
+      ...makeSettings({ apiKey: "" }),
+      apiKey: undefined,
+      apiKeyEncrypted,
+    });
+    localStorage.setItem(key, stored);
+
+    const originalDecrypt = crypto.subtle.decrypt.bind(crypto.subtle);
+    let releaseDecryption: (() => void) | undefined;
+    const decryptionGate = new Promise<void>((resolve) => {
+      releaseDecryption = resolve;
+    });
+    vi.spyOn(crypto.subtle, "decrypt").mockImplementation(async (algorithm, cryptoKey, data) => {
+      await decryptionGate;
+      return originalDecrypt(algorithm, cryptoKey, data);
+    });
+
+    const hydration = providerSettingsStore.hydrate(scopeIdentity);
+    await expect(
+      providerSettingsStore.save(scopeIdentity, makeSettings({ apiKey: "" })),
+    ).rejects.toThrow("Provider settings are still loading");
+    expect(localStorage.getItem(key)).toBe(stored);
+
+    releaseDecryption?.();
+    expect((await hydration)?.apiKey).toBe("sk-live");
   });
 
   it("fails loudly and preserves the legacy record when encrypted migration cannot decrypt", async () => {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -36,6 +36,10 @@ class MemoryStorage implements Storage {
     this.entries.delete(key);
   }
 
+  seed(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+
   setItem(key: string, value: string): void {
     if (this.failNextSet) {
       this.failNextSet = false;
@@ -239,7 +243,7 @@ describe("llm provider settings", () => {
       webllmPreferredModel: "",
       webllmLastRecommendedModel: "",
     };
-    localStorage.setItem(scopeStorageKey(scopeIdentity), JSON.stringify(withoutApiKey));
+    storage.seed(scopeStorageKey(scopeIdentity), JSON.stringify(withoutApiKey));
 
     expect((await loadSettingsAsync(scopeIdentity))?.apiKey).toBe("");
   });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,4 +1,4 @@
-import type { LLMProviderId } from "../llm/types";
+import type { LLMProviderDefinition, LLMProviderId } from "../llm/types";
 
 export type LLMProviderSettings = {
   providerId: LLMProviderId;
@@ -13,13 +13,117 @@ export type LLMProviderSettings = {
   webllmLastRecommendedModel: string;
 };
 
+export type ProviderSettingsHydrationState = "loading" | "ready" | "error";
+export type ProviderSettingsSaveState = "idle" | "saving" | "saved" | "error";
+
+export type ProviderSettingsStore = {
+  hydrate(scopeIdentity: string | null): Promise<LLMProviderSettings | null>;
+  save(scopeIdentity: string | null, settings: LLMProviderSettings): Promise<void>;
+};
+
+export function resolveHydratedProviderSettings(
+  saved: LLMProviderSettings | null,
+  defaults: LLMProviderSettings,
+): LLMProviderSettings {
+  return { ...(saved ?? defaults) };
+}
+
+export function createDefaultProviderSettings(
+  webLLMEnabled: boolean,
+  webLLMPrimaryModel: string,
+): LLMProviderSettings {
+  return {
+    providerId: webLLMEnabled ? "webllm" : "openai-compatible",
+    baseUrl: webLLMEnabled ? "" : "https://api.openai.com",
+    model: webLLMEnabled ? webLLMPrimaryModel : "gpt-4o-mini",
+    ollamaPreferredModel: "llama3.1:8b",
+    apiKey: "",
+    allowRemoteProvider: false,
+    allowLocalProvider: false,
+    webllmConsent: false,
+    webllmPreferredModel: "",
+    webllmLastRecommendedModel: "",
+  };
+}
+
+export type HydratedProviderSettingsView = {
+  providerId: LLMProviderId;
+  baseUrl: string;
+  model: string;
+  ollamaPreferredModel: string;
+  apiKey: string;
+  allowRemoteProvider: boolean;
+  allowLocalProvider: boolean;
+  webllmConsent: boolean;
+  webllmSelectedModel: string;
+  webllmModelManuallySet: boolean;
+  webllmLastRecommendedModel: string;
+};
+
+export function deriveHydratedProviderSettingsView(input: {
+  saved: LLMProviderSettings | null;
+  webLLMEnabled: boolean;
+  webLLMPrimaryModel: string;
+  providerDefinitions: LLMProviderDefinition[];
+}): HydratedProviderSettingsView {
+  const hydrated = resolveHydratedProviderSettings(
+    input.saved,
+    createDefaultProviderSettings(input.webLLMEnabled, input.webLLMPrimaryModel),
+  );
+  const providerId =
+    !input.webLLMEnabled && hydrated.providerId === "webllm"
+      ? "openai-compatible"
+      : hydrated.providerId;
+  const provider =
+    input.providerDefinitions.find((definition) => definition.id === providerId) ??
+    input.providerDefinitions[0];
+  const webllmSelectedModel =
+    provider.id === "webllm"
+      ? hydrated.webllmPreferredModel || hydrated.model || input.webLLMPrimaryModel
+      : hydrated.webllmPreferredModel ||
+        hydrated.webllmLastRecommendedModel ||
+        input.webLLMPrimaryModel;
+
+  return {
+    providerId,
+    baseUrl: hydrated.baseUrl || provider.defaultBaseUrl,
+    model: hydrated.model || provider.defaultModel,
+    ollamaPreferredModel: hydrated.ollamaPreferredModel || "llama3.1:8b",
+    apiKey: hydrated.apiKey,
+    allowRemoteProvider: hydrated.allowRemoteProvider,
+    allowLocalProvider: hydrated.allowLocalProvider,
+    webllmConsent: hydrated.webllmConsent,
+    webllmSelectedModel,
+    webllmModelManuallySet: Boolean(hydrated.webllmPreferredModel),
+    webllmLastRecommendedModel: hydrated.webllmLastRecommendedModel ?? "",
+  };
+}
+
+export function getProviderSettingsStatusMessage(
+  hydrationState: ProviderSettingsHydrationState,
+  saveState: ProviderSettingsSaveState,
+  error: string | null,
+): string {
+  if (hydrationState === "loading") return "Loading saved provider settings...";
+  if (saveState === "saving") return "Saving provider settings...";
+  if (saveState === "saved") return "Provider settings saved.";
+  if (saveState === "error") {
+    return `Provider settings not saved: ${error ?? "Unknown error"}`;
+  }
+  return "Provider settings save automatically.";
+}
+
 const STORAGE_KEY_PREFIX = "gitstarrecall.llm.settings.";
 const STABLE_SCOPE_KEY_PREFIX = `${STORAGE_KEY_PREFIX}scope.`;
 const GCM_IV_LENGTH = 12;
+const saveQueueByScope = new Map<string, Promise<void>>();
+const hydratedScopes = new Set<string>();
+const hydrationRevisionByScope = new Map<string, number>();
+const persistenceRevisionByScope = new Map<string, number>();
 
 function hashScopeValue(raw: string): string {
   return Math.abs(
-    raw.split("").reduce((acc, char) => ((acc << 5) - acc) + char.charCodeAt(0), 0),
+    raw.split("").reduce((acc, char) => (acc << 5) - acc + char.charCodeAt(0), 0),
   ).toString();
 }
 
@@ -88,11 +192,7 @@ async function deriveKey(sessionToken: string, envSecret: string): Promise<Crypt
 async function encrypt(plaintext: string, key: CryptoKey): Promise<string> {
   const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_LENGTH));
   const encoded = new TextEncoder().encode(plaintext);
-  const ciphertext = await crypto.subtle.encrypt(
-    { name: "AES-GCM", iv },
-    key,
-    encoded,
-  );
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
   const combined = new Uint8Array(iv.length + ciphertext.byteLength);
   combined.set(iv, 0);
   combined.set(new Uint8Array(ciphertext), iv.length);
@@ -103,11 +203,7 @@ async function decrypt(ciphertextBase64: string, key: CryptoKey): Promise<string
   const combined = Uint8Array.from(atob(ciphertextBase64), (c) => c.charCodeAt(0));
   const iv = combined.slice(0, GCM_IV_LENGTH);
   const data = combined.slice(GCM_IV_LENGTH);
-  const decrypted = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv },
-    key,
-    data,
-  );
+  const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, data);
   return new TextDecoder().decode(decrypted);
 }
 
@@ -128,149 +224,166 @@ function isValidStoredShape(parsed: unknown): parsed is StoredSettings {
     typeof p.allowLocalProvider === "boolean" &&
     (p.webllmConsent === undefined || typeof p.webllmConsent === "boolean") &&
     (p.webllmPreferredModel === undefined || typeof p.webllmPreferredModel === "string") &&
-    (p.webllmLastRecommendedModel === undefined || typeof p.webllmLastRecommendedModel === "string") &&
+    (p.webllmLastRecommendedModel === undefined ||
+      typeof p.webllmLastRecommendedModel === "string") &&
     (p.apiKey === undefined || typeof p.apiKey === "string") &&
     (p.apiKeyEncrypted === undefined || typeof p.apiKeyEncrypted === "string")
   );
 }
 
-export function loadSettings(scopeIdentity: string | null): LLMProviderSettings | null {
+export async function loadSettingsAsync(
+  scopeIdentity: string | null,
+): Promise<LLMProviderSettings | null> {
   if (!scopeIdentity) return null;
 
+  const stored = getStoredSettingsRecord(scopeIdentity);
+  if (!stored) return null;
+
+  let parsed: unknown;
   try {
-    const stored = getStoredSettingsRecord(scopeIdentity);
-    if (!stored) return null;
-
-    const parsed = JSON.parse(stored.value) as unknown;
-    if (!isValidStoredShape(parsed)) return null;
-
-    const base: Omit<LLMProviderSettings, "apiKey"> = {
-      providerId: parsed.providerId as LLMProviderId,
-      baseUrl: parsed.baseUrl,
-      model: parsed.model,
-      ollamaPreferredModel:
-        typeof parsed.ollamaPreferredModel === "string" ? parsed.ollamaPreferredModel : "",
-      allowRemoteProvider: parsed.allowRemoteProvider,
-      allowLocalProvider: parsed.allowLocalProvider,
-      webllmConsent: parsed.webllmConsent === true,
-      webllmPreferredModel:
-        typeof parsed.webllmPreferredModel === "string" ? parsed.webllmPreferredModel : "",
-      webllmLastRecommendedModel:
-        typeof parsed.webllmLastRecommendedModel === "string" ? parsed.webllmLastRecommendedModel : "",
-    };
-
-    if (typeof parsed.apiKeyEncrypted === "string") {
-      return { ...base, apiKey: "" };
-    }
-
-    if (typeof parsed.apiKey === "string") {
-      return { ...base, apiKey: parsed.apiKey };
-    }
-
-    return { ...base, apiKey: "" };
+    parsed = JSON.parse(stored.value) as unknown;
   } catch {
-    return null;
+    throw new Error("Saved provider settings are not valid JSON");
   }
-}
-
-export async function loadSettingsAsync(scopeIdentity: string | null): Promise<LLMProviderSettings | null> {
-  if (!scopeIdentity) return null;
-
-  try {
-    const stored = getStoredSettingsRecord(scopeIdentity);
-    if (!stored) return null;
-
-    const parsed = JSON.parse(stored.value) as unknown;
-    if (!isValidStoredShape(parsed)) return null;
-
-    const base: Omit<LLMProviderSettings, "apiKey"> = {
-      providerId: parsed.providerId as LLMProviderId,
-      baseUrl: parsed.baseUrl,
-      model: parsed.model,
-      ollamaPreferredModel:
-        typeof parsed.ollamaPreferredModel === "string" ? parsed.ollamaPreferredModel : "",
-      allowRemoteProvider: parsed.allowRemoteProvider,
-      allowLocalProvider: parsed.allowLocalProvider,
-      webllmConsent: parsed.webllmConsent === true,
-      webllmPreferredModel:
-        typeof parsed.webllmPreferredModel === "string" ? parsed.webllmPreferredModel : "",
-      webllmLastRecommendedModel:
-        typeof parsed.webllmLastRecommendedModel === "string" ? parsed.webllmLastRecommendedModel : "",
-    };
-
-    if (typeof parsed.apiKeyEncrypted === "string") {
-      const envSecret = getEncryptionKeyEnv();
-      if (!envSecret) return { ...base, apiKey: "" };
-      try {
-        const cryptoKey = await deriveKey(scopeIdentity, envSecret);
-        const apiKey = await decrypt(parsed.apiKeyEncrypted as string, cryptoKey);
-        return { ...base, apiKey };
-      } catch {
-        return { ...base, apiKey: "" };
-      }
-    }
-
-    if (typeof parsed.apiKey === "string") {
-      return { ...base, apiKey: parsed.apiKey };
-    }
-
-    return { ...base, apiKey: "" };
-  } catch {
-    return null;
+  if (!isValidStoredShape(parsed)) {
+    throw new Error("Saved provider settings have an invalid shape");
   }
-}
 
-export function saveSettings(scopeIdentity: string | null, settings: LLMProviderSettings): void {
-  if (!scopeIdentity) return;
-
-  const envSecret = getEncryptionKeyEnv();
-  const hasApiKey = Boolean(settings.apiKey && settings.apiKey.trim());
-
-  const toStore: StoredSettings = {
-    providerId: settings.providerId,
-    baseUrl: settings.baseUrl,
-    model: settings.model,
-    ollamaPreferredModel: settings.ollamaPreferredModel,
-    allowRemoteProvider: settings.allowRemoteProvider,
-    allowLocalProvider: settings.allowLocalProvider,
-    webllmConsent: settings.webllmConsent,
-    webllmPreferredModel: settings.webllmPreferredModel,
-    webllmLastRecommendedModel: settings.webllmLastRecommendedModel,
+  const base: Omit<LLMProviderSettings, "apiKey"> = {
+    providerId: parsed.providerId as LLMProviderId,
+    baseUrl: parsed.baseUrl,
+    model: parsed.model,
+    ollamaPreferredModel:
+      typeof parsed.ollamaPreferredModel === "string" ? parsed.ollamaPreferredModel : "",
+    allowRemoteProvider: parsed.allowRemoteProvider,
+    allowLocalProvider: parsed.allowLocalProvider,
+    webllmConsent: parsed.webllmConsent === true,
+    webllmPreferredModel:
+      typeof parsed.webllmPreferredModel === "string" ? parsed.webllmPreferredModel : "",
+    webllmLastRecommendedModel:
+      typeof parsed.webllmLastRecommendedModel === "string"
+        ? parsed.webllmLastRecommendedModel
+        : "",
   };
 
-  if (hasApiKey && envSecret && typeof crypto !== "undefined" && crypto.subtle) {
-    deriveKey(scopeIdentity, envSecret)
-      .then((cryptoKey) => encrypt(settings.apiKey.trim(), cryptoKey))
-      .then((apiKeyEncrypted) => {
-        try {
-          persistScopedSettingsValue(scopeIdentity, JSON.stringify({ ...toStore, apiKeyEncrypted }));
-        } catch {
-          console.warn("Failed to save LLM settings to localStorage");
-        }
-      })
-      .catch(() => {
-        try {
-          persistScopedSettingsValue(scopeIdentity, JSON.stringify({ ...toStore }));
-        } catch {
-          console.warn("Failed to save LLM settings to localStorage");
-        }
-      });
+  if (typeof parsed.apiKeyEncrypted === "string") {
+    const envSecret = getEncryptionKeyEnv();
+    if (!envSecret || typeof crypto === "undefined" || !crypto.subtle) {
+      throw new Error(
+        "Encrypted provider settings require VITE_LLM_SETTINGS_ENCRYPTION_KEY and Web Crypto support",
+      );
+    }
+    try {
+      const cryptoKey = await deriveKey(scopeIdentity, envSecret);
+      const apiKey = await decrypt(parsed.apiKeyEncrypted, cryptoKey);
+      return { ...base, apiKey };
+    } catch {
+      throw new Error("Encrypted provider settings could not be decrypted");
+    }
+  }
+
+  if (typeof parsed.apiKey === "string") {
+    return { ...base, apiKey: parsed.apiKey };
+  }
+
+  return { ...base, apiKey: "" };
+}
+
+async function persistSettingsSnapshot(
+  scopeIdentity: string,
+  settings: LLMProviderSettings,
+  persistenceRevision: number,
+): Promise<void> {
+  const snapshot = { ...settings, apiKey: settings.apiKey.trim() };
+
+  const envSecret = getEncryptionKeyEnv();
+  const hasApiKey = snapshot.apiKey.length > 0;
+
+  const toStore: StoredSettings = {
+    providerId: snapshot.providerId,
+    baseUrl: snapshot.baseUrl,
+    model: snapshot.model,
+    ollamaPreferredModel: snapshot.ollamaPreferredModel,
+    allowRemoteProvider: snapshot.allowRemoteProvider,
+    allowLocalProvider: snapshot.allowLocalProvider,
+    webllmConsent: snapshot.webllmConsent,
+    webllmPreferredModel: snapshot.webllmPreferredModel,
+    webllmLastRecommendedModel: snapshot.webllmLastRecommendedModel,
+  };
+
+  if (!hasApiKey) {
+    if ((persistenceRevisionByScope.get(scopeIdentity) ?? 0) !== persistenceRevision) return;
+    persistScopedSettingsValue(scopeIdentity, JSON.stringify({ ...toStore, apiKey: "" }));
     return;
   }
 
-  try {
-    if (!hasApiKey) {
-      persistScopedSettingsValue(scopeIdentity, JSON.stringify({ ...toStore, apiKey: "" }));
-    } else {
-      persistScopedSettingsValue(scopeIdentity, JSON.stringify(toStore));
-    }
-  } catch {
-    console.warn("Failed to save LLM settings to localStorage");
+  if (!envSecret || typeof crypto === "undefined" || !crypto.subtle) {
+    throw new Error(
+      "Provider API keys require VITE_LLM_SETTINGS_ENCRYPTION_KEY and Web Crypto support",
+    );
   }
+
+  const cryptoKey = await deriveKey(scopeIdentity, envSecret);
+  const apiKeyEncrypted = await encrypt(snapshot.apiKey, cryptoKey);
+  if ((persistenceRevisionByScope.get(scopeIdentity) ?? 0) !== persistenceRevision) return;
+  persistScopedSettingsValue(scopeIdentity, JSON.stringify({ ...toStore, apiKeyEncrypted }));
 }
+
+function enqueueSettingsSave(
+  scopeIdentity: string | null,
+  settings: LLMProviderSettings,
+): Promise<void> {
+  if (!scopeIdentity) return Promise.resolve();
+
+  const snapshot = { ...settings };
+  const persistenceRevision = persistenceRevisionByScope.get(scopeIdentity) ?? 0;
+  const previous = saveQueueByScope.get(scopeIdentity) ?? Promise.resolve();
+  const operation = previous.then(() =>
+    persistSettingsSnapshot(scopeIdentity, snapshot, persistenceRevision),
+  );
+  const queueTail = operation.catch(() => undefined);
+  saveQueueByScope.set(scopeIdentity, queueTail);
+  void queueTail.then(() => {
+    if (saveQueueByScope.get(scopeIdentity) === queueTail) {
+      saveQueueByScope.delete(scopeIdentity);
+    }
+  });
+  return operation;
+}
+
+export const providerSettingsStore: ProviderSettingsStore = {
+  hydrate(scopeIdentity) {
+    if (!scopeIdentity) return Promise.resolve(null);
+
+    hydratedScopes.delete(scopeIdentity);
+    const revision = (hydrationRevisionByScope.get(scopeIdentity) ?? 0) + 1;
+    hydrationRevisionByScope.set(scopeIdentity, revision);
+    return loadSettingsAsync(scopeIdentity).then((settings) => {
+      if (hydrationRevisionByScope.get(scopeIdentity) !== revision) return null;
+      hydratedScopes.add(scopeIdentity);
+      return settings;
+    });
+  },
+  save(scopeIdentity, settings) {
+    if (scopeIdentity && !hydratedScopes.has(scopeIdentity)) {
+      return Promise.reject(new Error("Provider settings are still loading"));
+    }
+    return enqueueSettingsSave(scopeIdentity, settings);
+  },
+};
 
 export function clearSettings(scopeIdentity: string | null): void {
   if (!scopeIdentity) return;
+
+  persistenceRevisionByScope.set(
+    scopeIdentity,
+    (persistenceRevisionByScope.get(scopeIdentity) ?? 0) + 1,
+  );
+  hydrationRevisionByScope.set(
+    scopeIdentity,
+    (hydrationRevisionByScope.get(scopeIdentity) ?? 0) + 1,
+  );
+  hydratedScopes.delete(scopeIdentity);
 
   try {
     const key = getStorageKey(scopeIdentity);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -70,13 +70,14 @@ export function deriveHydratedProviderSettingsView(input: {
     input.saved,
     createDefaultProviderSettings(input.webLLMEnabled, input.webLLMPrimaryModel),
   );
-  const providerId =
+  const requestedProviderId =
     !input.webLLMEnabled && hydrated.providerId === "webllm"
       ? "openai-compatible"
       : hydrated.providerId;
   const provider =
-    input.providerDefinitions.find((definition) => definition.id === providerId) ??
+    input.providerDefinitions.find((definition) => definition.id === requestedProviderId) ??
     input.providerDefinitions[0];
+  const providerId = provider.id;
   const webllmSelectedModel =
     provider.id === "webllm"
       ? hydrated.webllmPreferredModel || hydrated.model || input.webLLMPrimaryModel
@@ -120,6 +121,12 @@ const saveQueueByScope = new Map<string, Promise<void>>();
 const hydratedScopes = new Set<string>();
 const hydrationRevisionByScope = new Map<string, number>();
 const persistenceRevisionByScope = new Map<string, number>();
+const VALID_PROVIDER_IDS = new Set<LLMProviderId>([
+  "openai-compatible",
+  "ollama",
+  "lmstudio",
+  "webllm",
+]);
 
 function hashScopeValue(raw: string): string {
   return Math.abs(
@@ -217,6 +224,7 @@ function isValidStoredShape(parsed: unknown): parsed is StoredSettings {
   const p = parsed as Record<string, unknown>;
   return (
     typeof p.providerId === "string" &&
+    VALID_PROVIDER_IDS.has(p.providerId as LLMProviderId) &&
     typeof p.baseUrl === "string" &&
     typeof p.model === "string" &&
     (p.ollamaPreferredModel === undefined || typeof p.ollamaPreferredModel === "string") &&
@@ -250,7 +258,7 @@ export async function loadSettingsAsync(
   }
 
   const base: Omit<LLMProviderSettings, "apiKey"> = {
-    providerId: parsed.providerId as LLMProviderId,
+    providerId: parsed.providerId,
     baseUrl: parsed.baseUrl,
     model: parsed.model,
     ollamaPreferredModel:
@@ -371,6 +379,13 @@ export const providerSettingsStore: ProviderSettingsStore = {
     return enqueueSettingsSave(scopeIdentity, settings);
   },
 };
+
+export function resetProviderSettingsStoreForTests(): void {
+  saveQueueByScope.clear();
+  hydratedScopes.clear();
+  hydrationRevisionByScope.clear();
+  persistenceRevisionByScope.clear();
+}
 
 export function clearSettings(scopeIdentity: string | null): void {
   if (!scopeIdentity) return;

--- a/src/pages/UsagePage.tsx
+++ b/src/pages/UsagePage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 import { buildChatScopeKey, buildEmbeddingPreferenceScopeKey } from "../auth/authScope";
 import { createGitHubApiClient } from "../github/client";
-import type { GitHubStarredRepo, RepoReadmeRecord } from "../github/types";
+import type { RepoReadmeRecord } from "../github/types";
 import { getLocalDatabase } from "../db/client";
 import { backupChatSnapshot, loadChatBackup } from "../db/chatBackup";
 import type {
@@ -43,6 +43,12 @@ import {
   getReadmeProgressLabel,
   type IndexingStatus,
 } from "../sync/status";
+import {
+  applyReadmeBatchTransition,
+  buildIncompleteSyncResult,
+  buildSyncCompletion,
+  toPreviousReadmeStateByRepoId,
+} from "./readmeSyncOutcome";
 import { sortChatMessages } from "../chat/order";
 import { captureLocalError, captureLocalWarn } from "../observability/localLog";
 import { SessionChat } from "../components/SessionChat";
@@ -72,7 +78,7 @@ import {
 } from "../llm/providers";
 import { resolveProviderFallback } from "../llm/fallback";
 import type { LLMProviderDefinition, LLMProviderId } from "../llm/types";
-import { loadSettings, loadSettingsAsync, saveSettings } from "../lib/settings";
+import { useProviderSettingsPersistence } from "../hooks/useProviderSettingsPersistence";
 import {
   getWebLLMSelectableModels,
   WEBLLM_FALLBACK_MODEL_ID,
@@ -632,27 +638,6 @@ function getEmbeddingWorkerBatchSize(): number {
   return 8;
 }
 
-function mapStarredRepoToRecord(repo: GitHubStarredRepo, syncedAt: number): RepoRecord {
-  return {
-    id: repo.id,
-    fullName: repo.full_name,
-    name: repo.name,
-    description: repo.description,
-    topics: repo.topics ?? [],
-    language: repo.language,
-    htmlUrl: repo.html_url,
-    stars: repo.stargazers_count,
-    forks: repo.forks_count,
-    updatedAt: repo.updated_at,
-    readmeUrl: null,
-    readmeText: null,
-    readmeEtag: null,
-    readmeLastModified: null,
-    checksum: null,
-    lastSyncedAt: syncedAt,
-  };
-}
-
 async function clearWebLLMRuntimeCaches(): Promise<void> {
   if (!("caches" in globalThis)) {
     return;
@@ -708,21 +693,9 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
   const [languageFilter, setLanguageFilter] = useState("all");
   const [topicFilter, setTopicFilter] = useState("all");
   const [updatedWithinDaysFilter, setUpdatedWithinDaysFilter] = useState("all");
-  const defaultProviderId = webLLMEnabled ? "webllm" : "openai-compatible";
-  const [providerId, setProviderId] = useState<LLMProviderId>(defaultProviderId);
-  const [providerBaseUrl, setProviderBaseUrl] = useState(
-    providerDefinitions.find((provider) => provider.id === defaultProviderId)?.defaultBaseUrl ??
-    (defaultProviderId === "openai-compatible" ? "https://api.openai.com" : ""),
-  );
-  const [providerModel, setProviderModel] = useState(
-    providerDefinitions.find((provider) => provider.id === defaultProviderId)?.defaultModel ??
-    (defaultProviderId === "webllm" ? WEBLLM_PRIMARY_MODEL_ID : "gpt-4o-mini"),
-  );
-  const [providerApiKey, setProviderApiKey] = useState("");
-  const [ollamaPreferredChatModel, setOllamaPreferredChatModel] = useState("llama3.1:8b");
-  const [allowRemoteProvider, setAllowRemoteProvider] = useState(false);
-  const [allowLocalProvider, setAllowLocalProvider] = useState(false);
-  const [webllmConsent, setWebllmConsent] = useState(false);
+  const { providerId, setProviderId, providerBaseUrl, setProviderBaseUrl, providerModel, setProviderModel, providerApiKey, setProviderApiKey, ollamaPreferredChatModel, setOllamaPreferredChatModel, allowRemoteProvider, setAllowRemoteProvider,
+    allowLocalProvider, setAllowLocalProvider, webllmConsent, setWebllmConsent, webllmSelectedModel, setWebllmSelectedModel, webllmModelManuallySet, setWebllmModelManuallySet, webllmLastRecommendedModel, setWebllmLastRecommendedModel, saveState: providerSettingsSaveState, statusMessage: providerSettingsStatusMessage } =
+    useProviderSettingsPersistence({ scopeIdentity: authScopeIdentity, webLLMEnabled, webLLMPrimaryModel: WEBLLM_PRIMARY_MODEL_ID, providerDefinitions });
   const [webllmRuntimeState, setWebllmRuntimeState] = useState<
     "idle" | "probing" | "needs-consent" | "downloading" | "ready" | "failed"
   >("idle");
@@ -732,13 +705,10 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
   const [browserEmbeddingModelCandidates, setBrowserEmbeddingModelCandidates] = useState<string[]>(
     BROWSER_EMBEDDING_MODEL_CANDIDATES_DEFAULT,
   );
-  const [webllmSelectedModel, setWebllmSelectedModel] = useState(WEBLLM_PRIMARY_MODEL_ID);
-  const [webllmModelManuallySet, setWebllmModelManuallySet] = useState(false);
   const [webllmDownloadProgress, setWebllmDownloadProgress] = useState(0);
   const [webllmProgressText, setWebllmProgressText] = useState<string | null>(null);
   const [webllmDialogOpen, setWebllmDialogOpen] = useState(false);
   const [webllmAllowModelDownload, setWebllmAllowModelDownload] = useState(false);
-  const [webllmLastRecommendedModel, setWebllmLastRecommendedModel] = useState("");
   const [allowOllamaEmbedding, setAllowOllamaEmbedding] = useState(false);
   const [ollamaBaseUrl, setOllamaBaseUrl] = useState(getDefaultOllamaBaseUrl());
   const [ollamaModel, setOllamaModel] = useState(getDefaultOllamaModel());
@@ -853,7 +823,7 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
       setWebllmSelectedModel(resolveHermesModelSelection(value));
       setWebllmModelManuallySet(true);
     }
-  }, [providerId]);
+  }, [providerId, setOllamaPreferredChatModel, setProviderModel, setWebllmModelManuallySet, setWebllmSelectedModel]);
 
   const ensureBrowserEmbeddingRecommendation = useCallback(async (): Promise<BrowserEmbeddingRecommendation> => {
     if (browserEmbeddingRecommendation) {
@@ -1299,96 +1269,6 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
     };
   }, []);
 
-  // Load saved provider settings when user logs in (sync for plaintext, async for encrypted)
-  useEffect(() => {
-    if (!authScopeIdentity) return;
-    const sync = loadSettings(authScopeIdentity);
-    if (sync) {
-      const savedProviderId =
-        !webLLMEnabled && sync.providerId === "webllm" ? "openai-compatible" : sync.providerId;
-      const savedProviderDefinition =
-        providerDefinitions.find((provider) => provider.id === savedProviderId) ?? providerDefinitions[0];
-      setProviderId(savedProviderId);
-      setProviderBaseUrl(sync.baseUrl || savedProviderDefinition.defaultBaseUrl);
-      setProviderModel(sync.model || savedProviderDefinition.defaultModel);
-      setOllamaPreferredChatModel(sync.ollamaPreferredModel || "llama3.1:8b");
-      setProviderApiKey(sync.apiKey);
-      setAllowRemoteProvider(sync.allowRemoteProvider);
-      setAllowLocalProvider(sync.allowLocalProvider);
-      setWebllmConsent(sync.webllmConsent);
-      if (savedProviderDefinition.id === "webllm") {
-        setWebllmSelectedModel(sync.webllmPreferredModel || sync.model || WEBLLM_PRIMARY_MODEL_ID);
-        setWebllmModelManuallySet(Boolean(sync.webllmPreferredModel));
-      } else {
-        setWebllmSelectedModel(
-          sync.webllmPreferredModel || sync.webllmLastRecommendedModel || WEBLLM_PRIMARY_MODEL_ID,
-        );
-        setWebllmModelManuallySet(Boolean(sync.webllmPreferredModel));
-      }
-      setWebllmLastRecommendedModel(sync.webllmLastRecommendedModel ?? "");
-      return;
-    }
-    let cancelled = false;
-    loadSettingsAsync(authScopeIdentity).then((saved) => {
-      if (cancelled || !saved) return;
-      const savedProviderId =
-        !webLLMEnabled && saved.providerId === "webllm" ? "openai-compatible" : saved.providerId;
-      const savedProviderDefinition =
-        providerDefinitions.find((provider) => provider.id === savedProviderId) ?? providerDefinitions[0];
-      setProviderId(savedProviderId);
-      setProviderBaseUrl(saved.baseUrl || savedProviderDefinition.defaultBaseUrl);
-      setProviderModel(saved.model || savedProviderDefinition.defaultModel);
-      setOllamaPreferredChatModel(saved.ollamaPreferredModel || "llama3.1:8b");
-      setProviderApiKey(saved.apiKey);
-      setAllowRemoteProvider(saved.allowRemoteProvider);
-      setAllowLocalProvider(saved.allowLocalProvider);
-      setWebllmConsent(saved.webllmConsent);
-      if (savedProviderDefinition.id === "webllm") {
-        setWebllmSelectedModel(saved.webllmPreferredModel || saved.model || WEBLLM_PRIMARY_MODEL_ID);
-        setWebllmModelManuallySet(Boolean(saved.webllmPreferredModel));
-      } else {
-        setWebllmSelectedModel(
-          saved.webllmPreferredModel || saved.webllmLastRecommendedModel || WEBLLM_PRIMARY_MODEL_ID,
-        );
-        setWebllmModelManuallySet(Boolean(saved.webllmPreferredModel));
-      }
-      setWebllmLastRecommendedModel(saved.webllmLastRecommendedModel ?? "");
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [authScopeIdentity]);
-
-  // Save provider settings when they change
-  useEffect(() => {
-    if (authScopeIdentity) {
-      saveSettings(authScopeIdentity, {
-        providerId,
-        baseUrl: providerBaseUrl,
-        model: providerModel,
-        apiKey: providerApiKey,
-        allowRemoteProvider,
-        allowLocalProvider,
-        webllmConsent,
-        webllmPreferredModel: webllmSelectedModel,
-        webllmLastRecommendedModel,
-        ollamaPreferredModel: ollamaPreferredChatModel,
-      });
-    }
-  }, [
-    authScopeIdentity,
-    providerId,
-    providerBaseUrl,
-    providerModel,
-    providerApiKey,
-    allowRemoteProvider,
-    allowLocalProvider,
-    webllmConsent,
-    webllmSelectedModel,
-    webllmLastRecommendedModel,
-    ollamaPreferredChatModel,
-  ]);
-
   useEffect(() => {
     if (providerId !== "ollama") {
       return;
@@ -1403,7 +1283,7 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
       }
       return normalizedModel;
     });
-  }, [providerId, providerModel]);
+  }, [providerId, providerModel, setOllamaPreferredChatModel]);
 
   useEffect(() => {
     if (providerId !== "ollama") {
@@ -1450,6 +1330,8 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
     ollamaChatRecommendedModel,
     providerId,
     providerModel,
+    setOllamaPreferredChatModel,
+    setProviderModel,
   ]);
 
   useEffect(() => {
@@ -1516,7 +1398,7 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
     return () => {
       cancelled = true;
     };
-  }, [providerId, webllmLastRecommendedModel, webllmModelManuallySet, webllmSelectedModel]);
+  }, [providerId, setProviderModel, setWebllmLastRecommendedModel, setWebllmSelectedModel, webllmLastRecommendedModel, webllmModelManuallySet, webllmSelectedModel]);
 
   useEffect(() => {
     const fallbackPreference: OllamaPreferenceSnapshot = {
@@ -1777,19 +1659,12 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
 
     const candidateIds = new Set(syncPlan.candidateRepoIds);
     const candidates = starResult.repos.filter((repo) => candidateIds.has(repo.id));
-    const previousSyncStateByRepoId = new Map(
-      existingStates.map((state) => [
-        state.id,
-        {
-          checksum: state.checksum,
-          readmeEtag: state.readmeEtag ?? null,
-          readmeLastModified: state.readmeLastModified ?? null,
-        },
-      ]),
-    );
+    const previousSyncStateByRepoId = toPreviousReadmeStateByRepoId(existingStates);
     let chunkUpsertLatencyTotalMs = 0;
     let chunkUpsertCount = 0;
     let firstEmbeddingAvailableAt: number | null = null;
+    const successfullyChangedRepoIds = new Set<number>();
+    let chunkingCoverageCompleted = 0;
     let lastReadmeStats = {
       requested: candidates.length,
       succeeded: 0,
@@ -1840,43 +1715,32 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
 
         const localRepo = existingReposById.get(readme.repoId);
         const localState = existingById.get(readme.repoId);
-        const record = mapStarredRepoToRecord(remoteRepo, syncedAt);
-        if (readme.notModified && localRepo) {
-          record.readmeUrl = localRepo.readmeUrl;
-          record.readmeText = localRepo.readmeText;
-          record.checksum = localRepo.checksum;
-          record.readmeEtag = readme.readmeEtag ?? localRepo.readmeEtag;
-          record.readmeLastModified = readme.readmeLastModified ?? localRepo.readmeLastModified;
-        } else {
-          record.readmeUrl = readme.readmeUrl;
-          record.readmeText = readme.readmeText;
-          record.checksum = readme.checksum;
-          record.readmeEtag = readme.readmeEtag;
-          record.readmeLastModified = readme.readmeLastModified;
-        }
-
         const metadataChanged = localState ? repoMetadataChanged(localState, remoteRepo) : true;
-        const checksumChanged = localRepo ? localRepo.checksum !== record.checksum : true;
-        if (!localRepo || checksumChanged || metadataChanged) {
+        const transition = applyReadmeBatchTransition({
+          remoteRepo,
+          readme,
+          localRepo,
+          metadataChanged,
+          syncedAt,
+        });
+        if (transition.shouldUpsert) {
+          const { record } = transition;
           upserts.push(record);
         }
-        if (checksumChanged) {
+        if (transition.shouldRechunk) {
+          const { record } = transition;
           changedForChunk.push(record);
+          successfullyChangedRepoIds.add(record.id);
         }
 
+        const { record } = transition;
         existingReposById.set(record.id, record);
-        existingById.set(record.id, {
-          id: record.id,
-          fullName: record.fullName,
-          description: record.description,
-          topics: record.topics,
-          language: record.language,
-          updatedAt: record.updatedAt,
-          readmeEtag: record.readmeEtag,
-          readmeLastModified: record.readmeLastModified,
-          checksum: record.checksum,
-        });
+        existingById.set(record.id, transition.syncState);
       }
+
+      chunkingCoverageCompleted += batch.filter(
+        (readme) => readme.outcome !== "transient_failure",
+      ).length;
 
       if (upserts.length > 0) {
         await database.upsertRepos(upserts);
@@ -1914,7 +1778,10 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
               chunkingActive: completedReadmes < previous.chunkingTarget,
               embeddingWindowed: previous.embeddingWindowed,
               chunkTotal: database.getChunkCount(),
-              chunkingCompleted: Math.max(previous.chunkingCompleted, completedReadmes),
+              chunkingCompleted: Math.max(
+                previous.chunkingCompleted,
+                chunkingCoverageCompleted,
+              ),
             }
           : previous,
       );
@@ -1992,7 +1859,7 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
         totalRepos: starResult.repos.length,
         removedRepos: syncPlan.removedRepoIds.length,
         candidateRepos: candidates.length,
-        changedRepos: readmeResult.records.filter((record) => !record.notModified).length,
+        changedRepos: successfullyChangedRepoIds.size,
         fetchedPages: starResult.fetchedPages,
       }),
       updatedAt: Date.now(),
@@ -2019,45 +1886,60 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
     const localRepoCount = database.getRepoCount();
     const localChunkCount = database.getChunkCount();
     const localEmbeddingCount = database.getEmbeddingCount();
-    const readmeCount = readmeResult.records.length - readmeResult.missingCount - readmeResult.failedCount;
     const hasPendingEmbeddingChunks = database.getPendingEmbeddingChunkCount() > 0;
+    const hasReadmeRetriesPending = readmeResult.failedCount > 0;
+    const completion = buildSyncCompletion({
+      totalRepos: starResult.repos.length,
+      fetchedPages: starResult.fetchedPages,
+      candidateCount: candidates.length,
+      changedCount: successfullyChangedRepoIds.size,
+      removedCount: syncPlan.removedRepoIds.length,
+      records: readmeResult.records,
+      missingCount: readmeResult.missingCount,
+      failedCount: readmeResult.failedCount,
+      repoCount: localRepoCount,
+      chunkCount: localChunkCount,
+      embeddingCount: localEmbeddingCount,
+      pendingEmbeddings: hasPendingEmbeddingChunks,
+      pipelineV2: usePipelineV2,
+      readmeP95LatencyMs: lastReadmeStats.p95LatencyMs,
+    });
     setIndexingStatus((previous) =>
       previous
         ? {
-          ...previous,
-          phase: hasPendingEmbeddingChunks ? "Preparing embeddings for unindexed chunks" : "Sync complete",
-          primaryStage: hasPendingEmbeddingChunks ? "embedding-init" : "complete",
-          readmeActive: false,
-          chunkingActive: false,
-          embeddingActive: hasPendingEmbeddingChunks,
-          embeddingWindowed: false,
-          repoTotal: starResult.repos.length,
-          readmesTarget: candidates.length,
-          readmesCompleted: candidates.length,
-          chunkingTarget: candidates.length,
-          chunkingCompleted: candidates.length,
-          readmesMissing: readmeResult.missingCount,
-          readmesFailed: readmeResult.failedCount,
-          chunkTotal: localChunkCount,
-          embeddingsCreated: hasPendingEmbeddingChunks ? 0 : localEmbeddingCount,
-          embeddingTarget: 0,
-          elapsedSeconds: hasPendingEmbeddingChunks
-            ? undefined
-            : Math.max(1, Math.round((Date.now() - previous.startedAt) / 1000)),
-        }
+            ...previous,
+            ...completion.status,
+            elapsedSeconds: hasPendingEmbeddingChunks
+              ? undefined
+              : Math.max(1, Math.round((Date.now() - previous.startedAt) / 1000)),
+          }
         : previous,
     );
-
-    setStarsSummary(
-      `Sync complete: ${starResult.repos.length} stars scanned (${starResult.fetchedPages} pages), ` +
-      `${readmeResult.records.filter((record) => !record.notModified).length} changed/new, ${syncPlan.removedRepoIds.length} removed. ` +
-      `READMEs fetched: ${readmeCount}, missing: ${readmeResult.missingCount}, failed: ${readmeResult.failedCount}. ` +
-      `Local DB: ${localRepoCount} repos, ${localChunkCount} chunks, ${localEmbeddingCount} embeddings. ` +
-      `Pipeline: ${usePipelineV2 ? "batch-v2" : "legacy"} · README p95 ${Math.round(lastReadmeStats.p95LatencyMs)}ms.`,
-    );
+    setStarsSummary(completion.summary);
 
     if (hasPendingEmbeddingChunks) {
       await generateEmbeddings(database);
+    }
+    if (hasReadmeRetriesPending) {
+      const finalRepoCount = database.getRepoCount();
+      const finalChunkCount = database.getChunkCount();
+      const finalEmbeddingCount = database.getEmbeddingCount();
+      const incomplete = buildIncompleteSyncResult({
+        failedCount: readmeResult.failedCount,
+        candidateCount: candidates.length,
+        repoCount: finalRepoCount,
+        chunkCount: finalChunkCount,
+        embeddingCount: finalEmbeddingCount,
+      });
+      setIndexingStatus((previous) =>
+        previous
+          ? {
+              ...previous,
+              ...incomplete.status,
+            }
+          : previous,
+      );
+      setStarsSummary(incomplete.summary);
     }
   };
 
@@ -3654,6 +3536,8 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
                       void refreshOllamaCatalog();
                     }}
                   />
+                  <p aria-live="polite" className={`text-xs ${providerSettingsSaveState === "error" ? "text-destructive" : "text-muted-foreground"}`}>
+                    {providerSettingsStatusMessage}</p>
                   <div className="rounded-md border border-border/60 bg-background/70 p-4">
                     <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">Permissions</p>
                     <p className="mt-2">Remote providers: <span className="font-medium text-foreground">{allowRemoteProvider ? "enabled" : "disabled"}</span></p>

--- a/src/pages/UsagePage.tsx
+++ b/src/pages/UsagePage.tsx
@@ -58,6 +58,7 @@ import { SyncStatusBar } from "../components/SyncStatusBar";
 import { OllamaConfigPanel } from "../components/OllamaConfigPanel";
 import { DeveloperModePanel, type RetrievalTuning } from "../components/DeveloperModePanel";
 import { ProviderSettingsForm } from "../components/ProviderSettingsForm";
+import { ProviderSettingsStatus } from "../components/ProviderSettingsStatus";
 import { FilterBar } from "../components/FilterBar";
 import { RepoResultCard } from "../components/RepoResultCard";
 import { SessionSidebar } from "../components/SessionSidebar";
@@ -3536,8 +3537,10 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
                       void refreshOllamaCatalog();
                     }}
                   />
-                  <p aria-live="polite" className={`text-xs ${providerSettingsSaveState === "error" ? "text-destructive" : "text-muted-foreground"}`}>
-                    {providerSettingsStatusMessage}</p>
+                  <ProviderSettingsStatus
+                    saveState={providerSettingsSaveState}
+                    message={providerSettingsStatusMessage}
+                  />
                   <div className="rounded-md border border-border/60 bg-background/70 p-4">
                     <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">Permissions</p>
                     <p className="mt-2">Remote providers: <span className="font-medium text-foreground">{allowRemoteProvider ? "enabled" : "disabled"}</span></p>
@@ -3797,6 +3800,10 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
                           void refreshOllamaCatalog();
                         }}
                       />
+                      <ProviderSettingsStatus
+                        saveState={providerSettingsSaveState}
+                        message={providerSettingsStatusMessage}
+                      />
                     </>
                   ) : (
                     <EmptyState type="no-session" />
@@ -3994,6 +4001,10 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
                       onRefreshOllamaModels={() => {
                         void refreshOllamaCatalog();
                       }}
+                    />
+                    <ProviderSettingsStatus
+                      saveState={providerSettingsSaveState}
+                      message={providerSettingsStatusMessage}
                     />
                   </CardContent>
                 </Card>

--- a/src/pages/auth/AuthCallbackPage.test.tsx
+++ b/src/pages/auth/AuthCallbackPage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
+import { buildGitHubAuthorizeUrl, exchangeOAuthCode } from "../../auth/githubOAuth";
+import type { OAuthCallbackInput } from "../../auth/auth-types";
+import AuthCallbackPage from "./AuthCallbackPage";
+
+const mocks = vi.hoisted(() => ({
+  handleOAuthCallback: vi.fn<(input: OAuthCallbackInput) => Promise<void>>(),
+  navigate: vi.fn(),
+}));
+
+vi.mock("../../auth/useAuth", () => ({
+  useAuth: () => ({ handleOAuthCallback: mocks.handleOAuthCallback }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mocks.navigate };
+});
+
+function oauthResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ access_token: "issued-token" }),
+  } as unknown as Response;
+}
+
+async function setCallbackLocation(code = "callback-code"): Promise<OAuthCallbackInput> {
+  const authorizeUrl = new URL(await buildGitHubAuthorizeUrl());
+  const state = authorizeUrl.searchParams.get("state");
+  if (!state) {
+    throw new Error("OAuth test state was not created");
+  }
+
+  window.history.replaceState({}, "", `/auth/callback?code=${code}&state=${state}`);
+  return { code, state, error: undefined };
+}
+
+describe("AuthCallbackPage", () => {
+  beforeEach(() => {
+    mocks.handleOAuthCallback.mockReset();
+    mocks.navigate.mockReset();
+    vi.stubEnv("VITE_GITHUB_CLIENT_ID", "client-id-123");
+    vi.stubEnv("VITE_GITHUB_REDIRECT_URI", "http://localhost:5173/auth/callback");
+    vi.stubEnv("VITE_GITHUB_OAUTH_EXCHANGE_URL", "/api/github/oauth/exchange");
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("performs exactly one token exchange under React StrictMode", async () => {
+    const callback = await setCallbackLocation();
+    let resolveFetch!: (response: Response) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      ),
+    );
+    mocks.handleOAuthCallback.mockImplementation(async (input) => {
+      await exchangeOAuthCode({ code: input.code!, state: input.state! });
+    });
+
+    render(
+      <StrictMode>
+        <AuthCallbackPage />
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(mocks.handleOAuthCallback).toHaveBeenCalledWith(callback);
+    resolveFetch(oauthResponse());
+
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/app", { replace: true }));
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(mocks.handleOAuthCallback).toHaveBeenCalledOnce();
+    expect(mocks.navigate).toHaveBeenCalledOnce();
+  });
+
+  it("retries a transient callback directly with the same payload", async () => {
+    const user = userEvent.setup();
+    const callback = await setCallbackLocation();
+    const verifier = sessionStorage.getItem("gitstarrecall.oauth.verifier");
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ...oauthResponse(), ok: false, status: 503 })
+        .mockResolvedValueOnce(oauthResponse()),
+    );
+    mocks.handleOAuthCallback.mockImplementation(async (input) => {
+      await exchangeOAuthCode({ code: input.code!, state: input.state! });
+    });
+
+    render(<AuthCallbackPage />);
+
+    expect(
+      await screen.findByText("OAuth token exchange is temporarily unavailable (503)"),
+    ).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Retry callback" }));
+
+    await waitFor(() => expect(mocks.handleOAuthCallback).toHaveBeenCalledTimes(2));
+    expect(mocks.handleOAuthCallback).toHaveBeenNthCalledWith(1, callback);
+    expect(mocks.handleOAuthCallback).toHaveBeenNthCalledWith(2, callback);
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/app", { replace: true }));
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(fetch).mock.calls.map(([, options]) => JSON.parse(String(options?.body))),
+    ).toEqual([
+      expect.objectContaining({ codeVerifier: verifier }),
+      expect.objectContaining({ codeVerifier: verifier }),
+    ]);
+  });
+
+  it("does not offer retry after terminal callback validation failure", async () => {
+    await setCallbackLocation();
+    window.history.replaceState({}, "", "/auth/callback?error=access_denied");
+    mocks.handleOAuthCallback.mockRejectedValueOnce(
+      new Error("GitHub returned an OAuth error: access_denied"),
+    );
+
+    render(<AuthCallbackPage />);
+
+    expect(await screen.findByText("GitHub returned an OAuth error: access_denied")).toBeVisible();
+    expect(sessionStorage.getItem("gitstarrecall.oauth.state")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry callback" })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/auth/AuthCallbackPage.tsx
+++ b/src/pages/auth/AuthCallbackPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../auth/useAuth";
+import { clearOAuthSession, isRetryableOAuthError } from "../../auth/githubOAuth";
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -16,21 +17,39 @@ export default function AuthCallbackPage() {
   const navigate = useNavigate();
   const { handleOAuthCallback } = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const [canRetry, setCanRetry] = useState(false);
+  const [attempt, setAttempt] = useState(0);
   const [stage, setStage] = useState("Validating GitHub response");
+  const callbackPromiseRef = useRef<Promise<void> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     const run = async () => {
       const params = new URLSearchParams(window.location.search);
+      const callback = {
+        code: params.get("code") ?? undefined,
+        state: params.get("state") ?? undefined,
+        error: params.get("error") ?? undefined,
+      };
 
       try {
+        setError(null);
+        setCanRetry(false);
         setStage("Validating GitHub response");
-        await handleOAuthCallback({
-          code: params.get("code") ?? undefined,
-          state: params.get("state") ?? undefined,
-          error: params.get("error") ?? undefined,
-        });
+        if (callback.error || !callback.code || !callback.state) {
+          clearOAuthSession();
+        }
+        const callbackPromise = callbackPromiseRef.current ?? handleOAuthCallback(callback);
+        callbackPromiseRef.current = callbackPromise;
+        try {
+          await callbackPromise;
+        } catch (callbackError) {
+          if (callbackPromiseRef.current === callbackPromise) {
+            callbackPromiseRef.current = null;
+          }
+          throw callbackError;
+        }
         if (!cancelled) {
           setStage("Creating local session");
         }
@@ -42,6 +61,7 @@ export default function AuthCallbackPage() {
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : "OAuth callback failed");
+          setCanRetry(isRetryableOAuthError(err));
         }
       }
     };
@@ -51,7 +71,7 @@ export default function AuthCallbackPage() {
     return () => {
       cancelled = true;
     };
-  }, [handleOAuthCallback, navigate]);
+  }, [attempt, handleOAuthCallback, navigate]);
 
   return (
     <div className="flex min-h-[50vh] items-center justify-center">
@@ -59,11 +79,17 @@ export default function AuthCallbackPage() {
         <CardContent className="flex flex-col gap-5 p-8">
           <div className="flex items-center gap-4">
             <div className="flex h-12 w-12 items-center justify-center rounded-md bg-primary/10">
-              {error ? <ShieldAlert className="h-6 w-6 text-destructive" /> : <Github className="h-6 w-6 text-primary" />}
+              {error ? (
+                <ShieldAlert className="h-6 w-6 text-destructive" />
+              ) : (
+                <Github className="h-6 w-6 text-primary" />
+              )}
             </div>
             <div>
               <p className="font-display text-lg font-semibold text-foreground">GitHub callback</p>
-              <p className="text-sm text-muted-foreground">Finishing authentication and preparing the workspace.</p>
+              <p className="text-sm text-muted-foreground">
+                Finishing authentication and preparing the workspace.
+              </p>
             </div>
           </div>
           {error ? (
@@ -78,7 +104,9 @@ export default function AuthCallbackPage() {
               </div>
               <div className="space-y-2 rounded-md border border-border/60 bg-background/70 p-4 text-sm text-muted-foreground">
                 {CALLBACK_STEPS.map((step, index) => {
-                  const currentIndex = CALLBACK_STEPS.indexOf(stage as (typeof CALLBACK_STEPS)[number]);
+                  const currentIndex = CALLBACK_STEPS.indexOf(
+                    stage as (typeof CALLBACK_STEPS)[number],
+                  );
                   const isDone = index < currentIndex;
                   const isActive = index === currentIndex;
                   return (
@@ -90,7 +118,9 @@ export default function AuthCallbackPage() {
                       ) : (
                         <div className="h-4 w-4 rounded-full border border-border/70" />
                       )}
-                      <span className={isDone || isActive ? "text-foreground" : undefined}>{step}</span>
+                      <span className={isDone || isActive ? "text-foreground" : undefined}>
+                        {step}
+                      </span>
                     </div>
                   );
                 })}
@@ -99,12 +129,18 @@ export default function AuthCallbackPage() {
           )}
           {error ? (
             <div className="flex flex-wrap gap-3">
-              <Button variant="outline" className="rounded-md" onClick={() => navigate("/", { replace: true })}>
+              <Button
+                variant="outline"
+                className="rounded-md"
+                onClick={() => navigate("/", { replace: true })}
+              >
                 Return home
               </Button>
-              <Button className="rounded-md" onClick={() => window.location.reload()}>
-                Retry callback
-              </Button>
+              {canRetry ? (
+                <Button className="rounded-md" onClick={() => setAttempt((value) => value + 1)}>
+                  Retry callback
+                </Button>
+              ) : null}
             </div>
           ) : null}
         </CardContent>

--- a/src/pages/readmeSyncOutcome.test.ts
+++ b/src/pages/readmeSyncOutcome.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import type { RepoRecord } from "../db/types";
+import type { GitHubStarredRepo, RepoReadmeRecord } from "../github/types";
+import {
+  applyReadmeBatchTransition,
+  applyReadmeOutcome,
+  buildIncompleteSyncResult,
+  buildSyncCompletion,
+  mapStarredRepoToRecord,
+  readmeOutcomeCanChangeChunks,
+  toPreviousReadmeStateByRepoId,
+  toRepoSyncState,
+} from "./readmeSyncOutcome";
+
+function repo(overrides: Partial<RepoRecord> = {}): RepoRecord {
+  return {
+    id: 1,
+    fullName: "owner/repo",
+    name: "repo",
+    description: null,
+    topics: [],
+    language: "TypeScript",
+    htmlUrl: "https://github.com/owner/repo",
+    stars: 1,
+    forks: 1,
+    updatedAt: "2026-01-01T00:00:00Z",
+    readmeUrl: "https://github.com/owner/repo/blob/main/README.md",
+    readmeText: "known good bytes",
+    readmeEtag: '"etag-old"',
+    readmeLastModified: "Mon, 01 Jan 2026 00:00:00 GMT",
+    checksum: "checksum-old",
+    readmeRetryRequired: false,
+    lastSyncedAt: 1,
+    ...overrides,
+  };
+}
+
+function readme(
+  outcome: RepoReadmeRecord["outcome"],
+  overrides: Partial<RepoReadmeRecord> = {},
+): RepoReadmeRecord {
+  return {
+    repoId: 1,
+    outcome,
+    readmeUrl: null,
+    readmeText: null,
+    readmeEtag: null,
+    readmeLastModified: null,
+    checksum: null,
+    missingReadme: outcome === "not_found",
+    notModified: outcome === "not_modified",
+    ...overrides,
+  };
+}
+
+function remoteRepo(overrides: Partial<GitHubStarredRepo> = {}): GitHubStarredRepo {
+  return {
+    id: 1,
+    node_id: "R_1",
+    name: "repo",
+    full_name: "owner/repo",
+    private: false,
+    html_url: "https://github.com/owner/repo",
+    description: "updated description",
+    stargazers_count: 2,
+    forks_count: 3,
+    language: "TypeScript",
+    topics: ["search"],
+    updated_at: "2026-02-01T00:00:00Z",
+    owner: { login: "owner" },
+    ...overrides,
+  };
+}
+
+describe("README sync outcome integration", () => {
+  it("preserves every known README field and requests retry after a transient failure", () => {
+    const previous = repo();
+    const result = applyReadmeOutcome(
+      repo({ stars: 2, readmeText: null, checksum: null }),
+      readme("transient_failure"),
+      previous,
+    );
+
+    expect(result).toMatchObject({
+      stars: 2,
+      readmeUrl: previous.readmeUrl,
+      readmeText: previous.readmeText,
+      readmeEtag: previous.readmeEtag,
+      readmeLastModified: previous.readmeLastModified,
+      checksum: previous.checksum,
+      readmeRetryRequired: true,
+    });
+    expect(readmeOutcomeCanChangeChunks("transient_failure")).toBe(false);
+  });
+
+  it("preserves README bytes and clears retry state for not-modified responses", () => {
+    const previous = repo({ readmeRetryRequired: true });
+    const result = applyReadmeOutcome(
+      repo({ readmeText: null, checksum: null }),
+      readme("not_modified", { readmeEtag: '"etag-new"' }),
+      previous,
+    );
+
+    expect(result.readmeText).toBe("known good bytes");
+    expect(result.checksum).toBe("checksum-old");
+    expect(result.readmeEtag).toBe('"etag-new"');
+    expect(result.readmeRetryRequired).toBe(false);
+    expect(readmeOutcomeCanChangeChunks("not_modified")).toBe(false);
+  });
+
+  it("creates a stable known-empty README state for not-found responses", () => {
+    const result = applyReadmeOutcome(
+      repo(),
+      readme("not_found", { checksum: "checksum-empty" }),
+      repo({ readmeRetryRequired: true }),
+    );
+
+    expect(result).toMatchObject({
+      readmeUrl: null,
+      readmeText: null,
+      checksum: "checksum-empty",
+      readmeRetryRequired: false,
+    });
+    expect(readmeOutcomeCanChangeChunks("not_found")).toBe(true);
+  });
+
+  it("replaces README state after a successful fetch", () => {
+    const result = applyReadmeOutcome(
+      repo(),
+      readme("success", {
+        readmeUrl: "https://github.com/owner/repo/blob/main/README.md",
+        readmeText: "new bytes",
+        readmeEtag: '"etag-new"',
+        readmeLastModified: "Tue, 02 Jan 2026 00:00:00 GMT",
+        checksum: "checksum-new",
+      }),
+      repo({ readmeRetryRequired: true }),
+    );
+
+    expect(result).toMatchObject({
+      readmeText: "new bytes",
+      readmeEtag: '"etag-new"',
+      checksum: "checksum-new",
+      readmeRetryRequired: false,
+    });
+    expect(readmeOutcomeCanChangeChunks("success")).toBe(true);
+  });
+
+  it("maps GitHub metadata and persisted records into sync snapshots", () => {
+    const mapped = mapStarredRepoToRecord(remoteRepo({ topics: undefined }), 42);
+    expect(mapped).toMatchObject({
+      id: 1,
+      fullName: "owner/repo",
+      topics: [],
+      stars: 2,
+      forks: 3,
+      readmeRetryRequired: false,
+      lastSyncedAt: 42,
+    });
+
+    const syncState = toRepoSyncState(repo({ stars: 9, forks: 8, readmeRetryRequired: true }));
+    expect(syncState).toMatchObject({ stars: 9, forks: 8, readmeRetryRequired: true });
+    expect(toPreviousReadmeStateByRepoId([syncState]).get(1)).toEqual({
+      checksum: "checksum-old",
+      readmeUrl: "https://github.com/owner/repo/blob/main/README.md",
+      readmeText: "known good bytes",
+      readmeEtag: '"etag-old"',
+      readmeLastModified: "Mon, 01 Jan 2026 00:00:00 GMT",
+    });
+  });
+
+  it("upserts metadata but preserves chunks after a transient README failure", () => {
+    const transition = applyReadmeBatchTransition({
+      remoteRepo: remoteRepo(),
+      readme: readme("transient_failure"),
+      localRepo: repo(),
+      metadataChanged: true,
+      syncedAt: 42,
+    });
+
+    expect(transition.shouldUpsert).toBe(true);
+    expect(transition.shouldRechunk).toBe(false);
+    expect(transition.record).toMatchObject({
+      description: "updated description",
+      readmeText: "known good bytes",
+      checksum: "checksum-old",
+      readmeRetryRequired: true,
+    });
+    expect(transition.syncState).toEqual(toRepoSyncState(transition.record));
+  });
+
+  it("rechunks only successful checksum changes and skips unchanged records", () => {
+    const success = applyReadmeBatchTransition({
+      remoteRepo: remoteRepo(),
+      readme: readme("success", { readmeText: "new", checksum: "checksum-new" }),
+      localRepo: repo(),
+      metadataChanged: false,
+      syncedAt: 42,
+    });
+    const unchanged = applyReadmeBatchTransition({
+      remoteRepo: remoteRepo(),
+      readme: readme("not_modified"),
+      localRepo: repo(),
+      metadataChanged: false,
+      syncedAt: 42,
+    });
+    const initial = applyReadmeBatchTransition({
+      remoteRepo: remoteRepo(),
+      readme: readme("not_found", { checksum: "empty" }),
+      localRepo: undefined,
+      metadataChanged: true,
+      syncedAt: 42,
+    });
+
+    expect(success).toMatchObject({ shouldUpsert: true, shouldRechunk: true });
+    expect(unchanged).toMatchObject({ shouldUpsert: false, shouldRechunk: false });
+    expect(initial).toMatchObject({ shouldUpsert: true, shouldRechunk: true });
+  });
+
+  it("builds complete, embedding-pending, and retry-pending presentation states", () => {
+    const base = {
+      totalRepos: 20,
+      fetchedPages: 2,
+      candidateCount: 4,
+      changedCount: 2,
+      removedCount: 1,
+      records: [readme("success"), readme("not_modified")],
+      missingCount: 1,
+      failedCount: 0,
+      repoCount: 20,
+      chunkCount: 50,
+      embeddingCount: 49,
+      pendingEmbeddings: false,
+      pipelineV2: true,
+      readmeP95LatencyMs: 10.6,
+    };
+    const complete = buildSyncCompletion(base);
+    expect(complete.status).toMatchObject({
+      phase: "Sync complete",
+      primaryStage: "complete",
+      embeddingActive: false,
+      embeddingsCreated: 49,
+      chunkingCompleted: 4,
+    });
+    expect(complete.summary).toContain("READMEs fetched: 2");
+    expect(complete.summary).toContain("Pipeline: batch-v2 · README p95 11ms");
+
+    const embedding = buildSyncCompletion({ ...base, pendingEmbeddings: true, pipelineV2: false });
+    expect(embedding.status).toMatchObject({
+      phase: "Preparing embeddings for unindexed chunks",
+      primaryStage: "embedding-init",
+      embeddingActive: true,
+      embeddingsCreated: 0,
+    });
+    expect(embedding.summary).toContain("Pipeline: legacy");
+
+    const retry = buildSyncCompletion({ ...base, failedCount: 2 });
+    expect(retry.status).toMatchObject({
+      phase: "Sync incomplete: 2 README retries pending",
+      primaryStage: "failed",
+      chunkingCompleted: 2,
+      readmesFailed: 2,
+    });
+  });
+
+  it("builds the post-embedding incomplete result without claiming success", () => {
+    expect(
+      buildIncompleteSyncResult({
+        failedCount: 2,
+        candidateCount: 5,
+        repoCount: 10,
+        chunkCount: 30,
+        embeddingCount: 29,
+      }),
+    ).toEqual({
+      status: {
+        phase: "Sync incomplete: 2 README retries pending",
+        primaryStage: "failed",
+        readmeActive: false,
+        chunkingActive: false,
+        embeddingActive: false,
+        embeddingWindowed: false,
+        readmesFailed: 2,
+        chunkingCompleted: 3,
+      },
+      summary:
+        "Sync incomplete: 2 README retries pending; known local content was preserved. Local DB: 10 repos, 30 chunks, 29 embeddings.",
+    });
+  });
+});

--- a/src/pages/readmeSyncOutcome.test.ts
+++ b/src/pages/readmeSyncOutcome.test.ts
@@ -105,7 +105,7 @@ describe("README sync outcome integration", () => {
     expect(result.checksum).toBe("checksum-old");
     expect(result.readmeEtag).toBe('"etag-new"');
     expect(result.readmeRetryRequired).toBe(false);
-    expect(readmeOutcomeCanChangeChunks("not_modified")).toBe(false);
+    expect(readmeOutcomeCanChangeChunks("not_modified")).toBe(true);
   });
 
   it("creates a stable known-empty README state for not-found responses", () => {
@@ -189,7 +189,7 @@ describe("README sync outcome integration", () => {
     expect(transition.syncState).toEqual(toRepoSyncState(transition.record));
   });
 
-  it("rechunks only successful checksum changes and skips unchanged records", () => {
+  it("rechunks checksum-changing outcomes and skips an unchanged 304", () => {
     const success = applyReadmeBatchTransition({
       remoteRepo: remoteRepo(),
       readme: readme("success", { readmeText: "new", checksum: "checksum-new" }),
@@ -204,6 +204,13 @@ describe("README sync outcome integration", () => {
       metadataChanged: false,
       syncedAt: 42,
     });
+    const metadataChanged304 = applyReadmeBatchTransition({
+      remoteRepo: remoteRepo(),
+      readme: readme("not_modified", { checksum: "checksum-current-metadata" }),
+      localRepo: repo(),
+      metadataChanged: true,
+      syncedAt: 42,
+    });
     const initial = applyReadmeBatchTransition({
       remoteRepo: remoteRepo(),
       readme: readme("not_found", { checksum: "empty" }),
@@ -214,6 +221,11 @@ describe("README sync outcome integration", () => {
 
     expect(success).toMatchObject({ shouldUpsert: true, shouldRechunk: true });
     expect(unchanged).toMatchObject({ shouldUpsert: false, shouldRechunk: false });
+    expect(metadataChanged304).toMatchObject({
+      shouldUpsert: true,
+      shouldRechunk: true,
+      record: { readmeText: "known good bytes", checksum: "checksum-current-metadata" },
+    });
     expect(initial).toMatchObject({ shouldUpsert: true, shouldRechunk: true });
   });
 

--- a/src/pages/readmeSyncOutcome.ts
+++ b/src/pages/readmeSyncOutcome.ts
@@ -32,6 +32,7 @@ export function applyReadmeOutcome(
     return {
       ...record,
       ...preservedReadmeFields(previous, readme),
+      checksum: readme.checksum ?? previous?.checksum ?? null,
       readmeRetryRequired: false,
     };
   }
@@ -48,7 +49,7 @@ export function applyReadmeOutcome(
 }
 
 export function readmeOutcomeCanChangeChunks(outcome: RepoReadmeRecord["outcome"]): boolean {
-  return outcome === "success" || outcome === "not_found";
+  return outcome === "success" || outcome === "not_modified" || outcome === "not_found";
 }
 
 export function mapStarredRepoToRecord(repo: GitHubStarredRepo, syncedAt: number): RepoRecord {

--- a/src/pages/readmeSyncOutcome.ts
+++ b/src/pages/readmeSyncOutcome.ts
@@ -1,0 +1,255 @@
+import type { RepoRecord, RepoSyncState } from "../db/types";
+import type { GitHubStarredRepo, RepoReadmeRecord } from "../github/types";
+import type { IndexingStatus } from "../sync/status";
+
+function preservedReadmeFields(
+  previous: RepoRecord | undefined,
+  readme: RepoReadmeRecord,
+): Pick<RepoRecord, "readmeUrl" | "readmeText" | "readmeEtag" | "readmeLastModified" | "checksum"> {
+  return {
+    readmeUrl: previous?.readmeUrl ?? readme.readmeUrl,
+    readmeText: previous?.readmeText ?? readme.readmeText,
+    readmeEtag: readme.readmeEtag ?? previous?.readmeEtag ?? null,
+    readmeLastModified: readme.readmeLastModified ?? previous?.readmeLastModified ?? null,
+    checksum: previous?.checksum ?? readme.checksum,
+  };
+}
+
+export function applyReadmeOutcome(
+  record: RepoRecord,
+  readme: RepoReadmeRecord,
+  previous: RepoRecord | undefined,
+): RepoRecord {
+  if (readme.outcome === "transient_failure") {
+    return {
+      ...record,
+      ...preservedReadmeFields(previous, readme),
+      readmeRetryRequired: true,
+    };
+  }
+
+  if (readme.outcome === "not_modified") {
+    return {
+      ...record,
+      ...preservedReadmeFields(previous, readme),
+      readmeRetryRequired: false,
+    };
+  }
+
+  return {
+    ...record,
+    readmeUrl: readme.readmeUrl,
+    readmeText: readme.readmeText,
+    readmeEtag: readme.readmeEtag,
+    readmeLastModified: readme.readmeLastModified,
+    checksum: readme.checksum,
+    readmeRetryRequired: false,
+  };
+}
+
+export function readmeOutcomeCanChangeChunks(outcome: RepoReadmeRecord["outcome"]): boolean {
+  return outcome === "success" || outcome === "not_found";
+}
+
+export function mapStarredRepoToRecord(repo: GitHubStarredRepo, syncedAt: number): RepoRecord {
+  return {
+    id: repo.id,
+    fullName: repo.full_name,
+    name: repo.name,
+    description: repo.description,
+    topics: repo.topics ?? [],
+    language: repo.language,
+    htmlUrl: repo.html_url,
+    stars: repo.stargazers_count,
+    forks: repo.forks_count,
+    updatedAt: repo.updated_at,
+    readmeUrl: null,
+    readmeText: null,
+    readmeEtag: null,
+    readmeLastModified: null,
+    checksum: null,
+    readmeRetryRequired: false,
+    lastSyncedAt: syncedAt,
+  };
+}
+
+export function toRepoSyncState(record: RepoRecord): RepoSyncState {
+  return {
+    id: record.id,
+    fullName: record.fullName,
+    description: record.description,
+    topics: record.topics,
+    language: record.language,
+    updatedAt: record.updatedAt,
+    stars: record.stars,
+    forks: record.forks,
+    readmeUrl: record.readmeUrl,
+    readmeText: record.readmeText,
+    readmeEtag: record.readmeEtag,
+    readmeLastModified: record.readmeLastModified,
+    checksum: record.checksum,
+    readmeRetryRequired: record.readmeRetryRequired,
+  };
+}
+
+export function toPreviousReadmeStateByRepoId(states: RepoSyncState[]): Map<
+  number,
+  {
+    checksum: string | null;
+    readmeUrl: string | null;
+    readmeText: string | null;
+    readmeEtag: string | null;
+    readmeLastModified: string | null;
+  }
+> {
+  return new Map(
+    states.map((state) => [
+      state.id,
+      {
+        checksum: state.checksum,
+        readmeUrl: state.readmeUrl ?? null,
+        readmeText: state.readmeText ?? null,
+        readmeEtag: state.readmeEtag ?? null,
+        readmeLastModified: state.readmeLastModified ?? null,
+      },
+    ]),
+  );
+}
+
+export type ReadmeBatchTransition = {
+  record: RepoRecord;
+  syncState: RepoSyncState;
+  shouldUpsert: boolean;
+  shouldRechunk: boolean;
+};
+
+export function applyReadmeBatchTransition(input: {
+  remoteRepo: GitHubStarredRepo;
+  readme: RepoReadmeRecord;
+  localRepo: RepoRecord | undefined;
+  metadataChanged: boolean;
+  syncedAt: number;
+}): ReadmeBatchTransition {
+  const { remoteRepo, readme, localRepo, metadataChanged, syncedAt } = input;
+  const record = applyReadmeOutcome(
+    mapStarredRepoToRecord(remoteRepo, syncedAt),
+    readme,
+    localRepo,
+  );
+  const readmeStateChanged = localRepo
+    ? localRepo.readmeUrl !== record.readmeUrl ||
+      localRepo.readmeText !== record.readmeText ||
+      localRepo.readmeEtag !== record.readmeEtag ||
+      localRepo.readmeLastModified !== record.readmeLastModified ||
+      localRepo.checksum !== record.checksum ||
+      Boolean(localRepo.readmeRetryRequired) !== Boolean(record.readmeRetryRequired)
+    : true;
+
+  return {
+    record,
+    syncState: toRepoSyncState(record),
+    shouldUpsert: !localRepo || readmeStateChanged || metadataChanged,
+    shouldRechunk:
+      (!localRepo || localRepo.checksum !== record.checksum) &&
+      readmeOutcomeCanChangeChunks(readme.outcome),
+  };
+}
+
+type CompletionStatus = Pick<
+  IndexingStatus,
+  | "phase"
+  | "primaryStage"
+  | "readmeActive"
+  | "chunkingActive"
+  | "embeddingActive"
+  | "embeddingWindowed"
+  | "repoTotal"
+  | "readmesTarget"
+  | "readmesCompleted"
+  | "chunkingTarget"
+  | "chunkingCompleted"
+  | "readmesMissing"
+  | "readmesFailed"
+  | "chunkTotal"
+  | "embeddingsCreated"
+  | "embeddingTarget"
+>;
+
+export function buildSyncCompletion(input: {
+  totalRepos: number;
+  fetchedPages: number;
+  candidateCount: number;
+  changedCount: number;
+  removedCount: number;
+  records: RepoReadmeRecord[];
+  missingCount: number;
+  failedCount: number;
+  repoCount: number;
+  chunkCount: number;
+  embeddingCount: number;
+  pendingEmbeddings: boolean;
+  pipelineV2: boolean;
+  readmeP95LatencyMs: number;
+}): { status: CompletionStatus; summary: string } {
+  const hasReadmeRetries = input.failedCount > 0;
+  const readmeCount = input.records.filter(
+    (record) => record.outcome === "success" || record.outcome === "not_modified",
+  ).length;
+  const status: CompletionStatus = {
+    phase: input.pendingEmbeddings
+      ? "Preparing embeddings for unindexed chunks"
+      : hasReadmeRetries
+        ? `Sync incomplete: ${input.failedCount} README retries pending`
+        : "Sync complete",
+    primaryStage: input.pendingEmbeddings
+      ? "embedding-init"
+      : hasReadmeRetries
+        ? "failed"
+        : "complete",
+    readmeActive: false,
+    chunkingActive: false,
+    embeddingActive: input.pendingEmbeddings,
+    embeddingWindowed: false,
+    repoTotal: input.totalRepos,
+    readmesTarget: input.candidateCount,
+    readmesCompleted: input.candidateCount,
+    chunkingTarget: input.candidateCount,
+    chunkingCompleted: input.candidateCount - input.failedCount,
+    readmesMissing: input.missingCount,
+    readmesFailed: input.failedCount,
+    chunkTotal: input.chunkCount,
+    embeddingsCreated: input.pendingEmbeddings ? 0 : input.embeddingCount,
+    embeddingTarget: 0,
+  };
+  const summary =
+    `${hasReadmeRetries ? "Sync incomplete" : "Sync complete"}: ${input.totalRepos} stars scanned (${input.fetchedPages} pages), ` +
+    `${input.changedCount} changed/new, ${input.removedCount} removed. ` +
+    `READMEs fetched: ${readmeCount}, missing: ${input.missingCount}, failed: ${input.failedCount}. ` +
+    `Local DB: ${input.repoCount} repos, ${input.chunkCount} chunks, ${input.embeddingCount} embeddings. ` +
+    `Pipeline: ${input.pipelineV2 ? "batch-v2" : "legacy"} · README p95 ${Math.round(input.readmeP95LatencyMs)}ms.`;
+  return { status, summary };
+}
+
+export function buildIncompleteSyncResult(input: {
+  failedCount: number;
+  candidateCount: number;
+  repoCount: number;
+  chunkCount: number;
+  embeddingCount: number;
+}): { status: Partial<IndexingStatus>; summary: string } {
+  return {
+    status: {
+      phase: `Sync incomplete: ${input.failedCount} README retries pending`,
+      primaryStage: "failed",
+      readmeActive: false,
+      chunkingActive: false,
+      embeddingActive: false,
+      embeddingWindowed: false,
+      readmesFailed: input.failedCount,
+      chunkingCompleted: input.candidateCount - input.failedCount,
+    },
+    summary:
+      `Sync incomplete: ${input.failedCount} README retries pending; known local content was preserved. ` +
+      `Local DB: ${input.repoCount} repos, ${input.chunkCount} chunks, ${input.embeddingCount} embeddings.`,
+  };
+}

--- a/src/sync/plan.test.ts
+++ b/src/sync/plan.test.ts
@@ -10,6 +10,9 @@ function localRepo(overrides: Partial<RepoSyncState> = {}): RepoSyncState {
     topics: ["a", "b"],
     language: "TypeScript",
     updatedAt: "2026-01-01T00:00:00Z",
+    stars: 1,
+    forks: 1,
+    readmeRetryRequired: false,
     checksum: "hash-1",
     ...overrides,
   };
@@ -61,5 +64,27 @@ describe("sync planning", () => {
     });
 
     expect(repoMetadataChanged(local, remote)).toBe(false);
+  });
+
+  test("detects stars and forks changes without another metadata change", () => {
+    const local = localRepo({ stars: 1, forks: 1 });
+
+    expect(repoMetadataChanged(local, remoteRepo(1, { stargazers_count: 2 }))).toBe(true);
+    expect(repoMetadataChanged(local, remoteRepo(1, { forks_count: 2 }))).toBe(true);
+  });
+
+  test("retries an unchanged repository after a transient README failure", () => {
+    const plan = buildSyncPlan([localRepo({ readmeRetryRequired: true })], [remoteRepo(1)]);
+
+    expect(plan.candidateRepoIds).toEqual([1]);
+  });
+
+  test("does not repeatedly select a stable known-empty README", () => {
+    const plan = buildSyncPlan(
+      [localRepo({ checksum: "known-empty-checksum", readmeRetryRequired: false })],
+      [remoteRepo(1)],
+    );
+
+    expect(plan.candidateRepoIds).toEqual([]);
   });
 });

--- a/src/sync/plan.ts
+++ b/src/sync/plan.ts
@@ -23,6 +23,8 @@ export function repoMetadataChanged(local: RepoSyncState, remote: GitHubStarredR
     local.description !== remote.description ||
     local.language !== remote.language ||
     local.updatedAt !== remote.updated_at ||
+    (local.stars !== undefined && local.stars !== remote.stargazers_count) ||
+    (local.forks !== undefined && local.forks !== remote.forks_count) ||
     !equalTopics(local.topics, remote.topics ?? [])
   );
 }
@@ -32,13 +34,14 @@ export type SyncPlan = {
   candidateRepoIds: number[];
 };
 
-export function buildSyncPlan(localRepos: RepoSyncState[], remoteRepos: GitHubStarredRepo[]): SyncPlan {
+export function buildSyncPlan(
+  localRepos: RepoSyncState[],
+  remoteRepos: GitHubStarredRepo[],
+): SyncPlan {
   const localById = new Map(localRepos.map((repo) => [repo.id, repo]));
   const remoteIds = new Set(remoteRepos.map((repo) => repo.id));
 
-  const removedRepoIds = localRepos
-    .map((repo) => repo.id)
-    .filter((id) => !remoteIds.has(id));
+  const removedRepoIds = localRepos.map((repo) => repo.id).filter((id) => !remoteIds.has(id));
 
   const candidateRepoIds = remoteRepos
     .filter((repo) => {
@@ -48,6 +51,10 @@ export function buildSyncPlan(localRepos: RepoSyncState[], remoteRepos: GitHubSt
       }
 
       if (!local.checksum) {
+        return true;
+      }
+
+      if (local.readmeRetryRequired) {
         return true;
       }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(cleanup);


### PR DESCRIPTION
## Summary

Repairs the PR 3 integrity findings without broad architecture changes:

- Preserves known-good README content, validators, checksums, and chunks across transient GitHub failures, then retries unchanged repositories.
- Treats 404 as stable known-empty and 304 as preserved content while refreshing stars and forks.
- Honors server-directed rate-limit delays with abortable waits and bounded fallback backoff.
- Adds an additive retry-state migration and prevents failed database migration/open attempts from deleting persisted OPFS or local-storage bytes.
- Hydrates encrypted provider settings before saving, serializes writes, isolates account scopes, preserves WebLLM recommendation versus manual-selection semantics, and rejects unknown stored provider IDs.
- Single-flights the OAuth callback, bounds exchange lifetime to ten seconds, and supports direct retry with the same valid PKCE state.
- Surfaces provider-settings persistence failures in every authenticated provider-editing surface.

## Before and after proof

- Baseline README paths destructively replaced known-good state after transient failures and skipped later retries. Current regressions preserve bytes and chunk identity, select unchanged retry-required repositories, and distinguish 404, 304, transient failure, and success.
- Metadata-changing 304 responses now preserve README bytes while recomputing the canonical checksum and rechunking; unchanged 304 responses do not rechunk.
- Long Retry-After and rate-limit-reset waits are honored, abort promptly, release timers, and never issue a post-abort retry.
- Baseline database-open recovery could replace a migration-failing persisted snapshot with a fresh database. Current tests preserve byte-identical local-storage and OPFS snapshots, surface a controlled error, and prove a later healthy retry.
- Provider persistence runs 100 delayed AES-GCM saves with peak concurrency one and the newest value durable. Cross-account and clear/save races do not leak or resurrect credentials.
- StrictMode proves one complete OAuth callback/session establishment. Stalled fetch and stalled response-body tests prove bounded timeout, dedupe settlement, PKCE retention, and successful retry.

## Validation

- Node 24 full CI: format, zero-warning ESLint, typecheck, 14 component tests, 49 files and 272 tests, changed-line coverage 892/985 = 90.56%, production build, bundle budgets, and Chromium smoke/accessibility/visual checks 12/12.
- Node 22 compatibility: typecheck, 49 files and 272 tests, production build.
- Hosted head cf89a77: Node 22, Node 24, Chromium, CodeQL, Trivy, OSV, Greptile, and both Vercel previews pass.
- All eleven addressed review threads have evidence replies and are resolved; the style-only destructuring suggestion was intentionally declined as non-functional churn.
- Worktree is clean.

## Migration and rollback

Migration is additive: readme_retry_required INTEGER NOT NULL DEFAULT 0. It performs no reset or table recreation. A failed open or migration preserves original persisted bytes and evicts the rejected initialization promise so retry is possible without reload.

Rollback is the independent merge-commit revert. The added column is forward-compatible and can remain unused by the previous application. Rollback must not delete browser storage.

## Security and privacy

OAuth state expires after ten minutes. Exchange requests time out after ten seconds. Network, timeout, 429, and 5xx failures retain valid PKCE material for direct retry; mismatch, expiry, terminal rejection, success replay, and callback replay remain rejected. Provider settings remain scoped to the authenticated identity, and in-flight persistence is invalidated by clear or scope transition.

## UI and performance

No route, CSS, or public visual change. The intentional authenticated UI change is concise provider-settings loading/saving/saved/error status text in Settings, Recall, and legacy chat. The component uses aria-live and retains existing styling. Bundle budgets pass; no model/runtime dependency was added.