### PR TITLE
fix: harden provider and worker reliability

### DIFF
--- a/src/components/ProviderSettingsForm.test.tsx
+++ b/src/components/ProviderSettingsForm.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import type { LLMProviderDefinition } from "../llm/types";
+import { ProviderSettingsForm } from "./ProviderSettingsForm";
+
+const providerDefinitions: LLMProviderDefinition[] = [
+  {
+    id: "openai-compatible",
+    label: "Remote (OpenAI-compatible)",
+    kind: "remote",
+    defaultBaseUrl: "https://api.openai.com",
+    defaultModel: "gpt-4o-mini",
+    requiresApiKey: true,
+  },
+  {
+    id: "lmstudio",
+    label: "Local (LM Studio)",
+    kind: "local",
+    defaultBaseUrl: "http://localhost:1234",
+    defaultModel: "local-model",
+    requiresApiKey: false,
+  },
+];
+
+describe("ProviderSettingsForm provider consent copy", () => {
+  test("classifies OpenAI-compatible as remote and LM Studio as local", () => {
+    render(
+      <ProviderSettingsForm
+        providerId="lmstudio"
+        onProviderIdChange={vi.fn()}
+        providerDefinitions={providerDefinitions}
+        providerBaseUrl="http://localhost:1234"
+        onProviderBaseUrlChange={vi.fn()}
+        providerModel="local-model"
+        onProviderModelChange={vi.fn()}
+        providerApiKey=""
+        onProviderApiKeyChange={vi.fn()}
+        selectedProvider={providerDefinitions[1]}
+        allowRemoteProvider={false}
+        onAllowRemoteChange={vi.fn()}
+        allowLocalProvider={true}
+        onAllowLocalChange={vi.fn()}
+        webllmModels={[]}
+        ollamaModels={[]}
+        ollamaModelsStatus="idle"
+        ollamaModelsError={null}
+        onRefreshOllamaModels={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Allow OpenAI-compatible requests to remote endpoints.")).toBeVisible();
+    expect(
+      screen.getByText("Allow Ollama, LM Studio, and browser-local WebLLM runs."),
+    ).toBeVisible();
+    expect(screen.queryByText(/OpenAI-compatible and LM Studio/u)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ProviderSettingsForm.tsx
+++ b/src/components/ProviderSettingsForm.tsx
@@ -88,7 +88,10 @@ export function ProviderSettingsForm({
           <Label htmlFor="provider-select" className="text-muted-foreground">
             Provider
           </Label>
-          <Select value={providerId} onValueChange={(value) => onProviderIdChange(value as LLMProviderId)}>
+          <Select
+            value={providerId}
+            onValueChange={(value) => onProviderIdChange(value as LLMProviderId)}
+          >
             <SelectTrigger id="provider-select" className={inputClassName}>
               <SelectValue placeholder="Select provider" />
             </SelectTrigger>
@@ -248,7 +251,9 @@ export function ProviderSettingsForm({
           />
           <div className="min-w-0">
             <p className={`${textClassName} font-medium text-foreground`}>Remote providers</p>
-            <p className="text-xs text-muted-foreground">Allow OpenAI-compatible and LM Studio requests.</p>
+            <p className="text-xs text-muted-foreground">
+              Allow OpenAI-compatible requests to remote endpoints.
+            </p>
           </div>
         </label>
         <label className="flex cursor-pointer items-center gap-3 rounded-md border border-border/60 bg-background/50 px-3 py-3">
@@ -258,7 +263,9 @@ export function ProviderSettingsForm({
           />
           <div className="min-w-0">
             <p className={`${textClassName} font-medium text-foreground`}>Local providers</p>
-            <p className="text-xs text-muted-foreground">Allow Ollama and browser-local WebLLM runs.</p>
+            <p className="text-xs text-muted-foreground">
+              Allow Ollama, LM Studio, and browser-local WebLLM runs.
+            </p>
           </div>
         </label>
       </div>

--- a/src/embeddings/Embedder.test.ts
+++ b/src/embeddings/Embedder.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { Embedder } from "./Embedder";
 
 type WorkerResponse = {
   id: string;
   status: "complete" | "error";
-  embeddings?: Array<Float32Array | null>;
+  embeddings?: unknown[];
   errors?: Array<string | null>;
   error?: string;
   selectedBackend?: "webgpu" | "wasm";
@@ -14,6 +14,8 @@ type WorkerResponse = {
 
 class FakeWorker {
   onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => unknown) | null = null;
+  onmessageerror: ((event: MessageEvent) => void) | null = null;
   private readonly responder: (payload: unknown) => WorkerResponse;
 
   constructor(responder: (payload: unknown) => WorkerResponse) {
@@ -32,7 +34,43 @@ class FakeWorker {
   }
 }
 
+class ManualWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: ErrorEvent) => unknown) | null = null;
+  onmessageerror: ((event: MessageEvent) => void) | null = null;
+  readonly posted: unknown[] = [];
+  terminateCalls = 0;
+
+  postMessage(payload: unknown): void {
+    this.posted.push(payload);
+  }
+
+  respond(payload: unknown): void {
+    this.onmessage?.({ data: payload } as MessageEvent);
+  }
+
+  crash(message: string): void {
+    this.onerror?.({ message, error: new Error(message) } as ErrorEvent);
+  }
+
+  failMessage(): void {
+    this.onmessageerror?.({ data: null } as MessageEvent);
+  }
+
+  terminate(): void {
+    this.terminateCalls += 1;
+  }
+}
+
 describe("Embedder batch API", () => {
+  test("returns an empty batch without posting to the worker", async () => {
+    const worker = new ManualWorker();
+    const embedder = new Embedder({ workerFactory: () => worker });
+
+    await expect(embedder.embedBatch([])).resolves.toEqual([]);
+    expect(worker.posted).toHaveLength(0);
+  });
+
   test("embedBatch preserves input ordering", async () => {
     const embedder = new Embedder(
       () =>
@@ -41,7 +79,9 @@ describe("Embedder batch API", () => {
           return {
             id: request.id,
             status: "complete",
-            embeddings: request.texts.map((text, index) => Float32Array.from([index + 1, text.length])),
+            embeddings: request.texts.map((text, index) =>
+              Float32Array.from([index + 1, text.length]),
+            ),
             errors: request.texts.map(() => null),
           };
         }),
@@ -76,6 +116,26 @@ describe("Embedder batch API", () => {
     expect(result[2]?.error).toBeNull();
   });
 
+  test("normalizes plain array vectors and preserves invalid per-item results", async () => {
+    const embedder = new Embedder(
+      () =>
+        new FakeWorker((payload) => {
+          const request = payload as { id: string };
+          return {
+            id: request.id,
+            status: "complete",
+            embeddings: [[1, 2], {}],
+            errors: [null, "invalid vector"],
+          };
+        }),
+    );
+
+    const results = await embedder.embedBatch(["array", "invalid"]);
+
+    expect(results[0]?.embedding).toEqual(Float32Array.from([1, 2]));
+    expect(results[1]).toEqual({ embedding: null, error: "invalid vector" });
+  });
+
   test("embed throws when single-item batch reports an error", async () => {
     const embedder = new Embedder(
       () =>
@@ -91,6 +151,23 @@ describe("Embedder batch API", () => {
     );
 
     await expect(embedder.embed("bad-item")).rejects.toThrow("failed: bad-item");
+  });
+
+  test("embed resolves the vector returned by a successful single-item batch", async () => {
+    const embedder = new Embedder(
+      () =>
+        new FakeWorker((payload) => {
+          const request = payload as { id: string };
+          return {
+            id: request.id,
+            status: "complete",
+            embeddings: [Float32Array.from([0.25, 0.75])],
+            errors: [null],
+          };
+        }),
+    );
+
+    await expect(embedder.embed("valid")).resolves.toEqual(Float32Array.from([0.25, 0.75]));
   });
 
   test("passes preferred backend and captures runtime fallback diagnostics", async () => {
@@ -134,5 +211,207 @@ describe("Embedder batch API", () => {
       selectedModel: "Xenova/all-MiniLM-L6-v2",
       fallbackReason: "navigator.gpu unavailable",
     });
+  });
+
+  test("rejects every pending job with a typed error when the worker crashes", async () => {
+    const worker = new ManualWorker();
+    const embedder = new Embedder({ workerFactory: () => worker });
+    const first = embedder.embedBatch(["first"]);
+    const second = embedder.embedBatch(["second"]);
+    const firstRejection = expect(first).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "worker_error",
+      message: "worker crashed",
+    });
+    const secondRejection = expect(second).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "worker_error",
+    });
+
+    worker.crash("worker crashed");
+
+    await Promise.all([firstRejection, secondRejection]);
+    expect(worker.terminateCalls).toBe(1);
+  });
+
+  test("rejects pending work when a worker message cannot be decoded", async () => {
+    const worker = new ManualWorker();
+    const embedder = new Embedder({ workerFactory: () => worker });
+    const pending = embedder.embedBatch(["message"]);
+    const rejection = expect(pending).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "message_error",
+    });
+
+    worker.failMessage();
+
+    await rejection;
+    expect(worker.terminateCalls).toBe(1);
+  });
+
+  test("rejects a worker error response and records its runtime diagnostics", async () => {
+    const worker = new ManualWorker();
+    const embedder = new Embedder({ workerFactory: () => worker, preferredBackend: "webgpu" });
+    const pending = embedder.embedBatch(["error"]);
+    const request = worker.posted[0] as { id: string };
+    const rejection = expect(pending).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "worker_response_error",
+      message: "model initialization failed",
+    });
+
+    worker.respond({
+      id: request.id,
+      status: "error",
+      error: "model initialization failed",
+      selectedBackend: "wasm",
+      selectedModel: " fallback-model ",
+      fallbackReason: "webgpu unavailable",
+    });
+
+    await rejection;
+    expect(embedder.getRuntimeInfo()).toEqual({
+      preferredBackend: "webgpu",
+      selectedBackend: "wasm",
+      selectedModel: "fallback-model",
+      fallbackReason: "webgpu unavailable",
+    });
+  });
+
+  test("uses a bounded default message for an empty worker error response", async () => {
+    const worker = new ManualWorker();
+    const embedder = new Embedder({ workerFactory: () => worker });
+    const pending = embedder.embedBatch(["error"]);
+    const request = worker.posted[0] as { id: string };
+    const rejection = expect(pending).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "worker_response_error",
+      message: "Embedding worker failed",
+    });
+
+    worker.respond({ id: request.id, status: "error" });
+
+    await rejection;
+  });
+
+  test("rejects malformed response envelopes instead of leaving jobs pending", async () => {
+    const malformedResponses: Array<(id: string) => unknown> = [
+      () => null,
+      () => ({ status: "complete", embeddings: [], errors: [] }),
+      (id) => ({ id, status: "partial", embeddings: [], errors: [] }),
+      (id) => ({ id, status: "complete" }),
+    ];
+
+    for (const buildResponse of malformedResponses) {
+      const worker = new ManualWorker();
+      const embedder = new Embedder({ workerFactory: () => worker });
+      const pending = embedder.embedBatch(["malformed"]);
+      const request = worker.posted[0] as { id: string };
+      const rejection = expect(pending).rejects.toMatchObject({
+        name: "EmbeddingWorkerError",
+        code: "malformed_response",
+      });
+
+      worker.respond(buildResponse(request.id));
+
+      await rejection;
+      expect(worker.terminateCalls).toBe(1);
+    }
+  });
+
+  test("times out a stalled request and ignores its late response", async () => {
+    vi.useFakeTimers();
+    try {
+      const worker = new ManualWorker();
+      const embedder = new Embedder({ workerFactory: () => worker, requestTimeoutMs: 1_000 });
+      const pending = embedder.embedBatch(["slow"]);
+      const request = worker.posted[0] as { id: string };
+      const rejection = expect(pending).rejects.toMatchObject({
+        name: "EmbeddingWorkerError",
+        code: "request_timeout",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await rejection;
+      worker.respond({
+        id: request.id,
+        status: "complete",
+        embeddings: [Float32Array.from([1])],
+        errors: [null],
+      });
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects synchronous postMessage failures and clears the request timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const worker = new ManualWorker();
+      const postFailure = new Error("structured clone failed");
+      worker.postMessage = () => {
+        throw postFailure;
+      };
+      const embedder = new Embedder({ workerFactory: () => worker, requestTimeoutMs: 1_000 });
+
+      await expect(embedder.embedBatch(["uncloneable"])).rejects.toMatchObject({
+        name: "EmbeddingWorkerError",
+        code: "post_message_failed",
+        cause: postFailure,
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("termination rejects all jobs, is idempotent, and prevents future posts", async () => {
+    const worker = new ManualWorker();
+    const embedder = new Embedder({ workerFactory: () => worker });
+    const first = embedder.embedBatch(["first"]);
+    const second = embedder.embedBatch(["second"]);
+    const firstRejection = expect(first).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "terminated",
+    });
+    const secondRejection = expect(second).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "terminated",
+    });
+
+    embedder.terminate();
+    embedder.terminate();
+
+    await Promise.all([firstRejection, secondRejection]);
+    await expect(embedder.embedBatch(["after termination"])).rejects.toMatchObject({
+      name: "EmbeddingWorkerError",
+      code: "terminated",
+    });
+    expect(worker.posted).toHaveLength(2);
+    expect(worker.terminateCalls).toBe(1);
+  });
+
+  test("clears the request timeout after a successful response", async () => {
+    vi.useFakeTimers();
+    try {
+      const worker = new ManualWorker();
+      const embedder = new Embedder({ workerFactory: () => worker, requestTimeoutMs: 1_000 });
+      const pending = embedder.embedBatch(["complete"]);
+      const request = worker.posted[0] as { id: string };
+
+      worker.respond({
+        id: request.id,
+        status: "complete",
+        embeddings: [Float32Array.from([1])],
+        errors: [null],
+      });
+
+      await expect(pending).resolves.toHaveLength(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/embeddings/Embedder.test.ts
+++ b/src/embeddings/Embedder.test.ts
@@ -319,7 +319,7 @@ describe("Embedder batch API", () => {
     }
   });
 
-  test("times out a stalled request and ignores its late response", async () => {
+  test("times out a stalled request, ignores its late response, and keeps the worker alive", async () => {
     vi.useFakeTimers();
     try {
       const worker = new ManualWorker();
@@ -341,6 +341,22 @@ describe("Embedder batch API", () => {
       });
 
       expect(vi.getTimerCount()).toBe(0);
+
+      // A timeout must not tear down the worker: it was never terminated and it
+      // still serves a subsequent request on the same live worker.
+      expect(worker.terminateCalls).toBe(0);
+      const followUp = embedder.embedBatch(["fresh"]);
+      const followUpRequest = worker.posted[1] as { id: string };
+      expect(followUpRequest.id).not.toBe(request.id);
+      worker.respond({
+        id: followUpRequest.id,
+        status: "complete",
+        embeddings: [Float32Array.from([2])],
+        errors: [null],
+      });
+
+      await expect(followUp).resolves.toEqual([{ embedding: Float32Array.from([2]), error: null }]);
+      expect(worker.terminateCalls).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/embeddings/Embedder.ts
+++ b/src/embeddings/Embedder.ts
@@ -1,4 +1,3 @@
-
 import Worker from "./worker?worker";
 
 export type BatchEmbeddingResultItem = {
@@ -19,10 +18,13 @@ export type EmbeddingRuntimeInfo = {
 type PendingJob = {
   resolve: (result: BatchEmbeddingResultItem[]) => void;
   reject: (error: Error) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
 };
 
 type EmbedderWorker = {
   onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: ErrorEvent) => unknown) | null;
+  onmessageerror: ((event: MessageEvent) => void) | null;
   postMessage: (message: unknown) => void;
   terminate: () => void;
 };
@@ -31,7 +33,42 @@ type EmbedderOptions = {
   workerFactory?: () => EmbedderWorker;
   preferredBackend?: EmbeddingBackendPreference;
   modelCandidates?: BrowserEmbeddingModelCandidates;
+  requestTimeoutMs?: number;
 };
+
+export type EmbeddingWorkerErrorCode =
+  | "worker_error"
+  | "worker_response_error"
+  | "message_error"
+  | "malformed_response"
+  | "request_timeout"
+  | "terminated"
+  | "post_message_failed";
+
+export class EmbeddingWorkerError extends Error {
+  constructor(
+    public readonly code: EmbeddingWorkerErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "EmbeddingWorkerError";
+  }
+}
+
+export function isFatalEmbeddingWorkerError(error: unknown): error is EmbeddingWorkerError {
+  return (
+    error instanceof EmbeddingWorkerError &&
+    (error.code === "worker_error" ||
+      error.code === "message_error" ||
+      error.code === "malformed_response" ||
+      error.code === "terminated")
+  );
+}
+
+// A first request may include model download and initialization, so the shared
+// bound is deliberately longer than an ordinary already-warm worker request.
+const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
 
 function coerceFloat32Array(value: unknown): Float32Array | null {
   if (value == null) {
@@ -57,6 +94,8 @@ export class Embedder {
   private selectedBackend: EmbeddingBackendPreference | null = null;
   private selectedModel: string | null = null;
   private fallbackReason: string | null = null;
+  private readonly requestTimeoutMs: number;
+  private terminated = false;
 
   constructor(optionsOrWorkerFactory?: EmbedderOptions | (() => EmbedderWorker)) {
     const options: EmbedderOptions =
@@ -65,51 +104,138 @@ export class Embedder {
         : (optionsOrWorkerFactory ?? {});
     this.preferredBackend = options.preferredBackend ?? "webgpu";
     this.modelCandidates = options.modelCandidates ?? [];
+    this.requestTimeoutMs =
+      Number.isFinite(options.requestTimeoutMs) && Number(options.requestTimeoutMs) > 0
+        ? Math.trunc(Number(options.requestTimeoutMs))
+        : DEFAULT_REQUEST_TIMEOUT_MS;
     this.worker = options.workerFactory
       ? options.workerFactory()
       : (new Worker() as unknown as EmbedderWorker);
-    this.worker.onmessage = (event) => {
-      const { id, status, embeddings, errors, error, selectedBackend, selectedModel, fallbackReason } = event.data as {
-        id: string;
-        status: "complete" | "error";
-        embeddings?: unknown[];
-        errors?: unknown[];
-        error?: string;
-        selectedBackend?: EmbeddingBackendPreference;
-        selectedModel?: string | null;
-        fallbackReason?: string | null;
-      };
-      if (selectedBackend === "webgpu" || selectedBackend === "wasm") {
-        this.selectedBackend = selectedBackend;
-      }
-      this.selectedModel =
-        typeof selectedModel === "string" && selectedModel.trim().length > 0
-          ? selectedModel.trim()
-          : null;
-      this.fallbackReason = fallbackReason == null ? null : String(fallbackReason);
-      const job = this.pending.get(id);
-
-      if (job) {
-        this.pending.delete(id);
-        if (status === "complete") {
-          const normalizedEmbeddings = Array.isArray(embeddings) ? embeddings : [];
-          const normalizedErrors = Array.isArray(errors) ? errors : [];
-          const resultLength = Math.max(normalizedEmbeddings.length, normalizedErrors.length);
-          const results: BatchEmbeddingResultItem[] = [];
-          for (let i = 0; i < resultLength; i += 1) {
-            const embedding = coerceFloat32Array(normalizedEmbeddings[i]);
-            const itemError = normalizedErrors[i] == null ? null : String(normalizedErrors[i]);
-            results.push({
-              embedding,
-              error: itemError,
-            });
-          }
-          job.resolve(results);
-        } else {
-          job.reject(new Error(error ?? "Embedding worker failed"));
-        }
-      }
+    this.worker.onmessage = (event) => this.handleMessage(event);
+    this.worker.onerror = (event) => {
+      this.failWorker(
+        new EmbeddingWorkerError(
+          "worker_error",
+          event.message || "Embedding worker crashed",
+          event.error === undefined ? undefined : { cause: event.error },
+        ),
+      );
     };
+    this.worker.onmessageerror = () => {
+      this.failWorker(
+        new EmbeddingWorkerError("message_error", "Embedding worker message could not be decoded"),
+      );
+    };
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    const data = event.data;
+    if (data == null || typeof data !== "object") {
+      this.failWorker(
+        new EmbeddingWorkerError(
+          "malformed_response",
+          "Embedding worker returned a malformed response",
+        ),
+      );
+      return;
+    }
+
+    const {
+      id,
+      status,
+      embeddings,
+      errors,
+      error,
+      selectedBackend,
+      selectedModel,
+      fallbackReason,
+    } = data as Record<string, unknown>;
+    if (
+      typeof id !== "string" ||
+      id.length === 0 ||
+      (status !== "complete" && status !== "error")
+    ) {
+      this.failWorker(
+        new EmbeddingWorkerError(
+          "malformed_response",
+          "Embedding worker returned a malformed response",
+        ),
+      );
+      return;
+    }
+
+    const job = this.pending.get(id);
+    if (!job) {
+      // A timed-out request may still produce a late response. It must not
+      // affect a newer request using the same worker.
+      return;
+    }
+
+    if (status === "complete" && (!Array.isArray(embeddings) || !Array.isArray(errors))) {
+      this.failWorker(
+        new EmbeddingWorkerError(
+          "malformed_response",
+          "Embedding worker returned a malformed response",
+        ),
+      );
+      return;
+    }
+
+    clearTimeout(job.timeoutId);
+    this.pending.delete(id);
+    if (selectedBackend === "webgpu" || selectedBackend === "wasm") {
+      this.selectedBackend = selectedBackend;
+    }
+    this.selectedModel =
+      typeof selectedModel === "string" && selectedModel.trim().length > 0
+        ? selectedModel.trim()
+        : null;
+    this.fallbackReason = fallbackReason == null ? null : String(fallbackReason);
+
+    if (status === "complete") {
+      const normalizedEmbeddings = embeddings as unknown[];
+      const normalizedErrors = errors as unknown[];
+      const resultLength = Math.max(normalizedEmbeddings.length, normalizedErrors.length);
+      const results: BatchEmbeddingResultItem[] = [];
+      for (let i = 0; i < resultLength; i += 1) {
+        const embedding = coerceFloat32Array(normalizedEmbeddings[i]);
+        const itemError = normalizedErrors[i] == null ? null : String(normalizedErrors[i]);
+        results.push({
+          embedding,
+          error: itemError,
+        });
+      }
+      job.resolve(results);
+      return;
+    }
+
+    job.reject(
+      new EmbeddingWorkerError(
+        "worker_response_error",
+        typeof error === "string" && error.length > 0 ? error : "Embedding worker failed",
+      ),
+    );
+  }
+
+  private rejectPending(error: EmbeddingWorkerError): void {
+    const jobs = [...this.pending.values()];
+    this.pending.clear();
+    for (const job of jobs) {
+      clearTimeout(job.timeoutId);
+      job.reject(error);
+    }
+  }
+
+  private failWorker(error: EmbeddingWorkerError): void {
+    if (this.terminated) {
+      return;
+    }
+    this.terminated = true;
+    this.rejectPending(error);
+    this.worker.onmessage = null;
+    this.worker.onerror = null;
+    this.worker.onmessageerror = null;
+    this.worker.terminate();
   }
 
   async embedBatch(texts: string[]): Promise<BatchEmbeddingResultItem[]> {
@@ -117,15 +243,44 @@ export class Embedder {
       return [];
     }
 
+    if (this.terminated) {
+      throw new EmbeddingWorkerError("terminated", "Embedding worker has been terminated");
+    }
+
     const id = crypto.randomUUID();
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.worker.postMessage({
-        id,
-        texts,
-        preferredBackend: this.preferredBackend,
-        modelCandidates: this.modelCandidates,
-      });
+      const timeoutId = setTimeout(() => {
+        if (!this.pending.delete(id)) {
+          return;
+        }
+        reject(
+          new EmbeddingWorkerError(
+            "request_timeout",
+            `Embedding worker request timed out after ${this.requestTimeoutMs}ms`,
+          ),
+        );
+      }, this.requestTimeoutMs);
+      this.pending.set(id, { resolve, reject, timeoutId });
+      try {
+        this.worker.postMessage({
+          id,
+          texts,
+          preferredBackend: this.preferredBackend,
+          modelCandidates: this.modelCandidates,
+        });
+      } catch (error) {
+        clearTimeout(timeoutId);
+        this.pending.delete(id);
+        reject(
+          new EmbeddingWorkerError(
+            "post_message_failed",
+            "Embedding worker request could not be sent",
+            {
+              cause: error,
+            },
+          ),
+        );
+      }
     });
   }
 
@@ -139,8 +294,8 @@ export class Embedder {
     return first.embedding;
   }
 
-  terminate() {
-    this.worker.terminate();
+  terminate(): void {
+    this.failWorker(new EmbeddingWorkerError("terminated", "Embedding worker was terminated"));
   }
 
   getRuntimeInfo(): EmbeddingRuntimeInfo {

--- a/src/embeddings/WorkerPool.test.ts
+++ b/src/embeddings/WorkerPool.test.ts
@@ -220,6 +220,10 @@ describe("EmbeddingWorkerPool", () => {
   test("removes the exact crashed embedder and retains the healthy worker during downshift", async () => {
     const callCounts = [0, 0, 0];
     const terminationCounts = [0, 0, 0];
+    // Raw invocations are counted before the worker's own idempotency guard so
+    // the pool's retirement call is observable independently of the worker
+    // self-terminating on crash.
+    const terminateInvocations = [0, 0, 0];
     const terminated = [false, false, false];
     let nextWorkerId = 0;
     const pool = new EmbeddingWorkerPool({
@@ -230,6 +234,7 @@ describe("EmbeddingWorkerPool", () => {
         const workerId = nextWorkerId;
         nextWorkerId += 1;
         const terminate = () => {
+          terminateInvocations[workerId] += 1;
           if (terminated[workerId]) {
             return;
           }
@@ -272,6 +277,10 @@ describe("EmbeddingWorkerPool", () => {
     );
     expect(pool.getStatus().activePoolSize).toBe(1);
     expect(terminationCounts).toEqual([1, 0, 0]);
+    // The pool retired the crashed worker itself: terminate() was invoked a
+    // second time on worker 0 during retirement, over and above its self-crash
+    // termination, while the healthy worker was never touched.
+    expect(terminateInvocations).toEqual([2, 0, 0]);
 
     const downshiftedResult = await pool.embedBatch(["still healthy"]);
     expect(downshiftedResult[0]?.embedding).toEqual(Float32Array.from([1]));

--- a/src/embeddings/WorkerPool.test.ts
+++ b/src/embeddings/WorkerPool.test.ts
@@ -284,6 +284,95 @@ describe("EmbeddingWorkerPool", () => {
     expect(terminationCounts).toEqual([1, 0, 0]);
   });
 
+  test("drains queued jobs with a replacement when the sole downshifted worker fatally exits", async () => {
+    const callCounts = [0, 0];
+    const terminationCounts = [0, 0];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: async (texts: string[]) => {
+            callCounts[workerId] += 1;
+            if (workerId === 0) {
+              throw new EmbeddingWorkerError("worker_error", "sole worker crashed");
+            }
+            return texts.map(() => ({ embedding: Float32Array.from([workerId]), error: null }));
+          },
+          terminate: () => {
+            terminationCounts[workerId] += 1;
+          },
+        };
+      },
+    });
+
+    // Downshift to a single worker before the batch runs.
+    pool.setConcurrency(1);
+    expect(pool.getStatus().activePoolSize).toBe(1);
+
+    const results = await pool.embedBatch(["crash", "queued-1", "queued-2"]);
+
+    // The affected job keeps its typed failure...
+    expect(results[0]).toEqual({ embedding: null, error: "sole worker crashed" });
+    // ...and later queued jobs are drained by a healthy replacement instead of
+    // being left as "embedding job was not executed".
+    expect(results.slice(1).map((item) => Array.from(item.embedding ?? []))).toEqual([[1], [1]]);
+    expect(results.some((item) => item.error === "embedding job was not executed")).toBe(false);
+    // The crashed worker is retired and the healthy replacement survives.
+    expect(nextWorkerId).toBe(2);
+    expect(terminationCounts).toEqual([1, 0]);
+    expect(pool.getStatus().activePoolSize).toBe(1);
+  });
+
+  test("drains the queue across repeated fatal replacements without leaving unexecuted jobs", async () => {
+    const callCounts = [0, 0, 0];
+    const terminationCounts = [0, 0, 0];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: async (texts: string[]) => {
+            callCounts[workerId] += 1;
+            // The original sole worker and its first replacement both crash
+            // fatally; only the second replacement is healthy.
+            if (workerId <= 1) {
+              throw new EmbeddingWorkerError("worker_error", `worker ${workerId} crashed`);
+            }
+            return texts.map(() => ({ embedding: Float32Array.from([workerId]), error: null }));
+          },
+          terminate: () => {
+            terminationCounts[workerId] += 1;
+          },
+        };
+      },
+    });
+
+    // A single live runner so every fatal exit forces an in-line replacement.
+    pool.setConcurrency(1);
+    expect(pool.getStatus().activePoolSize).toBe(1);
+
+    const results = await pool.embedBatch(["crash-0", "crash-1", "healthy"]);
+
+    // Each crashed job keeps its typed failure...
+    expect(results[0]).toEqual({ embedding: null, error: "worker 0 crashed" });
+    expect(results[1]).toEqual({ embedding: null, error: "worker 1 crashed" });
+    // ...and the trailing job is still drained by the healthy replacement, never
+    // left as an unexecuted sentinel (which would also indicate a hang).
+    expect(results[2]?.embedding).toEqual(Float32Array.from([2]));
+    expect(results.some((item) => item.error === "embedding job was not executed")).toBe(false);
+    // Two replacements were created; both crashed embedders are retired.
+    expect(nextWorkerId).toBe(3);
+    expect(terminationCounts).toEqual([1, 1, 0]);
+    expect(pool.getStatus().activePoolSize).toBe(1);
+  });
+
   test("turns a batch-length mismatch into item errors and threshold downshifts", async () => {
     const terminationCounts = [0, 0];
     let nextWorkerId = 0;

--- a/src/embeddings/WorkerPool.test.ts
+++ b/src/embeddings/WorkerPool.test.ts
@@ -1,12 +1,41 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import { EmbeddingWorkerError } from "./Embedder";
 import { EmbeddingWorkerPool } from "./WorkerPool";
 
 type FakeEmbedder = {
-  embedBatch: (texts: string[]) => Promise<Array<{ embedding: Float32Array | null; error: string | null }>>;
+  embedBatch: (
+    texts: string[],
+  ) => Promise<Array<{ embedding: Float32Array | null; error: string | null }>>;
   terminate: () => void;
 };
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("EmbeddingWorkerPool", () => {
+  test("returns an empty batch without creating a worker", async () => {
+    const createEmbedder = vi.fn();
+    const pool = new EmbeddingWorkerPool({ createEmbedder });
+
+    await expect(pool.embedBatch([])).resolves.toEqual([]);
+    expect(createEmbedder).not.toHaveBeenCalled();
+  });
+
+  test("rejects a batch that exceeds the configured queue bound", async () => {
+    const createEmbedder = vi.fn();
+    const pool = new EmbeddingWorkerPool({ maxQueueSize: 1, createEmbedder });
+
+    await expect(pool.embedBatch(["first", "second"])).rejects.toThrow(
+      "embedding queue overflow: 2 > 1",
+    );
+    expect(createEmbedder).not.toHaveBeenCalled();
+  });
+
   test("reduces worker calls by micro-batching texts", async () => {
     let callCount = 0;
     const pool = new EmbeddingWorkerPool({
@@ -110,5 +139,300 @@ describe("EmbeddingWorkerPool", () => {
     await pool.embedBatch(["next-1", "next-2", "next-3"]);
     const worker1CallsAfter = callCounts[1] ?? 0;
     expect(worker1CallsAfter).toBe(worker1CallsBefore);
+
+    pool.setConcurrency(2);
+    expect(pool.getStatus()).toMatchObject({
+      activePoolSize: 2,
+      downshifted: false,
+      downshiftReason: null,
+    });
+    await pool.embedBatch(["restored-1", "restored-2"]);
+    expect(pool.getStatus()).toMatchObject({ activePoolSize: 2, downshifted: false });
+  });
+
+  test("setConcurrency retires surplus idle embedders", async () => {
+    const terminationCounts = [0, 0];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: async (texts) =>
+            texts.map((text) => ({ embedding: Float32Array.from([text.length]), error: null })),
+          terminate: () => {
+            terminationCounts[workerId] += 1;
+          },
+        };
+      },
+    });
+
+    await pool.embedBatch(["first", "second"]);
+    expect(nextWorkerId).toBe(2);
+
+    pool.setConcurrency(1);
+
+    expect(pool.getStatus().activePoolSize).toBe(1);
+    expect(terminationCounts).toEqual([0, 1]);
+    await pool.embedBatch(["third"]);
+    expect(nextWorkerId).toBe(2);
+    expect(terminationCounts).toEqual([0, 1]);
+    expect(pool.getStatus().activePoolSize).toBe(1);
+  });
+
+  test("defers retirement until active jobs finish without losing their results", async () => {
+    const operations = [
+      deferred<Array<{ embedding: Float32Array | null; error: string | null }>>(),
+      deferred<Array<{ embedding: Float32Array | null; error: string | null }>>(),
+    ];
+    const terminationCounts = [0, 0];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: () => operations[workerId].promise,
+          terminate: () => {
+            terminationCounts[workerId] += 1;
+          },
+        };
+      },
+    });
+
+    const pending = pool.embedBatch(["first", "second"]);
+    pool.setConcurrency(1);
+    expect(terminationCounts).toEqual([0, 0]);
+
+    operations[0].resolve([{ embedding: Float32Array.from([1]), error: null }]);
+    operations[1].resolve([{ embedding: Float32Array.from([2]), error: null }]);
+    const results = await pending;
+
+    expect(results.map((item) => Array.from(item.embedding ?? []))).toEqual([[1], [2]]);
+    expect(terminationCounts).toEqual([0, 1]);
+    expect(pool.getStatus().activePoolSize).toBe(1);
+  });
+
+  test("removes the exact crashed embedder and retains the healthy worker during downshift", async () => {
+    const callCounts = [0, 0, 0];
+    const terminationCounts = [0, 0, 0];
+    const terminated = [false, false, false];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      downshiftErrorThreshold: 1,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        const terminate = () => {
+          if (terminated[workerId]) {
+            return;
+          }
+          terminated[workerId] = true;
+          terminationCounts[workerId] += 1;
+        };
+        return {
+          embedBatch: async (texts: string[]) => {
+            callCounts[workerId] += 1;
+            if (workerId === 0) {
+              terminate();
+              throw new EmbeddingWorkerError("worker_error", "worker zero crashed");
+            }
+            return texts.map(() => ({
+              embedding: Float32Array.from([workerId]),
+              error: null,
+            }));
+          },
+          terminate,
+        };
+      },
+    });
+
+    const firstResults = await pool.embedBatch([
+      "crash",
+      "healthy-1",
+      "healthy-2",
+      "healthy-3",
+      "healthy-4",
+    ]);
+    expect(firstResults[0]).toEqual({ embedding: null, error: "worker zero crashed" });
+    expect(firstResults.slice(1).map((item) => Array.from(item.embedding ?? []))).toEqual([
+      [1],
+      [1],
+      [1],
+      [1],
+    ]);
+    expect(firstResults.some((item) => item.error === "embedding job was not executed")).toBe(
+      false,
+    );
+    expect(pool.getStatus().activePoolSize).toBe(1);
+    expect(terminationCounts).toEqual([1, 0, 0]);
+
+    const downshiftedResult = await pool.embedBatch(["still healthy"]);
+    expect(downshiftedResult[0]?.embedding).toEqual(Float32Array.from([1]));
+    expect(callCounts[0]).toBe(1);
+
+    pool.setConcurrency(2);
+    const restoredResults = await pool.embedBatch(["healthy", "replacement"]);
+    expect(restoredResults.map((item) => Array.from(item.embedding ?? []))).toEqual([[1], [2]]);
+    expect(nextWorkerId).toBe(3);
+    expect(terminationCounts).toEqual([1, 0, 0]);
+  });
+
+  test("turns a batch-length mismatch into item errors and threshold downshifts", async () => {
+    const terminationCounts = [0, 0];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 2,
+      downshiftErrorThreshold: 2,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: async () => [],
+          terminate: () => {
+            terminationCounts[workerId] += 1;
+          },
+        };
+      },
+    });
+
+    const results = await pool.embedBatch(["first", "second"]);
+
+    expect(results).toEqual([
+      { embedding: null, error: "embedding batch length mismatch: expected 2, got 0" },
+      { embedding: null, error: "embedding batch length mismatch: expected 2, got 0" },
+    ]);
+    expect(pool.getStatus()).toMatchObject({
+      activePoolSize: 1,
+      downshifted: true,
+      errorCount: 2,
+    });
+    expect(terminationCounts).toEqual([0, 1]);
+  });
+
+  test("downshifts after repeated non-memory item errors", async () => {
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 2,
+      downshiftErrorThreshold: 2,
+      createEmbedder: () => ({
+        embedBatch: async (texts: string[]) =>
+          texts.map(() => ({ embedding: null, error: "temporary inference failure" })),
+        terminate: () => undefined,
+      }),
+    });
+
+    const results = await pool.embedBatch(["first", "second"]);
+
+    expect(results.every((item) => item.error === "temporary inference failure")).toBe(true);
+    expect(pool.getStatus()).toMatchObject({
+      activePoolSize: 1,
+      downshiftReason: "temporary inference failure",
+      errorCount: 2,
+    });
+  });
+
+  test("converts a sparse batch result into an explicit missing-item error", async () => {
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 1,
+      workerBatchSize: 2,
+      createEmbedder: () => ({
+        embedBatch: async () => {
+          const sparse = new Array<{
+            embedding: Float32Array | null;
+            error: string | null;
+          }>(2);
+          sparse[0] = { embedding: Float32Array.from([1]), error: null };
+          return sparse;
+        },
+        terminate: () => undefined,
+      }),
+    });
+
+    const results = await pool.embedBatch(["first", "second"]);
+
+    expect(results[0]?.embedding).toEqual(Float32Array.from([1]));
+    expect(results[1]).toEqual({ embedding: null, error: "missing batch item result" });
+  });
+
+  test("uses one worker for WebGPU and retires the unused surplus worker after the batch", async () => {
+    const calls = [0, 0];
+    const terminationCounts = [0, 0];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: async (texts: string[]) => {
+            calls[workerId] += 1;
+            return texts.map(() => ({ embedding: Float32Array.from([workerId]), error: null }));
+          },
+          terminate: () => {
+            terminationCounts[workerId] += 1;
+          },
+          getRuntimeInfo: () => ({
+            preferredBackend: "webgpu" as const,
+            selectedBackend: "webgpu" as const,
+            selectedModel: "webgpu-model",
+            fallbackReason: null,
+          }),
+        };
+      },
+    });
+
+    const results = await pool.embedBatch(["first", "second"]);
+
+    expect(results).toHaveLength(2);
+    expect(calls).toEqual([2, 0]);
+    expect(terminationCounts).toEqual([0, 1]);
+    expect(pool.getStatus()).toMatchObject({ activePoolSize: 1, selectedBackend: "webgpu" });
+  });
+
+  test("reports worker runtime diagnostics and terminates every created embedder", async () => {
+    const terminate = [vi.fn(), vi.fn()];
+    let nextWorkerId = 0;
+    const pool = new EmbeddingWorkerPool({
+      poolSize: 2,
+      workerBatchSize: 1,
+      preferredBackend: "webgpu",
+      createEmbedder: () => {
+        const workerId = nextWorkerId;
+        nextWorkerId += 1;
+        return {
+          embedBatch: async (texts: string[]) =>
+            texts.map(() => ({ embedding: Float32Array.from([workerId]), error: null })),
+          terminate: terminate[workerId],
+          getRuntimeInfo: () => ({
+            preferredBackend: "webgpu" as const,
+            selectedBackend: workerId === 0 ? ("wasm" as const) : null,
+            selectedModel: workerId === 0 ? "fallback-model" : null,
+            fallbackReason: workerId === 0 ? "webgpu unavailable" : null,
+          }),
+        };
+      },
+    });
+
+    await pool.embedBatch(["first", "second"]);
+    expect(pool.getStatus()).toMatchObject({
+      preferredBackend: "webgpu",
+      selectedBackend: "wasm",
+      selectedModel: "fallback-model",
+      backendFallbackReason: "webgpu unavailable",
+    });
+
+    pool.terminate();
+    pool.terminate();
+    expect(terminate[0]).toHaveBeenCalledOnce();
+    expect(terminate[1]).toHaveBeenCalledOnce();
   });
 });

--- a/src/embeddings/WorkerPool.ts
+++ b/src/embeddings/WorkerPool.ts
@@ -210,10 +210,12 @@ export class EmbeddingWorkerPool {
       }
       let cursor = 0;
       const workerCount = Math.min(this.activePoolSize, jobs.length);
+      let liveRunners = workerCount;
 
       const runWorker = async (workerIndex: number) => {
-        const embedder = this.embedders[workerIndex];
+        let embedder = this.embedders[workerIndex];
         if (!embedder) {
+          liveRunners -= 1;
           return;
         }
 
@@ -268,10 +270,22 @@ export class EmbeddingWorkerPool {
               this.downshiftToSingle(message);
             }
             if (workerIsFatal) {
-              break;
+              const jobsRemain = cursor < jobs.length;
+              if (jobsRemain && liveRunners === 1) {
+                // The sole runner hit a fatal worker error while jobs are still
+                // queued. Retire the crashed embedder (already marked unusable)
+                // and continue draining with a healthy replacement so later jobs
+                // don't fall through as "embedding job was not executed".
+                embedder = this.createEmbedder();
+                this.embedders.push(embedder);
+                continue;
+              }
+              liveRunners -= 1;
+              return;
             }
           }
         }
+        liveRunners -= 1;
       };
 
       await Promise.all(Array.from({ length: workerCount }, (_, index) => runWorker(index)));

--- a/src/embeddings/WorkerPool.ts
+++ b/src/embeddings/WorkerPool.ts
@@ -1,5 +1,6 @@
 import {
   Embedder,
+  isFatalEmbeddingWorkerError,
   type BatchEmbeddingResultItem,
   type BrowserEmbeddingModelCandidates,
   type EmbeddingBackendPreference,
@@ -80,6 +81,8 @@ export class EmbeddingWorkerPool {
   private embedders: EmbedderLike[] = [];
   private errorCount = 0;
   private downshiftReason: string | null = null;
+  private activeBatchCount = 0;
+  private unusableEmbedders = new Set<EmbedderLike>();
 
   constructor(options: EmbeddingWorkerPoolOptions = {}) {
     const configuredPoolSize = clampPositiveInt(options.poolSize, DEFAULT_POOL_SIZE);
@@ -115,25 +118,43 @@ export class EmbeddingWorkerPool {
     if (!this.downshiftReason) {
       this.downshiftReason = reason;
     }
+    this.retireSurplusIdleWorkers();
+  }
+
+  private retireSurplusIdleWorkers(): void {
+    if (this.activeBatchCount > 0) {
+      return;
+    }
+    if (this.unusableEmbedders.size > 0) {
+      this.embedders = this.embedders.filter((embedder) => {
+        if (!this.unusableEmbedders.delete(embedder)) {
+          return true;
+        }
+        embedder.terminate();
+        return false;
+      });
+    }
+    while (this.embedders.length > this.activePoolSize) {
+      this.embedders.pop()?.terminate();
+    }
   }
 
   setConcurrency(targetPoolSize: number): void {
     const normalized = clampPositiveInt(targetPoolSize, 1);
-    this.activePoolSize = Math.max(1, Math.min(normalized, this.maxPoolSize, this.configuredPoolSize));
+    this.activePoolSize = Math.max(
+      1,
+      Math.min(normalized, this.maxPoolSize, this.configuredPoolSize),
+    );
     if (this.activePoolSize > 1) {
       this.downshiftReason = null;
     }
+    this.retireSurplusIdleWorkers();
   }
 
   private updateConcurrencyForRuntime(): void {
     const status = this.getStatus();
     if (status.selectedBackend === "webgpu") {
       this.setConcurrency(1);
-      return;
-    }
-
-    if (!status.downshifted && this.activePoolSize < this.configuredPoolSize) {
-      this.setConcurrency(this.configuredPoolSize);
     }
   }
 
@@ -171,83 +192,94 @@ export class EmbeddingWorkerPool {
       throw new Error(`embedding queue overflow: ${texts.length} > ${this.maxQueueSize}`);
     }
 
-    this.ensureWorkers();
-    this.updateConcurrencyForRuntime();
-    const results: BatchEmbeddingResultItem[] = Array.from({ length: texts.length }, () => ({
-      embedding: null,
-      error: "embedding job was not executed",
-    }));
+    this.activeBatchCount += 1;
+    try {
+      this.ensureWorkers();
+      this.updateConcurrencyForRuntime();
+      const results: BatchEmbeddingResultItem[] = Array.from({ length: texts.length }, () => ({
+        embedding: null,
+        error: "embedding job was not executed",
+      }));
 
-    const jobs: Array<{ offset: number; texts: string[] }> = [];
-    for (let offset = 0; offset < texts.length; offset += this.workerBatchSize) {
-      jobs.push({
-        offset,
-        texts: texts.slice(offset, offset + this.workerBatchSize),
-      });
-    }
-    let cursor = 0;
-    const workerCount = Math.min(this.activePoolSize, jobs.length);
-
-    const runWorker = async (workerIndex: number) => {
-      const embedder = this.embedders[workerIndex];
-      if (!embedder) {
-        return;
+      const jobs: Array<{ offset: number; texts: string[] }> = [];
+      for (let offset = 0; offset < texts.length; offset += this.workerBatchSize) {
+        jobs.push({
+          offset,
+          texts: texts.slice(offset, offset + this.workerBatchSize),
+        });
       }
+      let cursor = 0;
+      const workerCount = Math.min(this.activePoolSize, jobs.length);
 
-      while (true) {
-        const nextIndex = cursor;
-        if (nextIndex >= jobs.length) {
-          break;
+      const runWorker = async (workerIndex: number) => {
+        const embedder = this.embedders[workerIndex];
+        if (!embedder) {
+          return;
         }
-        cursor += 1;
 
-        const job = jobs[nextIndex];
-        if (!job) {
-          break;
-        }
-        try {
-          const itemResults = await embedder.embedBatch(job.texts);
-          if (itemResults.length !== job.texts.length) {
-            throw new Error(
-              `embedding batch length mismatch: expected ${job.texts.length}, got ${itemResults.length}`,
-            );
+        while (true) {
+          const nextIndex = cursor;
+          if (nextIndex >= jobs.length) {
+            break;
           }
+          cursor += 1;
 
-          for (let i = 0; i < itemResults.length; i += 1) {
-            const targetIndex = job.offset + i;
-            const item = itemResults[i] ?? { embedding: null, error: "missing batch item result" };
-            results[targetIndex] = item;
-            if (item.error) {
-              this.errorCount += 1;
-              if (
-                isMemoryPressureError(item.error) ||
-                this.errorCount >= this.downshiftErrorThreshold
-              ) {
-                this.downshiftToSingle(item.error);
+          const job = jobs[nextIndex];
+          if (!job) {
+            break;
+          }
+          try {
+            const itemResults = await embedder.embedBatch(job.texts);
+            if (itemResults.length !== job.texts.length) {
+              throw new Error(
+                `embedding batch length mismatch: expected ${job.texts.length}, got ${itemResults.length}`,
+              );
+            }
+
+            for (let i = 0; i < itemResults.length; i += 1) {
+              const targetIndex = job.offset + i;
+              const item = itemResults[i] ?? {
+                embedding: null,
+                error: "missing batch item result",
+              };
+              results[targetIndex] = item;
+              if (item.error) {
+                this.errorCount += 1;
+                if (
+                  isMemoryPressureError(item.error) ||
+                  this.errorCount >= this.downshiftErrorThreshold
+                ) {
+                  this.downshiftToSingle(item.error);
+                }
               }
             }
-          }
-        } catch (error) {
-          const message = normalizeError(error);
-          for (let i = 0; i < job.texts.length; i += 1) {
-            const targetIndex = job.offset + i;
-            this.errorCount += 1;
-            results[targetIndex] = { embedding: null, error: message };
-          }
-          if (isMemoryPressureError(message) || this.errorCount >= this.downshiftErrorThreshold) {
-            this.downshiftToSingle(message);
+          } catch (error) {
+            const message = normalizeError(error);
+            const workerIsFatal = isFatalEmbeddingWorkerError(error);
+            if (workerIsFatal) {
+              this.unusableEmbedders.add(embedder);
+            }
+            for (let i = 0; i < job.texts.length; i += 1) {
+              const targetIndex = job.offset + i;
+              this.errorCount += 1;
+              results[targetIndex] = { embedding: null, error: message };
+            }
+            if (isMemoryPressureError(message) || this.errorCount >= this.downshiftErrorThreshold) {
+              this.downshiftToSingle(message);
+            }
+            if (workerIsFatal) {
+              break;
+            }
           }
         }
+      };
 
-        if (this.activePoolSize === 1 && workerIndex > 0) {
-          // Exit extra workers once pool is downshifted.
-          break;
-        }
-      }
-    };
-
-    await Promise.all(Array.from({ length: workerCount }, (_, index) => runWorker(index)));
-    return results;
+      await Promise.all(Array.from({ length: workerCount }, (_, index) => runWorker(index)));
+      return results;
+    } finally {
+      this.activeBatchCount -= 1;
+      this.retireSurplusIdleWorkers();
+    }
   }
 
   terminate(): void {
@@ -255,5 +287,6 @@ export class EmbeddingWorkerPool {
       embedder.terminate();
     }
     this.embedders = [];
+    this.unusableEmbedders.clear();
   }
 }

--- a/src/embeddings/ollamaClient.test.ts
+++ b/src/embeddings/ollamaClient.test.ts
@@ -17,6 +17,49 @@ describe("OllamaEmbeddingClient", () => {
     ).toThrow("localhost");
   });
 
+  test.each([
+    "http://localhost.example.com:11434",
+    "http://127.0.0.1.example.com",
+    "http://user@localhost:11434",
+    "https://192.168.1.10:11434",
+    "ftp://localhost:11434",
+  ])("rejects unsafe endpoint %s before discovery or embedding fetch", (baseUrl) => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(
+      () =>
+        new OllamaEmbeddingClient({
+          baseUrl,
+          model: "nomic-embed-text",
+          timeoutMs: 10_000,
+        }),
+    ).toThrow(/endpoint/u);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts any 127.0.0.0/8 address and preserves a safe proxy path", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify({ models: [{ name: "nomic-embed-text" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new OllamaEmbeddingClient({
+      baseUrl: "https://127.255.42.7:11434/proxy/",
+      model: "nomic-embed-text",
+      timeoutMs: 10_000,
+    });
+
+    await expect(client.healthCheck()).resolves.toEqual(["nomic-embed-text"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://127.255.42.7:11434/proxy/api/tags",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
   test("probes runtime and embeds via /api/embed", async () => {
     const fetchMock = vi.fn<typeof fetch>();
     fetchMock.mockResolvedValueOnce(
@@ -113,6 +156,79 @@ describe("OllamaEmbeddingClient", () => {
     expect(vectors[0]?.[0]).toBeCloseTo(0.1, 4);
     expect(vectors[1]?.[0]).toBeCloseTo(1.1, 4);
   });
+
+  test("rejects /api/embed responses whose vector count does not match the input batch", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ embeddings: [[0.1, 0.2]] }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ embeddings: [[1.1, 1.2]] }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new OllamaEmbeddingClient({
+      baseUrl: "http://localhost:11434",
+      model: "nomic-embed-text",
+      timeoutMs: 10_000,
+    });
+
+    await expect(client.embedBatch(["alpha", "beta"])).rejects.toThrow(
+      "Ollama /api/embed mismatch: expected 2, got 1",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "http://localhost:11434/api/embed",
+      "http://localhost:11434/api/embed",
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      model: "nomic-embed-text",
+      input: ["alpha", "beta"],
+    });
+  });
+
+  test.each([
+    { embeddings: [], expectedCount: 0 },
+    {
+      embeddings: [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ],
+      expectedCount: 2,
+    },
+  ])(
+    "rejects a legacy single-prompt response containing $expectedCount vectors",
+    async ({ embeddings, expectedCount }) => {
+      const fetchMock = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response("not found", { status: 404 }))
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ embeddings }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      const client = new OllamaEmbeddingClient({
+        baseUrl: "http://localhost:11434",
+        model: "nomic-embed-text",
+        timeoutMs: 10_000,
+      });
+
+      await expect(client.embedBatch(["alpha"])).rejects.toThrow(
+        `Ollama /api/embeddings returned ${expectedCount} vectors for single prompt`,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+        "http://localhost:11434/api/embed",
+        "http://localhost:11434/api/embeddings",
+      ]);
+      expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+        model: "nomic-embed-text",
+        prompt: "alpha",
+      });
+    },
+  );
 
   test("returns deterministic timeout errors", async () => {
     vi.useFakeTimers();

--- a/src/embeddings/ollamaClient.ts
+++ b/src/embeddings/ollamaClient.ts
@@ -1,3 +1,5 @@
+import { buildLocalEndpointUrl, normalizeLocalEndpoint } from "../llm/localEndpoint";
+
 export type OllamaEmbeddingEndpoint = "embed" | "embeddings";
 
 export type OllamaEmbeddingRuntimeInfo = {
@@ -10,12 +12,6 @@ export type OllamaEmbeddingRuntimeInfo = {
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 type JsonObject = { [key: string]: JsonValue };
-
-const LOCAL_ENDPOINT_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/i;
-
-function isLocalEndpoint(baseUrl: string): boolean {
-  return LOCAL_ENDPOINT_PATTERN.test(baseUrl);
-}
 
 function asObject(value: JsonValue | null | undefined): JsonObject | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -102,10 +98,7 @@ export class OllamaEmbeddingClient {
   private availableModels: string[] = [];
 
   constructor(args: { baseUrl: string; model: string; timeoutMs: number }) {
-    const normalizedBaseUrl = args.baseUrl.trim().replace(/\/+$/, "");
-    if (!isLocalEndpoint(normalizedBaseUrl)) {
-      throw new Error("Ollama endpoint must use localhost / 127.0.0.1 / [::1]");
-    }
+    const normalizedBaseUrl = normalizeLocalEndpoint(args.baseUrl, "Ollama");
     const normalizedModel = args.model.trim();
     if (!normalizedModel) {
       throw new Error("Ollama embedding model is required");
@@ -115,11 +108,11 @@ export class OllamaEmbeddingClient {
     this.timeoutMs = Math.max(1_000, Math.trunc(args.timeoutMs));
   }
 
-  private async fetchWithTimeout(path: string, init: RequestInit): Promise<Response> {
+  private async fetchWithTimeout(path: `/${string}`, init: RequestInit): Promise<Response> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
-      return await fetch(`${this.baseUrl}${path}`, {
+      return await fetch(buildLocalEndpointUrl(this.baseUrl, path, "Ollama"), {
         ...init,
         signal: controller.signal,
       });
@@ -210,7 +203,9 @@ export class OllamaEmbeddingClient {
       const payload = (await response.json()) as JsonValue;
       const vectors = parseEmbedResponse(payload);
       if (vectors.length !== texts.length) {
-        throw new Error(`Ollama /api/embed mismatch: expected ${texts.length}, got ${vectors.length}`);
+        throw new Error(
+          `Ollama /api/embed mismatch: expected ${texts.length}, got ${vectors.length}`,
+        );
       }
       return vectors.map((vector) => Float32Array.from(vector));
     }
@@ -234,7 +229,9 @@ export class OllamaEmbeddingClient {
       const payload = (await response.json()) as JsonValue;
       const vectorRows = parseEmbedResponse(payload);
       if (vectorRows.length !== 1) {
-        throw new Error(`Ollama /api/embeddings returned ${vectorRows.length} vectors for single prompt`);
+        throw new Error(
+          `Ollama /api/embeddings returned ${vectorRows.length} vectors for single prompt`,
+        );
       }
       vectors.push(Float32Array.from(vectorRows[0]));
     }

--- a/src/llm/generationExecution.test.ts
+++ b/src/llm/generationExecution.test.ts
@@ -175,6 +175,8 @@ describe("generation execution", () => {
       allowModelDownload: false,
     });
     let liveLmStudioBaseUrl = "http://changed-live-state.invalid";
+    const preReassignmentLiveUrl = liveLmStudioBaseUrl;
+    const probedBaseUrls: string[] = [];
     const stream = vi
       .fn<GenerationExecutionDependencies["stream"]>()
       .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
@@ -186,7 +188,11 @@ describe("generation execution", () => {
     const canReachLocalProvider = vi.fn(
       async (provider: "ollama" | "lmstudio", baseUrl: string) => {
         if (provider === "ollama") return false;
+        probedBaseUrls.push(baseUrl);
         expect(baseUrl).toBe("http://127.0.0.3:1234");
+        // The snapshot must be used regardless of live mutations both before
+        // (preReassignmentLiveUrl) and after (liveLmStudioBaseUrl) generation().
+        expect(baseUrl).not.toBe(preReassignmentLiveUrl);
         expect(baseUrl).not.toBe(liveLmStudioBaseUrl);
         return true;
       },
@@ -198,6 +204,9 @@ describe("generation execution", () => {
     await expect(executeGeneration(pending, dependencies)).resolves.toBe("completed");
 
     expect(stream).toHaveBeenCalledTimes(3);
+    expect(probedBaseUrls).toEqual(["http://127.0.0.3:1234"]);
+    expect(preReassignmentLiveUrl).toBe("http://changed-live-state.invalid");
+    expect(liveLmStudioBaseUrl).toBe("http://another-live-change.invalid");
     expect(dependencies.onProviderFallback).toHaveBeenCalledWith(fallbackConfig, "LM Studio");
     expect(messages.filter((message) => message.role === "assistant")).toHaveLength(1);
     expect(messages.at(-1)?.content).toBe("fallback answer");
@@ -247,6 +256,53 @@ describe("generation execution", () => {
     expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
     expect(dependencies.canReachLocalProvider).not.toHaveBeenCalled();
     expect(dependencies.onError).toHaveBeenCalledOnce();
+  });
+
+  it("clears a partial WebLLM attempt before retrying its fallback model", async () => {
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockImplementationOnce(async ({ onToken }) => {
+        onToken("stale partial ");
+        throw webLLMError("WEBLLM_INIT_FAILED");
+      })
+      .mockImplementationOnce(async ({ onToken }) => onToken("clean answer"));
+    const { dependencies, messages } = harness({ stream });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("completed");
+
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", content: "clean answer" });
+    expect(dependencies.onResetAnswer).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears whitespace tokens before a provider fallback so they cannot prefix the answer", async () => {
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockImplementationOnce(async ({ onToken }) => {
+        onToken("  \n ");
+        throw webLLMError("WEBLLM_STREAM_FAILED");
+      })
+      .mockImplementationOnce(async ({ onToken }) => onToken("fallback answer"));
+    const { dependencies, messages } = harness({ stream });
+
+    await expect(
+      executeGeneration(
+        generation({
+          providerConfig: createProviderRequestConfig({
+            providerId: "webllm",
+            baseUrl: "",
+            model: "fallback-web-model",
+            apiKey: "sk-snapshot",
+            allowModelDownload: true,
+          }),
+        }),
+        dependencies,
+      ),
+    ).resolves.toBe("completed");
+
+    expect(stream).toHaveBeenCalledTimes(2);
+    expect(dependencies.onProviderFallback).toHaveBeenCalledOnce();
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", content: "fallback answer" });
+    expect(dependencies.onResetAnswer).toHaveBeenCalledTimes(2);
   });
 
   it("cancels during database acquisition before prompt clear or user write", async () => {

--- a/src/llm/generationExecution.test.ts
+++ b/src/llm/generationExecution.test.ts
@@ -1,0 +1,558 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChatMessageRecord } from "../db/types";
+import {
+  checkLocalProviderReachability,
+  executeGeneration,
+  streamProviderRequest,
+  type GenerationExecutionDependencies,
+} from "./generationExecution";
+import {
+  createPendingGeneration,
+  createProviderRequestConfig,
+  markPendingUserMessagePersisted,
+  type PendingGeneration,
+  type ProviderRequestConfig,
+} from "./generationState";
+import type { LLMProviderDefinition } from "./types";
+
+const providerDefinitions: LLMProviderDefinition[] = [
+  {
+    id: "ollama",
+    label: "Ollama",
+    kind: "local",
+    defaultBaseUrl: "http://localhost:11434",
+    defaultModel: "llama3.2",
+    requiresApiKey: false,
+  },
+  {
+    id: "lmstudio",
+    label: "LM Studio",
+    kind: "local",
+    defaultBaseUrl: "http://localhost:1234",
+    defaultModel: "fallback-local-model",
+    requiresApiKey: false,
+  },
+  {
+    id: "openai-compatible",
+    label: "OpenAI compatible",
+    kind: "remote",
+    defaultBaseUrl: "https://api.openai.com/v1",
+    defaultModel: "gpt-4o-mini",
+    requiresApiKey: true,
+  },
+];
+
+function webLLMError(
+  code: "WEBLLM_DOWNLOAD_REQUIRED" | "WEBLLM_INIT_FAILED" | "WEBLLM_STREAM_FAILED",
+): Error & { code: typeof code } {
+  return Object.assign(new Error(code), { name: "WebLLMProviderError", code });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function generation(overrides: Partial<PendingGeneration> = {}): PendingGeneration {
+  return createPendingGeneration({
+    requestId: "request-1",
+    sessionId: "session-1",
+    promptText: "Which repository?",
+    snippets: ["owner/repo\ncontext"],
+    providerConfig: createProviderRequestConfig({
+      providerId: "webllm",
+      baseUrl: "",
+      model: "web-model",
+      apiKey: "sk-snapshot",
+      allowModelDownload: false,
+    }),
+    executionPolicy: {
+      allowLocalProvider: true,
+      allowRemoteProvider: true,
+      webllmConsent: true,
+      ollamaBaseUrl: "http://127.0.0.2:11434",
+      lmStudioBaseUrl: "http://127.0.0.3:1234",
+    },
+    userMessagePersisted: false,
+    ...overrides,
+  });
+}
+
+function harness(overrides: Partial<GenerationExecutionDependencies> = {}) {
+  const messages: ChatMessageRecord[] = [];
+  let nextId = 0;
+  const database = {
+    getNextChatMessageSequence: vi.fn(() => messages.length + 1),
+    addChatMessage: vi.fn(async (message: ChatMessageRecord) => {
+      messages.push(message);
+    }),
+  };
+  const dependencies: GenerationExecutionDependencies = {
+    controller: new AbortController(),
+    fallbackWebLLMModelId: "fallback-web-model",
+    getDatabase: vi.fn().mockResolvedValue(database),
+    stream: vi.fn(async ({ onToken }) => onToken("answer")),
+    providerDefinitions,
+    canReachLocalProvider: vi.fn().mockResolvedValue(false),
+    createId: () => `message-${++nextId}`,
+    now: () => 1000 + nextId,
+    onGeneratingChange: vi.fn(),
+    onResetAnswer: vi.fn(),
+    onClearPrompt: vi.fn(),
+    onToken: vi.fn(),
+    onMessage: vi.fn(),
+    onRuntimeState: vi.fn(),
+    onDownloadRequired: vi.fn(),
+    onWebLLMModelFallback: vi.fn(),
+    onProviderFallback: vi.fn(),
+    onError: vi.fn(),
+    onFinished: vi.fn(),
+    ...overrides,
+  };
+  return { database, dependencies, messages };
+}
+
+describe("generation execution", () => {
+  it("persists exactly one user and assistant on first execution", async () => {
+    const { dependencies, messages } = harness();
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("completed");
+
+    expect(messages.map(({ role, content }) => ({ role, content }))).toEqual([
+      { role: "user", content: "Which repository?" },
+      { role: "assistant", content: "answer" },
+    ]);
+    expect(dependencies.onClearPrompt).toHaveBeenCalledOnce();
+    expect(dependencies.onMessage).toHaveBeenCalledTimes(2);
+    expect(dependencies.onGeneratingChange).toHaveBeenNthCalledWith(1, true);
+    expect(dependencies.onGeneratingChange).toHaveBeenLastCalledWith(false);
+    expect(dependencies.onFinished).toHaveBeenCalledOnce();
+  });
+
+  it("resumes a persisted-user generation without clearing or duplicating the user", async () => {
+    const { dependencies, messages } = harness();
+    const resumed = markPendingUserMessagePersisted(generation());
+
+    await expect(executeGeneration(resumed, dependencies)).resolves.toBe("completed");
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ role: "assistant", content: "answer" });
+    expect(dependencies.onClearPrompt).not.toHaveBeenCalled();
+    expect(dependencies.onMessage).toHaveBeenCalledOnce();
+  });
+
+  it("suspends DOWNLOAD_REQUIRED with a persisted-user immutable snapshot", async () => {
+    const { dependencies, messages } = harness({
+      stream: vi.fn().mockRejectedValue(webLLMError("WEBLLM_DOWNLOAD_REQUIRED")),
+    });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("suspended");
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(dependencies.onDownloadRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "request-1",
+        userMessagePersisted: true,
+        executionPolicy: expect.objectContaining({
+          lmStudioBaseUrl: "http://127.0.0.3:1234",
+        }),
+      }),
+    );
+    expect(dependencies.onMessage).toHaveBeenCalledOnce();
+    expect(dependencies.onRuntimeState).toHaveBeenCalledWith("needs-consent");
+  });
+
+  it("executes an explicit fallback config and ignores changed live policy", async () => {
+    const fallbackConfig: ProviderRequestConfig = createProviderRequestConfig({
+      providerId: "lmstudio",
+      baseUrl: "http://127.0.0.3:1234",
+      model: "fallback-local-model",
+      apiKey: "sk-snapshot",
+      allowModelDownload: false,
+    });
+    let liveLmStudioBaseUrl = "http://changed-live-state.invalid";
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockRejectedValueOnce(webLLMError("WEBLLM_STREAM_FAILED"))
+      .mockImplementationOnce(async ({ config, onToken }) => {
+        expect(config).toEqual(fallbackConfig);
+        onToken("fallback answer");
+      });
+    const canReachLocalProvider = vi.fn(
+      async (provider: "ollama" | "lmstudio", baseUrl: string) => {
+        if (provider === "ollama") return false;
+        expect(baseUrl).toBe("http://127.0.0.3:1234");
+        expect(baseUrl).not.toBe(liveLmStudioBaseUrl);
+        return true;
+      },
+    );
+    const { dependencies, messages } = harness({ stream, canReachLocalProvider });
+    const pending = generation();
+    liveLmStudioBaseUrl = "http://another-live-change.invalid";
+
+    await expect(executeGeneration(pending, dependencies)).resolves.toBe("completed");
+
+    expect(stream).toHaveBeenCalledTimes(3);
+    expect(dependencies.onProviderFallback).toHaveBeenCalledWith(fallbackConfig, "LM Studio");
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(1);
+    expect(messages.at(-1)?.content).toBe("fallback answer");
+  });
+
+  it("uses reachable Ollama without starting a lower-priority LM Studio probe", async () => {
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockRejectedValueOnce(webLLMError("WEBLLM_STREAM_FAILED"))
+      .mockImplementationOnce(async ({ config, onToken }) => {
+        expect(config.providerId).toBe("ollama");
+        expect(config.baseUrl).toBe("http://127.0.0.2:11434");
+        onToken("ollama answer");
+      });
+    const canReachLocalProvider = vi.fn().mockResolvedValue(true);
+    const { dependencies, messages } = harness({ stream, canReachLocalProvider });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("completed");
+
+    expect(canReachLocalProvider).toHaveBeenCalledOnce();
+    expect(canReachLocalProvider).toHaveBeenCalledWith(
+      "ollama",
+      "http://127.0.0.2:11434",
+      dependencies.controller.signal,
+    );
+    expect(dependencies.onProviderFallback).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "ollama" }),
+      "Ollama",
+    );
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", content: "ollama answer" });
+  });
+
+  it("does not persist a partial assistant after a failed WebLLM retry", async () => {
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockImplementationOnce(async ({ onToken }) => {
+        onToken("partial");
+        throw webLLMError("WEBLLM_STREAM_FAILED");
+      });
+    const { dependencies, messages } = harness({ stream });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("failed");
+
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
+    expect(dependencies.canReachLocalProvider).not.toHaveBeenCalled();
+    expect(dependencies.onError).toHaveBeenCalledOnce();
+  });
+
+  it("cancels during database acquisition before prompt clear or user write", async () => {
+    const databaseGate = deferred<ReturnType<typeof harness>["database"]>();
+    const { database, dependencies, messages } = harness({
+      getDatabase: vi.fn().mockReturnValue(databaseGate.promise),
+    });
+    const execution = executeGeneration(generation(), dependencies);
+    dependencies.controller.abort();
+    databaseGate.resolve(database);
+
+    await expect(execution).resolves.toBe("cancelled");
+    expect(messages).toHaveLength(0);
+    expect(dependencies.onClearPrompt).not.toHaveBeenCalled();
+    expect(dependencies.stream).not.toHaveBeenCalled();
+  });
+
+  it("cancels while resolving fallback before fallback execution", async () => {
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockRejectedValueOnce(webLLMError("WEBLLM_STREAM_FAILED"));
+    const fetchImplementation = vi.fn<typeof fetch>().mockReturnValue(new Promise(() => {}));
+    const canReachLocalProvider = vi.fn(
+      (provider: "ollama" | "lmstudio", baseUrl: string, signal: AbortSignal) =>
+        checkLocalProviderReachability(provider, baseUrl, signal, fetchImplementation, 10_000),
+    );
+    const { dependencies, messages } = harness({
+      stream,
+      canReachLocalProvider,
+    });
+    const execution = executeGeneration(generation(), dependencies);
+    await vi.waitFor(() => expect(dependencies.canReachLocalProvider).toHaveBeenCalledOnce());
+    dependencies.controller.abort();
+
+    await expect(execution).resolves.toBe("cancelled");
+    expect(dependencies.canReachLocalProvider).toHaveBeenCalledOnce();
+    expect(fetchImplementation).toHaveBeenCalledOnce();
+    expect(stream).toHaveBeenCalledTimes(2);
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
+    expect(dependencies.onProviderFallback).not.toHaveBeenCalled();
+  });
+
+  it("cancels after streaming before assistant persistence", async () => {
+    const streamGate = deferred<void>();
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockImplementation(async ({ onToken }) => {
+        onToken("answer that must not persist");
+        await streamGate.promise;
+      });
+    const { dependencies, messages } = harness({ stream });
+    const execution = executeGeneration(generation(), dependencies);
+    await vi.waitFor(() => expect(dependencies.onToken).toHaveBeenCalledOnce());
+    dependencies.controller.abort();
+    streamGate.resolve();
+
+    await expect(execution).resolves.toBe("cancelled");
+    expect(messages.filter((message) => message.role === "user")).toHaveLength(1);
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
+  });
+
+  it("reports an ordinary provider stream failure without attempting WebLLM recovery", async () => {
+    const streamError = new Error("provider failed");
+    const { dependencies, messages } = harness({
+      stream: vi.fn().mockRejectedValue(streamError),
+    });
+
+    await expect(
+      executeGeneration(
+        generation({
+          providerConfig: createProviderRequestConfig({
+            providerId: "lmstudio",
+            baseUrl: "http://127.0.0.3:1234",
+            model: "local-model",
+            apiKey: "",
+            allowModelDownload: false,
+          }),
+        }),
+        dependencies,
+      ),
+    ).resolves.toBe("failed");
+
+    expect(dependencies.stream).toHaveBeenCalledOnce();
+    expect(dependencies.canReachLocalProvider).not.toHaveBeenCalled();
+    expect(dependencies.onError).toHaveBeenCalledWith(streamError, "lmstudio");
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
+  });
+
+  it("attributes a failing remote fallback to the remote provider", async () => {
+    const fallbackError = new Error("remote fallback failed");
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockRejectedValueOnce(webLLMError("WEBLLM_STREAM_FAILED"))
+      .mockRejectedValueOnce(fallbackError);
+    const { dependencies, messages } = harness({ stream });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("failed");
+
+    expect(stream).toHaveBeenCalledTimes(3);
+    expect(dependencies.onProviderFallback).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "openai-compatible" }),
+      "OpenAI compatible",
+    );
+    expect(dependencies.onError).toHaveBeenCalledOnce();
+    expect(dependencies.onError).toHaveBeenCalledWith(fallbackError, "openai-compatible");
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
+  });
+
+  it("attributes a failing local fallback to the local provider", async () => {
+    const fallbackError = new Error("local fallback failed");
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockRejectedValueOnce(webLLMError("WEBLLM_STREAM_FAILED"))
+      .mockRejectedValueOnce(fallbackError);
+    const canReachLocalProvider = vi.fn(async (provider: "ollama" | "lmstudio") => {
+      return provider === "lmstudio";
+    });
+    const { dependencies, messages } = harness({ stream, canReachLocalProvider });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("failed");
+
+    expect(stream).toHaveBeenCalledTimes(3);
+    expect(dependencies.onProviderFallback).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "lmstudio" }),
+      "LM Studio",
+    );
+    expect(dependencies.onError).toHaveBeenCalledOnce();
+    expect(dependencies.onError).toHaveBeenCalledWith(fallbackError, "lmstudio");
+    expect(messages.filter((message) => message.role === "assistant")).toHaveLength(0);
+  });
+
+  it("marks WebLLM ready after its fallback model succeeds", async () => {
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValueOnce(webLLMError("WEBLLM_INIT_FAILED"))
+      .mockImplementationOnce(async ({ onToken }) => onToken("fallback model answer"));
+    const { dependencies, messages } = harness({ stream });
+
+    await expect(executeGeneration(generation(), dependencies)).resolves.toBe("completed");
+
+    expect(dependencies.onRuntimeState).toHaveBeenCalledWith("downloading");
+    expect(dependencies.onRuntimeState).toHaveBeenLastCalledWith("ready");
+    expect(dependencies.onWebLLMModelFallback).toHaveBeenCalledWith("fallback-web-model");
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", content: "fallback model answer" });
+  });
+
+  it("does not retry the same WebLLM fallback model", async () => {
+    const streamError = webLLMError("WEBLLM_STREAM_FAILED");
+    const stream = vi
+      .fn<GenerationExecutionDependencies["stream"]>()
+      .mockRejectedValue(streamError);
+    const { dependencies } = harness({ stream });
+
+    await expect(
+      executeGeneration(
+        generation({
+          providerConfig: createProviderRequestConfig({
+            providerId: "webllm",
+            baseUrl: "",
+            model: "fallback-web-model",
+            apiKey: "",
+            allowModelDownload: true,
+          }),
+          executionPolicy: {
+            ...generation().executionPolicy,
+            allowLocalProvider: false,
+            allowRemoteProvider: false,
+          },
+        }),
+        dependencies,
+      ),
+    ).resolves.toBe("failed");
+
+    expect(stream).toHaveBeenCalledOnce();
+    expect(dependencies.onRuntimeState).toHaveBeenCalledWith("failed");
+    expect(dependencies.onWebLLMModelFallback).not.toHaveBeenCalled();
+  });
+});
+
+describe("local provider reachability", () => {
+  it.each([
+    ["ollama", "", "http://localhost:11434/api/tags"],
+    ["lmstudio", "http://127.0.0.3:1234", "http://127.0.0.3:1234/v1/models"],
+  ] as const)("checks the %s discovery endpoint", async (provider, baseUrl, expectedUrl) => {
+    const fetchImplementation = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await expect(
+      checkLocalProviderReachability(
+        provider,
+        baseUrl,
+        new AbortController().signal,
+        fetchImplementation,
+        100,
+      ),
+    ).resolves.toBe(true);
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      expectedUrl,
+      expect.objectContaining({ method: "GET", signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("fails closed for invalid endpoints and network failures", async () => {
+    const fetchImplementation = vi.fn<typeof fetch>().mockRejectedValue(new Error("offline"));
+
+    await expect(
+      checkLocalProviderReachability(
+        "ollama",
+        "http://localhost.example.com",
+        new AbortController().signal,
+        fetchImplementation,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      checkLocalProviderReachability(
+        "ollama",
+        "http://127.0.0.1:11434",
+        new AbortController().signal,
+        fetchImplementation,
+      ),
+    ).resolves.toBe(false);
+    expect(fetchImplementation).toHaveBeenCalledOnce();
+  });
+
+  it("does not fetch when reachability is already aborted", async () => {
+    const caller = new AbortController();
+    caller.abort();
+    const fetchImplementation = vi.fn<typeof fetch>();
+
+    await expect(
+      checkLocalProviderReachability(
+        "ollama",
+        "http://localhost:11434",
+        caller.signal,
+        fetchImplementation,
+      ),
+    ).resolves.toBe(false);
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+
+  it("returns false on timeout and removes its timer and caller listener", async () => {
+    vi.useFakeTimers();
+    try {
+      const caller = new AbortController();
+      const removeListener = vi.spyOn(caller.signal, "removeEventListener");
+      const fetchImplementation = vi.fn<typeof fetch>().mockReturnValue(new Promise(() => {}));
+      const pending = checkLocalProviderReachability(
+        "ollama",
+        "http://localhost:11434",
+        caller.signal,
+        fetchImplementation,
+        25,
+      );
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(pending).resolves.toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("provider request transport", () => {
+  it("passes the immutable request config and abort signal to the selected provider", async () => {
+    const controller = new AbortController();
+    const onToken = vi.fn();
+    const onInitProgress = vi.fn();
+    const stream = vi.fn().mockResolvedValue(undefined);
+    const config = createProviderRequestConfig({
+      providerId: "lmstudio",
+      baseUrl: "http://127.0.0.3:1234",
+      model: "configured-model",
+      apiKey: "snapshot-key",
+      allowModelDownload: false,
+    });
+
+    await streamProviderRequest(
+      { config, promptText: "question", snippets: ["context"], controller, onToken },
+      {
+        definition: providerDefinitions[1]!,
+        stream,
+      },
+      onInitProgress,
+    );
+
+    expect(stream).toHaveBeenCalledWith(
+      {
+        baseUrl: "http://127.0.0.3:1234",
+        model: "configured-model",
+        apiKey: "snapshot-key",
+        allowModelDownload: false,
+      },
+      {
+        prompt: "question",
+        contextSnippets: ["context"],
+        signal: controller.signal,
+        onToken,
+        onInitProgress,
+      },
+    );
+  });
+});

--- a/src/llm/generationExecution.ts
+++ b/src/llm/generationExecution.ts
@@ -253,6 +253,8 @@ export async function executeGeneration(
           allowModelDownload: true,
         });
         dependencies.onWebLLMModelFallback(effectiveConfig.model);
+        streamedAnswer = "";
+        dependencies.onResetAnswer();
         try {
           dependencies.onRuntimeState("downloading");
           await dependencies.stream({
@@ -277,6 +279,8 @@ export async function executeGeneration(
           const fallback = await resolveFallbackConfig(activeGeneration, dependencies);
           throwIfGenerationCancelled(controller.signal);
           if (!fallback) throw streamError;
+          streamedAnswer = "";
+          dependencies.onResetAnswer();
           dependencies.onProviderFallback(fallback.config, fallback.label);
           errorProviderId = fallback.config.providerId;
           await dependencies.stream({

--- a/src/llm/generationExecution.ts
+++ b/src/llm/generationExecution.ts
@@ -1,0 +1,317 @@
+import type { ChatMessageRecord } from "../db/types";
+import { resolveProviderFallback } from "./fallback";
+import {
+  buildFallbackProviderRequestConfig,
+  createProviderRequestConfig,
+  getGenerationStartPlan,
+  markPendingUserMessagePersisted,
+  throwIfGenerationCancelled,
+  updatePendingProviderConfig,
+  type PendingGeneration,
+  type ProviderRequestConfig,
+} from "./generationState";
+import { buildLocalEndpointUrl } from "./localEndpoint";
+import type { LLMProviderDefinition, LLMStreamProvider } from "./types";
+
+type WebLLMExecutionError = Error & {
+  code:
+    | "WEBLLM_UNSUPPORTED"
+    | "WEBLLM_DOWNLOAD_REQUIRED"
+    | "WEBLLM_INIT_FAILED"
+    | "WEBLLM_STREAM_FAILED";
+};
+
+export type GenerationDatabase = {
+  getNextChatMessageSequence(sessionId: string): number;
+  addChatMessage(message: ChatMessageRecord): Promise<void>;
+};
+
+type StreamArguments = {
+  config: ProviderRequestConfig;
+  promptText: string;
+  snippets: string[];
+  controller: AbortController;
+  onToken: (token: string) => void;
+};
+
+export async function streamProviderRequest(
+  args: StreamArguments,
+  provider: LLMStreamProvider,
+  onInitProgress: (progress: number, text: string) => void,
+): Promise<void> {
+  await provider.stream(
+    {
+      baseUrl: args.config.baseUrl,
+      model: args.config.model,
+      apiKey: args.config.apiKey,
+      allowModelDownload: args.config.allowModelDownload,
+    },
+    {
+      prompt: args.promptText,
+      contextSnippets: args.snippets,
+      signal: args.controller.signal,
+      onToken: args.onToken,
+      onInitProgress,
+    },
+  );
+}
+
+export type GenerationExecutionOutcome = "completed" | "suspended" | "failed" | "cancelled";
+
+export type GenerationExecutionDependencies = {
+  controller: AbortController;
+  fallbackWebLLMModelId: string;
+  getDatabase(): Promise<GenerationDatabase>;
+  stream(args: StreamArguments): Promise<void>;
+  providerDefinitions: readonly LLMProviderDefinition[];
+  canReachLocalProvider(
+    provider: "ollama" | "lmstudio",
+    baseUrl: string,
+    signal: AbortSignal,
+  ): Promise<boolean>;
+  createId(): string;
+  now(): number;
+  onGeneratingChange(active: boolean): void;
+  onResetAnswer(): void;
+  onClearPrompt(): void;
+  onToken(token: string): void;
+  onMessage(message: ChatMessageRecord): void;
+  onRuntimeState(state: "ready" | "needs-consent" | "downloading" | "failed"): void;
+  onDownloadRequired(generation: PendingGeneration): void;
+  onWebLLMModelFallback(model: string): void;
+  onProviderFallback(config: ProviderRequestConfig, label: string): void;
+  onError(error: unknown, providerId: ProviderRequestConfig["providerId"]): void;
+  onFinished(): void;
+};
+
+export async function checkLocalProviderReachability(
+  provider: "ollama" | "lmstudio",
+  configuredBaseUrl: string,
+  callerSignal: AbortSignal,
+  fetchImplementation: typeof fetch = fetch,
+  timeoutMs = 2_000,
+): Promise<boolean> {
+  if (callerSignal.aborted) return false;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const abortForCaller = () => controller.abort(callerSignal.reason);
+  callerSignal.addEventListener("abort", abortForCaller, { once: true });
+  let rejectForAbort: (() => void) | null = null;
+  try {
+    const url =
+      provider === "ollama"
+        ? buildLocalEndpointUrl(
+            configuredBaseUrl || "http://localhost:11434",
+            "/api/tags",
+            "Ollama",
+          )
+        : buildLocalEndpointUrl(
+            configuredBaseUrl || "http://localhost:1234",
+            "/v1/models",
+            "LM Studio",
+          );
+    const aborted = new Promise<never>((_, reject) => {
+      rejectForAbort = () => reject(new DOMException("Local provider probe aborted", "AbortError"));
+      controller.signal.addEventListener("abort", rejectForAbort, { once: true });
+    });
+    const response = await Promise.race([
+      fetchImplementation(url, { method: "GET", signal: controller.signal }),
+      aborted,
+    ]);
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+    callerSignal.removeEventListener("abort", abortForCaller);
+    if (rejectForAbort) controller.signal.removeEventListener("abort", rejectForAbort);
+  }
+}
+
+async function resolveFallbackConfig(
+  generation: PendingGeneration,
+  dependencies: GenerationExecutionDependencies,
+): Promise<{ config: ProviderRequestConfig; label: string } | null> {
+  const { executionPolicy } = generation;
+  throwIfGenerationCancelled(dependencies.controller.signal);
+  let canUseOllama = false;
+  let canUseLmStudio = false;
+  if (executionPolicy.allowLocalProvider) {
+    canUseOllama = await dependencies.canReachLocalProvider(
+      "ollama",
+      executionPolicy.ollamaBaseUrl,
+      dependencies.controller.signal,
+    );
+    throwIfGenerationCancelled(dependencies.controller.signal);
+    if (!canUseOllama) {
+      canUseLmStudio = await dependencies.canReachLocalProvider(
+        "lmstudio",
+        executionPolicy.lmStudioBaseUrl,
+        dependencies.controller.signal,
+      );
+      throwIfGenerationCancelled(dependencies.controller.signal);
+    }
+  }
+  const providerId = resolveProviderFallback({
+    canUseOllama,
+    canUseLmStudio,
+    canUseOpenAICompatible:
+      executionPolicy.allowRemoteProvider && generation.providerConfig.apiKey.length > 0,
+  });
+  const definition =
+    dependencies.providerDefinitions.find((provider) => provider.id === providerId) ?? null;
+  if (!providerId || !definition) return null;
+  return {
+    config: buildFallbackProviderRequestConfig({
+      providerId,
+      providerDefinition: definition,
+      providerBaseUrl: executionPolicy.lmStudioBaseUrl,
+      ollamaBaseUrl: executionPolicy.ollamaBaseUrl,
+      apiKey: generation.providerConfig.apiKey,
+    }),
+    label: definition.label,
+  };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function isWebLLMExecutionError(error: unknown): error is WebLLMExecutionError {
+  return (
+    error instanceof Error &&
+    error.name === "WebLLMProviderError" &&
+    typeof (error as Partial<WebLLMExecutionError>).code === "string"
+  );
+}
+
+export async function executeGeneration(
+  generation: PendingGeneration,
+  dependencies: GenerationExecutionDependencies,
+): Promise<GenerationExecutionOutcome> {
+  let activeGeneration = generation;
+  let streamedAnswer = "";
+  let errorProviderId: ProviderRequestConfig["providerId"] = generation.providerConfig.providerId;
+  const { controller } = dependencies;
+
+  try {
+    dependencies.onResetAnswer();
+    dependencies.onGeneratingChange(true);
+    const database = await dependencies.getDatabase();
+    throwIfGenerationCancelled(controller.signal);
+
+    const startPlan = getGenerationStartPlan(activeGeneration);
+    if (startPlan.clearPrompt) dependencies.onClearPrompt();
+    if (startPlan.persistUserMessage) {
+      const userMessage: ChatMessageRecord = {
+        id: dependencies.createId(),
+        sessionId: activeGeneration.sessionId,
+        role: "user",
+        content: activeGeneration.promptText,
+        sequence: database.getNextChatMessageSequence(activeGeneration.sessionId),
+        createdAt: dependencies.now(),
+      };
+      throwIfGenerationCancelled(controller.signal);
+      await database.addChatMessage(userMessage);
+      dependencies.onMessage(userMessage);
+      activeGeneration = markPendingUserMessagePersisted(activeGeneration);
+    }
+
+    const onToken = (token: string) => {
+      streamedAnswer += token;
+      dependencies.onToken(token);
+    };
+    let effectiveConfig = activeGeneration.providerConfig;
+
+    try {
+      await dependencies.stream({
+        config: effectiveConfig,
+        promptText: activeGeneration.promptText,
+        snippets: [...activeGeneration.snippets],
+        controller,
+        onToken,
+      });
+      if (effectiveConfig.providerId === "webllm") dependencies.onRuntimeState("ready");
+    } catch (streamError) {
+      throwIfGenerationCancelled(controller.signal);
+      if (effectiveConfig.providerId !== "webllm" || !isWebLLMExecutionError(streamError)) {
+        throw streamError;
+      }
+
+      if (streamError.code === "WEBLLM_DOWNLOAD_REQUIRED") {
+        const pending = updatePendingProviderConfig(activeGeneration, effectiveConfig);
+        dependencies.onRuntimeState("needs-consent");
+        dependencies.onDownloadRequired(pending);
+        return "suspended";
+      }
+
+      let recoveredWithWebLLM = false;
+      if (effectiveConfig.model !== dependencies.fallbackWebLLMModelId) {
+        effectiveConfig = createProviderRequestConfig({
+          ...effectiveConfig,
+          model: dependencies.fallbackWebLLMModelId,
+          allowModelDownload: true,
+        });
+        dependencies.onWebLLMModelFallback(effectiveConfig.model);
+        try {
+          dependencies.onRuntimeState("downloading");
+          await dependencies.stream({
+            config: effectiveConfig,
+            promptText: activeGeneration.promptText,
+            snippets: [...activeGeneration.snippets],
+            controller,
+            onToken,
+          });
+          dependencies.onRuntimeState("ready");
+          recoveredWithWebLLM = true;
+        } catch {
+          dependencies.onRuntimeState("failed");
+        }
+      } else {
+        dependencies.onRuntimeState("failed");
+      }
+
+      if (!recoveredWithWebLLM) {
+        throwIfGenerationCancelled(controller.signal);
+        if (streamedAnswer.trim().length === 0) {
+          const fallback = await resolveFallbackConfig(activeGeneration, dependencies);
+          throwIfGenerationCancelled(controller.signal);
+          if (!fallback) throw streamError;
+          dependencies.onProviderFallback(fallback.config, fallback.label);
+          errorProviderId = fallback.config.providerId;
+          await dependencies.stream({
+            config: fallback.config,
+            promptText: activeGeneration.promptText,
+            snippets: [...activeGeneration.snippets],
+            controller,
+            onToken,
+          });
+        } else {
+          throw streamError;
+        }
+      }
+    }
+
+    throwIfGenerationCancelled(controller.signal);
+    if (streamedAnswer.trim()) {
+      const assistantMessage: ChatMessageRecord = {
+        id: dependencies.createId(),
+        sessionId: activeGeneration.sessionId,
+        role: "assistant",
+        content: streamedAnswer,
+        sequence: database.getNextChatMessageSequence(activeGeneration.sessionId),
+        createdAt: dependencies.now(),
+      };
+      throwIfGenerationCancelled(controller.signal);
+      await database.addChatMessage(assistantMessage);
+      dependencies.onMessage(assistantMessage);
+    }
+    return "completed";
+  } catch (error) {
+    dependencies.onError(error, errorProviderId);
+    return isAbortError(error) ? "cancelled" : "failed";
+  } finally {
+    dependencies.onGeneratingChange(false);
+    dependencies.onFinished();
+  }
+}

--- a/src/llm/generationState.test.ts
+++ b/src/llm/generationState.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import type { LLMProviderDefinition } from "./types";
+import {
+  buildFallbackProviderRequestConfig,
+  buildSelectedProviderRequestConfig,
+  cancelPendingGeneration,
+  consumePendingGeneration,
+  createPendingGeneration,
+  createSelectedProviderGeneration,
+  getGenerationStartPlan,
+  markPendingUserMessagePersisted,
+  resumePendingWebLLMGeneration,
+  throwIfGenerationCancelled,
+  updatePendingExecutionPolicy,
+  updatePendingProviderConfig,
+} from "./generationState";
+
+const lmStudioDefinition: LLMProviderDefinition = {
+  id: "lmstudio",
+  label: "LM Studio",
+  kind: "local",
+  defaultBaseUrl: "http://localhost:1234",
+  defaultModel: "local-model",
+  requiresApiKey: false,
+};
+
+const ollamaDefinition: LLMProviderDefinition = {
+  id: "ollama",
+  label: "Ollama",
+  kind: "local",
+  defaultBaseUrl: "http://localhost:11434",
+  defaultModel: "llama3.2",
+  requiresApiKey: false,
+};
+
+const executionPolicy = {
+  allowLocalProvider: true,
+  allowRemoteProvider: false,
+  webllmConsent: false,
+  ollamaBaseUrl: "http://localhost:11434",
+  lmStudioBaseUrl: "http://localhost:1234",
+};
+
+describe("generation request state", () => {
+  it("uses the configured LM Studio URL for a selected request", () => {
+    expect(
+      buildSelectedProviderRequestConfig({
+        providerId: "lmstudio",
+        providerBaseUrl: " http://127.0.0.1:2345/v1 ",
+        ollamaBaseUrl: "http://localhost:11434",
+        model: " configured-model ",
+        apiKey: " local-key ",
+        allowModelDownload: false,
+      }),
+    ).toEqual({
+      providerId: "lmstudio",
+      baseUrl: "http://127.0.0.1:2345/v1",
+      model: "configured-model",
+      apiKey: "local-key",
+      allowModelDownload: false,
+    });
+  });
+
+  it("uses the safe Ollama default when its configured URL is blank", () => {
+    expect(
+      buildSelectedProviderRequestConfig({
+        providerId: "ollama",
+        providerBaseUrl: "http://stale-selected.invalid",
+        ollamaBaseUrl: "",
+        model: "llama3.2",
+        apiKey: "",
+        allowModelDownload: false,
+      }).baseUrl,
+    ).toBe("http://localhost:11434");
+
+    expect(
+      buildFallbackProviderRequestConfig({
+        providerId: "ollama",
+        providerDefinition: ollamaDefinition,
+        providerBaseUrl: "http://stale-selected.invalid",
+        ollamaBaseUrl: "",
+        apiKey: "",
+      }).baseUrl,
+    ).toBe("http://localhost:11434");
+  });
+
+  it("builds fallback transport from the fallback definition instead of stale selected state", () => {
+    expect(
+      buildFallbackProviderRequestConfig({
+        providerId: "lmstudio",
+        providerDefinition: lmStudioDefinition,
+        providerBaseUrl: "http://127.0.0.1:2345",
+        ollamaBaseUrl: "http://localhost:11434",
+        apiKey: "",
+      }),
+    ).toEqual({
+      providerId: "lmstudio",
+      baseUrl: "http://127.0.0.1:2345",
+      model: "local-model",
+      apiKey: "",
+      allowModelDownload: false,
+    });
+
+    expect(
+      buildFallbackProviderRequestConfig({
+        providerId: "openai-compatible",
+        providerDefinition: {
+          id: "openai-compatible",
+          label: "OpenAI compatible",
+          kind: "remote",
+          defaultBaseUrl: "https://api.openai.com",
+          defaultModel: "gpt-4o-mini",
+          requiresApiKey: true,
+        },
+        providerBaseUrl: "http://stale-selected-provider.invalid",
+        ollamaBaseUrl: "http://stale-selected-provider.invalid",
+        apiKey: "sk-fallback",
+      }),
+    ).toEqual({
+      providerId: "openai-compatible",
+      baseUrl: "https://api.openai.com",
+      model: "gpt-4o-mini",
+      apiKey: "sk-fallback",
+      allowModelDownload: false,
+    });
+  });
+
+  it("consumes a download resume exactly once and retains persisted-user state", () => {
+    const pending = markPendingUserMessagePersisted(
+      createPendingGeneration({
+        requestId: "request-1",
+        sessionId: "session-1",
+        promptText: "question",
+        snippets: ["owner/repo\ncontext"],
+        providerConfig: buildSelectedProviderRequestConfig({
+          providerId: "webllm",
+          providerBaseUrl: "",
+          ollamaBaseUrl: "",
+          model: "model-a",
+          apiKey: "",
+          allowModelDownload: false,
+        }),
+        executionPolicy,
+        userMessagePersisted: false,
+      }),
+    );
+    const resumed = updatePendingProviderConfig(pending, {
+      ...pending.providerConfig,
+      model: "model-b",
+      allowModelDownload: true,
+    });
+    const first = consumePendingGeneration(resumed);
+    const second = consumePendingGeneration(first.nextPending);
+
+    expect(first.generation).toMatchObject({
+      requestId: "request-1",
+      sessionId: "session-1",
+      promptText: "question",
+      userMessagePersisted: true,
+      providerConfig: { model: "model-b", allowModelDownload: true },
+      executionPolicy,
+    });
+    expect(second.generation).toBeNull();
+    expect(getGenerationStartPlan(pending)).toEqual({
+      clearPrompt: false,
+      persistUserMessage: false,
+    });
+  });
+
+  it("resumes a pending WebLLM request with consent and the selected model", () => {
+    const pending = createPendingGeneration({
+      requestId: "request-resume",
+      sessionId: "session-resume",
+      promptText: "question",
+      snippets: ["context"],
+      providerConfig: buildSelectedProviderRequestConfig({
+        providerId: "webllm",
+        providerBaseUrl: "",
+        ollamaBaseUrl: "",
+        model: "old-model",
+        apiKey: "",
+        allowModelDownload: false,
+      }),
+      executionPolicy,
+      userMessagePersisted: true,
+    });
+
+    const resumed = resumePendingWebLLMGeneration(pending, "selected-model");
+    expect(resumed.nextPending).toBeNull();
+    expect(resumed.generation).toMatchObject({
+      requestId: "request-resume",
+      userMessagePersisted: true,
+      providerConfig: {
+        providerId: "webllm",
+        model: "selected-model",
+        allowModelDownload: true,
+      },
+      executionPolicy: { webllmConsent: true },
+    });
+    expect(resumePendingWebLLMGeneration(null, "unused-model").generation).toBeNull();
+  });
+
+  it("clears the prompt and persists the user only on the first execution", () => {
+    const generation = createPendingGeneration({
+      requestId: "request-2",
+      sessionId: "session-2",
+      promptText: "question",
+      snippets: ["context"],
+      providerConfig: buildSelectedProviderRequestConfig({
+        providerId: "webllm",
+        providerBaseUrl: "",
+        ollamaBaseUrl: "",
+        model: "model-a",
+        apiKey: "",
+        allowModelDownload: false,
+      }),
+      executionPolicy,
+      userMessagePersisted: false,
+    });
+
+    expect(getGenerationStartPlan(generation)).toEqual({
+      clearPrompt: true,
+      persistUserMessage: true,
+    });
+    expect(getGenerationStartPlan(markPendingUserMessagePersisted(generation))).toEqual({
+      clearPrompt: false,
+      persistUserMessage: false,
+    });
+    const consented = updatePendingExecutionPolicy(generation, {
+      ...generation.executionPolicy,
+      webllmConsent: true,
+    });
+    expect(consented.executionPolicy.webllmConsent).toBe(true);
+    expect(generation.executionPolicy.webllmConsent).toBe(false);
+  });
+
+  it("snapshots a selected provider and execution policy into one pending request", () => {
+    const selected = createSelectedProviderGeneration({
+      requestId: "request-selected",
+      sessionId: "session-selected",
+      promptText: "question",
+      snippets: ["context"],
+      providerSelection: {
+        providerId: "lmstudio",
+        providerBaseUrl: " http://127.0.0.1:2345 ",
+        ollamaBaseUrl: "http://localhost:11434",
+        model: " local-model ",
+        apiKey: " local-key ",
+        allowModelDownload: false,
+      },
+      executionPolicy,
+    });
+
+    expect(selected).toMatchObject({
+      requestId: "request-selected",
+      sessionId: "session-selected",
+      promptText: "question",
+      snippets: ["context"],
+      providerConfig: {
+        providerId: "lmstudio",
+        baseUrl: "http://127.0.0.1:2345",
+        model: "local-model",
+        apiKey: "local-key",
+      },
+      executionPolicy,
+      userMessagePersisted: false,
+    });
+  });
+
+  it("discards a cancelled pending generation", () => {
+    expect(consumePendingGeneration(cancelPendingGeneration()).generation).toBeNull();
+
+    const controller = new AbortController();
+    expect(() => throwIfGenerationCancelled(controller.signal)).not.toThrow();
+    controller.abort();
+    expect(() => throwIfGenerationCancelled(controller.signal)).toThrowError(
+      expect.objectContaining({ name: "AbortError" }),
+    );
+
+    const nonErrorReasonController = new AbortController();
+    nonErrorReasonController.abort("cancelled by caller");
+    expect(() => throwIfGenerationCancelled(nonErrorReasonController.signal)).toThrowError(
+      expect.objectContaining({ name: "AbortError" }),
+    );
+  });
+});

--- a/src/llm/generationState.test.ts
+++ b/src/llm/generationState.test.ts
@@ -9,7 +9,9 @@ import {
   createSelectedProviderGeneration,
   getGenerationStartPlan,
   markPendingUserMessagePersisted,
+  resolveLmStudioPolicyUrl,
   resumePendingWebLLMGeneration,
+  shouldResetRuntimeAfterEmptyResume,
   throwIfGenerationCancelled,
   updatePendingExecutionPolicy,
   updatePendingProviderConfig,
@@ -82,6 +84,49 @@ describe("generation request state", () => {
         apiKey: "",
       }).baseUrl,
     ).toBe("http://localhost:11434");
+  });
+
+  it("falls back to safe defaults when configured URLs are whitespace-only", () => {
+    expect(
+      buildSelectedProviderRequestConfig({
+        providerId: "ollama",
+        providerBaseUrl: "http://stale-selected.invalid",
+        ollamaBaseUrl: "   ",
+        model: "llama3.2",
+        apiKey: "",
+        allowModelDownload: false,
+      }).baseUrl,
+    ).toBe("http://localhost:11434");
+
+    expect(
+      buildFallbackProviderRequestConfig({
+        providerId: "ollama",
+        providerDefinition: ollamaDefinition,
+        providerBaseUrl: "http://stale-selected.invalid",
+        ollamaBaseUrl: "  \t ",
+        apiKey: "",
+      }).baseUrl,
+    ).toBe("http://localhost:11434");
+
+    expect(
+      buildFallbackProviderRequestConfig({
+        providerId: "lmstudio",
+        providerDefinition: lmStudioDefinition,
+        providerBaseUrl: "   ",
+        ollamaBaseUrl: "http://localhost:11434",
+        apiKey: "",
+      }).baseUrl,
+    ).toBe("http://localhost:1234");
+  });
+
+  it("derives the LM Studio policy URL only from an actual LM Studio selection", () => {
+    expect(resolveLmStudioPolicyUrl("lmstudio", " http://127.0.0.1:2345/v1 ")).toBe(
+      "http://127.0.0.1:2345/v1",
+    );
+    expect(resolveLmStudioPolicyUrl("webllm", "http://webllm-injected.invalid")).toBe("");
+    expect(resolveLmStudioPolicyUrl("openai-compatible", "https://api.openai.com/v1")).toBe("");
+    expect(resolveLmStudioPolicyUrl("ollama", "http://127.0.0.1:11434")).toBe("");
+    expect(resolveLmStudioPolicyUrl("lmstudio", "   ")).toBe("");
   });
 
   it("builds fallback transport from the fallback definition instead of stale selected state", () => {
@@ -265,6 +310,21 @@ describe("generation request state", () => {
       executionPolicy,
       userMessagePersisted: false,
     });
+  });
+
+  it("keeps the active runtime after an empty resume but idles when no live generation exists", () => {
+    // Rapid double-confirm: the first click consumed the pending request and
+    // started a live generation, so the second (empty) resume must not idle it.
+    const active = new AbortController();
+    expect(shouldResetRuntimeAfterEmptyResume(active.signal)).toBe(false);
+
+    // No controller has ever been created (nothing to protect) -> idle.
+    expect(shouldResetRuntimeAfterEmptyResume(null)).toBe(true);
+
+    // A cancelled/aborted generation is no longer live -> idle.
+    const cancelled = new AbortController();
+    cancelled.abort();
+    expect(shouldResetRuntimeAfterEmptyResume(cancelled.signal)).toBe(true);
   });
 
   it("discards a cancelled pending generation", () => {

--- a/src/llm/generationState.ts
+++ b/src/llm/generationState.ts
@@ -1,0 +1,169 @@
+import type { LLMProviderDefinition, LLMProviderId } from "./types";
+
+export type ProviderRequestConfig = Readonly<{
+  providerId: LLMProviderId;
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+  allowModelDownload: boolean;
+}>;
+
+export type PendingGeneration = Readonly<{
+  requestId: string;
+  sessionId: string;
+  promptText: string;
+  snippets: readonly string[];
+  providerConfig: ProviderRequestConfig;
+  executionPolicy: Readonly<{
+    allowLocalProvider: boolean;
+    allowRemoteProvider: boolean;
+    webllmConsent: boolean;
+    ollamaBaseUrl: string;
+    lmStudioBaseUrl: string;
+  }>;
+  userMessagePersisted: boolean;
+}>;
+
+export function createProviderRequestConfig(config: ProviderRequestConfig): ProviderRequestConfig {
+  return Object.freeze({
+    ...config,
+    baseUrl: config.baseUrl.trim(),
+    model: config.model.trim(),
+    apiKey: config.apiKey.trim(),
+  });
+}
+
+export function buildSelectedProviderRequestConfig(input: {
+  providerId: LLMProviderId;
+  providerBaseUrl: string;
+  ollamaBaseUrl: string;
+  model: string;
+  apiKey: string;
+  allowModelDownload: boolean;
+}): ProviderRequestConfig {
+  return createProviderRequestConfig({
+    providerId: input.providerId,
+    baseUrl:
+      input.providerId === "ollama"
+        ? input.ollamaBaseUrl || "http://localhost:11434"
+        : input.providerBaseUrl,
+    model: input.model,
+    apiKey: input.apiKey,
+    allowModelDownload: input.allowModelDownload,
+  });
+}
+
+export function buildFallbackProviderRequestConfig(input: {
+  providerId: LLMProviderId;
+  providerDefinition: LLMProviderDefinition;
+  providerBaseUrl: string;
+  ollamaBaseUrl: string;
+  apiKey: string;
+}): ProviderRequestConfig {
+  return createProviderRequestConfig({
+    providerId: input.providerId,
+    baseUrl:
+      input.providerId === "ollama"
+        ? input.ollamaBaseUrl || "http://localhost:11434"
+        : input.providerId === "lmstudio"
+          ? input.providerBaseUrl || input.providerDefinition.defaultBaseUrl
+          : input.providerDefinition.defaultBaseUrl,
+    model: input.providerDefinition.defaultModel,
+    apiKey: input.apiKey,
+    allowModelDownload: false,
+  });
+}
+
+export function createPendingGeneration(input: PendingGeneration): PendingGeneration {
+  return Object.freeze({
+    ...input,
+    snippets: Object.freeze([...input.snippets]),
+    providerConfig: createProviderRequestConfig(input.providerConfig),
+    executionPolicy: Object.freeze({ ...input.executionPolicy }),
+  });
+}
+
+export function createSelectedProviderGeneration(input: {
+  requestId: string;
+  sessionId: string;
+  promptText: string;
+  snippets: readonly string[];
+  providerSelection: Parameters<typeof buildSelectedProviderRequestConfig>[0];
+  executionPolicy: PendingGeneration["executionPolicy"];
+}): PendingGeneration {
+  return createPendingGeneration({
+    requestId: input.requestId,
+    sessionId: input.sessionId,
+    promptText: input.promptText,
+    snippets: input.snippets,
+    providerConfig: buildSelectedProviderRequestConfig(input.providerSelection),
+    executionPolicy: input.executionPolicy,
+    userMessagePersisted: false,
+  });
+}
+
+export function markPendingUserMessagePersisted(generation: PendingGeneration): PendingGeneration {
+  return createPendingGeneration({ ...generation, userMessagePersisted: true });
+}
+
+export function getGenerationStartPlan(generation: PendingGeneration): {
+  clearPrompt: boolean;
+  persistUserMessage: boolean;
+} {
+  const firstExecution = !generation.userMessagePersisted;
+  return { clearPrompt: firstExecution, persistUserMessage: firstExecution };
+}
+
+export function updatePendingProviderConfig(
+  generation: PendingGeneration,
+  providerConfig: ProviderRequestConfig,
+): PendingGeneration {
+  return createPendingGeneration({ ...generation, providerConfig });
+}
+
+export function updatePendingExecutionPolicy(
+  generation: PendingGeneration,
+  executionPolicy: PendingGeneration["executionPolicy"],
+): PendingGeneration {
+  return createPendingGeneration({ ...generation, executionPolicy });
+}
+
+export function consumePendingGeneration(pending: PendingGeneration | null): {
+  generation: PendingGeneration | null;
+  nextPending: null;
+} {
+  return { generation: pending, nextPending: null };
+}
+
+export function cancelPendingGeneration(): null {
+  return null;
+}
+
+export function resumePendingWebLLMGeneration(
+  pending: PendingGeneration | null,
+  model: string,
+): { generation: PendingGeneration | null; nextPending: null } {
+  const consumed = consumePendingGeneration(pending);
+  if (!consumed.generation) return consumed;
+  return {
+    generation: updatePendingExecutionPolicy(
+      updatePendingProviderConfig(
+        consumed.generation,
+        createProviderRequestConfig({
+          ...consumed.generation.providerConfig,
+          providerId: "webllm",
+          model,
+          allowModelDownload: true,
+        }),
+      ),
+      { ...consumed.generation.executionPolicy, webllmConsent: true },
+    ),
+    nextPending: null,
+  };
+}
+
+export function throwIfGenerationCancelled(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  if (signal.reason instanceof Error) throw signal.reason;
+  throw new DOMException("Generation cancelled", "AbortError");
+}

--- a/src/llm/generationState.ts
+++ b/src/llm/generationState.ts
@@ -45,7 +45,7 @@ export function buildSelectedProviderRequestConfig(input: {
     providerId: input.providerId,
     baseUrl:
       input.providerId === "ollama"
-        ? input.ollamaBaseUrl || "http://localhost:11434"
+        ? input.ollamaBaseUrl.trim() || "http://localhost:11434"
         : input.providerBaseUrl,
     model: input.model,
     apiKey: input.apiKey,
@@ -64,14 +64,21 @@ export function buildFallbackProviderRequestConfig(input: {
     providerId: input.providerId,
     baseUrl:
       input.providerId === "ollama"
-        ? input.ollamaBaseUrl || "http://localhost:11434"
+        ? input.ollamaBaseUrl.trim() || "http://localhost:11434"
         : input.providerId === "lmstudio"
-          ? input.providerBaseUrl || input.providerDefinition.defaultBaseUrl
+          ? input.providerBaseUrl.trim() || input.providerDefinition.defaultBaseUrl
           : input.providerDefinition.defaultBaseUrl,
     model: input.providerDefinition.defaultModel,
     apiKey: input.apiKey,
     allowModelDownload: false,
   });
+}
+
+export function resolveLmStudioPolicyUrl(
+  providerId: LLMProviderId,
+  providerBaseUrl: string,
+): string {
+  return providerId === "lmstudio" ? providerBaseUrl.trim() : "";
 }
 
 export function createPendingGeneration(input: PendingGeneration): PendingGeneration {
@@ -160,6 +167,10 @@ export function resumePendingWebLLMGeneration(
     ),
     nextPending: null,
   };
+}
+
+export function shouldResetRuntimeAfterEmptyResume(activeSignal: AbortSignal | null): boolean {
+  return activeSignal === null || activeSignal.aborted;
 }
 
 export function throwIfGenerationCancelled(signal: AbortSignal): void {

--- a/src/llm/localEndpoint.test.ts
+++ b/src/llm/localEndpoint.test.ts
@@ -1,0 +1,45 @@
+import { buildLocalEndpointUrl, normalizeLocalEndpoint } from "./localEndpoint";
+
+describe("local provider endpoint validation", () => {
+  test.each([
+    ["http://localhost", "http://localhost"],
+    ["HTTPS://LOCALHOST:1234/", "https://localhost:1234"],
+    ["http://127.0.0.1:11434", "http://127.0.0.1:11434"],
+    ["https://127.42.7.255:9443/api/", "https://127.42.7.255:9443/api"],
+    ["http://[::1]", "http://[::1]"],
+    ["https://[::1]:1234/models/", "https://[::1]:1234/models"],
+  ])("accepts loopback endpoint %s", (input, expected) => {
+    expect(normalizeLocalEndpoint(input)).toBe(expected);
+  });
+
+  test.each([
+    "https://example.com",
+    "http://localhost.example.com:11434",
+    "http://127.0.0.1.example.com",
+    "http://128.0.0.1",
+    "http://[::2]",
+    "http://user@localhost:11434",
+    "http://user:secret@127.0.0.1",
+    "ftp://localhost/resource",
+    "javascript:alert(1)",
+    "localhost:11434",
+    "http://localhost:99999",
+    "http://localhost:11434?target=https://example.com",
+    "http://localhost:11434/#fragment",
+    "http://2130706433:11434",
+    "http://0x7f000001:11434",
+    "http://0177.0.0.1:11434",
+    "http://127.1:11434",
+    "http://127.000.0.1:11434",
+    "http://127.0.00.1:11434",
+    "http://[0:0:0:0:0:0:0:1]:11434",
+  ])("rejects unsafe or malformed endpoint %s", (input) => {
+    expect(() => normalizeLocalEndpoint(input)).toThrow(/endpoint/u);
+  });
+
+  test("preserves a safe base path while appending the request path", () => {
+    expect(buildLocalEndpointUrl("http://127.12.0.8:11434/proxy/", "/api/chat", "Ollama")).toBe(
+      "http://127.12.0.8:11434/proxy/api/chat",
+    );
+  });
+});

--- a/src/llm/localEndpoint.ts
+++ b/src/llm/localEndpoint.ts
@@ -11,6 +11,11 @@ function isExplicitIpv4Loopback(hostname: string): boolean {
   return values[0] === 127 && values.every((value) => value >= 0 && value <= 255);
 }
 
+// Security-maintenance: validate the raw authority as written, never the parsed
+// URL.hostname. WHATWG URL parsing canonicalizes alternate loopback spellings
+// (e.g. "127.1", "0x7f.1", "2130706433") into "127.0.0.1", which would smuggle
+// non-explicit forms past this allowlist. Matching the raw text keeps only the
+// literal loopback authorities we intend to permit.
 function isExplicitLoopbackAuthority(value: string): boolean {
   const authority = /^https?:\/\/([^/?#]+)/iu.exec(value)?.[1];
   if (!authority) {

--- a/src/llm/localEndpoint.ts
+++ b/src/llm/localEndpoint.ts
@@ -1,0 +1,60 @@
+function isExplicitIpv4Loopback(hostname: string): boolean {
+  const octets = hostname.split(".");
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !/^\d{1,3}$/u.test(octet) || (octet.length > 1 && octet.startsWith("0")))
+  ) {
+    return false;
+  }
+
+  const values = octets.map(Number);
+  return values[0] === 127 && values.every((value) => value >= 0 && value <= 255);
+}
+
+function isExplicitLoopbackAuthority(value: string): boolean {
+  const authority = /^https?:\/\/([^/?#]+)/iu.exec(value)?.[1];
+  if (!authority) {
+    return false;
+  }
+
+  const bracketedIpv6 = /^\[([^\]]+)\](?::\d+)?$/u.exec(authority);
+  if (bracketedIpv6) {
+    return bracketedIpv6[1]?.toLowerCase() === "::1";
+  }
+
+  const host = /^(.*?)(?::\d+)?$/u.exec(authority)?.[1];
+  if (!host) {
+    return false;
+  }
+  return host.toLowerCase() === "localhost" || isExplicitIpv4Loopback(host);
+}
+
+export function normalizeLocalEndpoint(value: string, label = "Local provider"): string {
+  const rawValue = value.trim();
+  let endpoint: URL;
+  try {
+    endpoint = new URL(rawValue);
+  } catch {
+    throw new Error(`${label} endpoint must be a valid HTTP(S) loopback URL`);
+  }
+
+  if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") {
+    throw new Error(`${label} endpoint must use HTTP or HTTPS`);
+  }
+  if (endpoint.username || endpoint.password) {
+    throw new Error(`${label} endpoint must not include credentials`);
+  }
+  if (!isExplicitLoopbackAuthority(rawValue)) {
+    throw new Error(`${label} endpoint must use localhost, 127.0.0.0/8, or [::1]`);
+  }
+  if (endpoint.search || endpoint.hash) {
+    throw new Error(`${label} endpoint must not include a query or fragment`);
+  }
+
+  endpoint.pathname = endpoint.pathname.replace(/\/+$/u, "");
+  return endpoint.toString().replace(/\/$/u, "");
+}
+
+export function buildLocalEndpointUrl(baseUrl: string, path: `/${string}`, label: string): string {
+  return `${normalizeLocalEndpoint(baseUrl, label)}${path}`;
+}

--- a/src/llm/providers.test.ts
+++ b/src/llm/providers.test.ts
@@ -1,0 +1,208 @@
+import { getProviderById } from "./providers";
+import type { LLMProviderId, LLMStreamRequest } from "./types";
+import { getWebLLMEngineManager } from "./webllm/engine";
+
+vi.mock("./webllm/engine", () => {
+  class WebLLMProviderError extends Error {
+    readonly code = "WEBLLM_UNSUPPORTED";
+  }
+  return {
+    getWebLLMEngineManager: vi.fn(),
+    WebLLMProviderError,
+  };
+});
+
+const encoder = new TextEncoder();
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function responseFromChunks(chunks: Uint8Array[]): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+function everyTwoChunkSplit(value: string): Uint8Array[][] {
+  const bytes = encoder.encode(value);
+  const splits = Array.from({ length: bytes.length + 1 }, (_, index) =>
+    [bytes.slice(0, index), bytes.slice(index)].filter((chunk) => chunk.byteLength > 0),
+  );
+  splits.push(Array.from(bytes, (byte) => Uint8Array.of(byte)));
+  return splits;
+}
+
+function streamRequest(onToken: (token: string) => void): LLMStreamRequest {
+  return {
+    prompt: "Find a repository",
+    contextSnippets: ["Context"],
+    signal: new AbortController().signal,
+    onToken,
+  };
+}
+
+async function streamWith(providerId: LLMProviderId, baseUrl: string, body: string) {
+  const tokens: string[] = [];
+  vi.mocked(fetch).mockResolvedValueOnce(responseFromChunks([encoder.encode(body)]));
+  await getProviderById(providerId).stream(
+    { baseUrl, model: "test-model" },
+    streamRequest((token) => tokens.push(token)),
+  );
+  return tokens;
+}
+
+describe("provider transports", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.mocked(getWebLLMEngineManager).mockReset();
+  });
+
+  test("LM Studio SSE emits a valid terminal record across every byte split", async () => {
+    const terminalRecord = `data: ${JSON.stringify({ choices: [{ delta: { content: "hé🌟" } }] })}`;
+
+    for (const chunks of everyTwoChunkSplit(terminalRecord)) {
+      const tokens: string[] = [];
+      vi.mocked(fetch).mockResolvedValueOnce(responseFromChunks(chunks));
+      await getProviderById("lmstudio").stream(
+        { baseUrl: "http://127.42.7.9:1234/proxy/", model: "test-model" },
+        streamRequest((token) => tokens.push(token)),
+      );
+      expect(tokens).toEqual(["hé🌟"]);
+    }
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe(
+      "http://127.42.7.9:1234/proxy/v1/chat/completions",
+    );
+  });
+
+  test("LM Studio SSE ignores metadata and empty data before the done sentinel", async () => {
+    await expect(
+      streamWith("lmstudio", "http://localhost:1234", "event: ping\n\ndata:\n\ndata: [DONE]\n"),
+    ).resolves.toEqual([]);
+  });
+
+  test("Ollama JSONL emits a valid terminal record across every byte split", async () => {
+    const terminalRecord = JSON.stringify({ message: { content: "hé🌟" }, done: true });
+
+    for (const chunks of everyTwoChunkSplit(terminalRecord)) {
+      const tokens: string[] = [];
+      vi.mocked(fetch).mockResolvedValueOnce(responseFromChunks(chunks));
+      await getProviderById("ollama").stream(
+        { baseUrl: "https://[::1]:11434/proxy/", model: "test-model" },
+        streamRequest((token) => tokens.push(token)),
+      );
+      expect(tokens).toEqual(["hé🌟"]);
+    }
+
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toBe("https://[::1]:11434/proxy/api/chat");
+  });
+
+  test("Ollama stops reading at a newline-terminated done record", async () => {
+    await expect(
+      streamWith(
+        "ollama",
+        "http://localhost:11434",
+        `${JSON.stringify({ done: true })}\n${JSON.stringify({ response: "must-not-emit" })}\n`,
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  test.each([
+    ["lmstudio" as const, "http://localhost:1234", "data: {bad", "Malformed terminal SSE record"],
+    ["ollama" as const, "http://localhost:11434", "{bad", "Malformed terminal JSONL record"],
+  ])(
+    "%s reports malformed last meaningful data at EOF with or without trailing newlines",
+    async (providerId, baseUrl, malformedRecord, expectedError) => {
+      for (const suffix of ["", "\n", "\n\n"] as const) {
+        await expect(
+          streamWith(providerId, baseUrl, `${malformedRecord}${suffix}`),
+        ).rejects.toThrow(expectedError);
+      }
+    },
+  );
+
+  test.each([
+    [
+      "lmstudio" as const,
+      "http://localhost:1234",
+      `data: {bad\n\ndata: ${JSON.stringify({ choices: [{ delta: { content: "recovered" } }] })}`,
+    ],
+    [
+      "ollama" as const,
+      "http://localhost:11434",
+      `{bad\n\n${JSON.stringify({ response: "recovered", done: true })}`,
+    ],
+  ])(
+    "%s preserves compatibility for malformed nonterminal lines",
+    async (providerId, baseUrl, body) => {
+      await expect(streamWith(providerId, baseUrl, body)).resolves.toEqual(["recovered"]);
+    },
+  );
+
+  test.each([
+    ["ollama" as const, "http://localhost.example.com:11434"],
+    ["ollama" as const, "http://user@localhost:11434"],
+    ["ollama" as const, "http://2130706433:11434"],
+    ["lmstudio" as const, "https://127.0.0.1.example.com"],
+    ["lmstudio" as const, "ftp://localhost:1234"],
+    ["lmstudio" as const, "http://127.1:1234"],
+  ])("%s rejects unsafe endpoint %s before fetch", async (providerId, baseUrl) => {
+    await expect(
+      getProviderById(providerId).stream(
+        { baseUrl, model: "test-model" },
+        streamRequest(() => undefined),
+      ),
+    ).rejects.toThrow(/endpoint/u);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("WebLLM cancellation during initialization settles without starting a stream", async () => {
+    vi.stubEnv("VITE_WEBLLM_ENABLED", "true");
+    const initialization = deferred<void>();
+    const ensureReady = vi.fn(
+      (_modelId: string, options: { signal: AbortSignal }) =>
+        new Promise<void>((resolve, reject) => {
+          const onAbort = () => reject(new DOMException("aborted", "AbortError"));
+          options.signal.addEventListener("abort", onAbort, { once: true });
+          void initialization.promise.then(resolve, reject);
+        }),
+    );
+    const stream = vi.fn();
+    vi.mocked(getWebLLMEngineManager).mockReturnValue({ ensureReady, stream } as never);
+    const controller = new AbortController();
+
+    const pending = getProviderById("webllm").stream(
+      { baseUrl: "", model: "test-model", allowModelDownload: true },
+      { ...streamRequest(() => undefined), signal: controller.signal },
+    );
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(ensureReady).toHaveBeenCalledWith(
+      "test-model",
+      expect.objectContaining({ signal: controller.signal }),
+    );
+    expect(stream).not.toHaveBeenCalled();
+    initialization.resolve();
+  });
+});

--- a/src/llm/providers.test.ts
+++ b/src/llm/providers.test.ts
@@ -38,6 +38,25 @@ function responseFromChunks(chunks: Uint8Array[]): Response {
   );
 }
 
+function trackedResponse(chunks: Uint8Array[]): { response: Response; wasCanceled: () => boolean } {
+  let canceled = false;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    }),
+    { status: 200 },
+  );
+  return { response, wasCanceled: () => canceled };
+}
+
 function everyTwoChunkSplit(value: string): Uint8Array[][] {
   const bytes = encoder.encode(value);
   const splits = Array.from({ length: bytes.length + 1 }, (_, index) =>
@@ -125,6 +144,57 @@ describe("provider transports", () => {
         `${JSON.stringify({ done: true })}\n${JSON.stringify({ response: "must-not-emit" })}\n`,
       ),
     ).resolves.toEqual([]);
+  });
+
+  test("LM Studio SSE cancels the reader when the done sentinel precedes stream end", async () => {
+    const tracked = trackedResponse([
+      encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\n`),
+      encoder.encode("data: [DONE]\n"),
+      encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: "leaked" } }] })}\n`),
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(tracked.response);
+    const tokens: string[] = [];
+
+    await getProviderById("lmstudio").stream(
+      { baseUrl: "http://localhost:1234", model: "test-model" },
+      streamRequest((token) => tokens.push(token)),
+    );
+
+    expect(tokens).toEqual(["hi"]);
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  test("Ollama JSONL cancels the reader when the done record precedes stream end", async () => {
+    const tracked = trackedResponse([
+      encoder.encode(`${JSON.stringify({ message: { content: "hi" }, done: true })}\n`),
+      encoder.encode(`${JSON.stringify({ response: "leaked" })}\n`),
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(tracked.response);
+    const tokens: string[] = [];
+
+    await getProviderById("ollama").stream(
+      { baseUrl: "http://localhost:11434", model: "test-model" },
+      streamRequest((token) => tokens.push(token)),
+    );
+
+    expect(tokens).toEqual(["hi"]);
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  test("SSE reaching end of stream without a terminal record does not cancel the reader", async () => {
+    const tracked = trackedResponse([
+      encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\n`),
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(tracked.response);
+    const tokens: string[] = [];
+
+    await getProviderById("lmstudio").stream(
+      { baseUrl: "http://localhost:1234", model: "test-model" },
+      streamRequest((token) => tokens.push(token)),
+    );
+
+    expect(tokens).toEqual(["hi"]);
+    expect(tracked.wasCanceled()).toBe(false);
   });
 
   test.each([

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -6,6 +6,7 @@ import type {
   LLMStreamRequest,
 } from "./types";
 import { getWebLLMEngineManager, WebLLMProviderError } from "./webllm/engine";
+import { buildLocalEndpointUrl } from "./localEndpoint";
 
 const TOP_K_LIMIT = 8;
 
@@ -28,6 +29,36 @@ function normalizeProviderError(error: unknown): Error {
   return new Error(String(error));
 }
 
+type StreamRecordOutcome = "ignored" | "valid" | "malformed" | "done";
+
+function consumeSseLine(line: string, onToken: (token: string) => void): StreamRecordOutcome {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("data:")) {
+    return "ignored";
+  }
+
+  const raw = trimmed.slice(5).trim();
+  if (raw === "[DONE]") {
+    return "done";
+  }
+  if (!raw) {
+    return "ignored";
+  }
+
+  try {
+    const payload = JSON.parse(raw) as {
+      choices?: Array<{ delta?: { content?: string }; message?: { content?: string } }>;
+    };
+    const token = payload.choices?.[0]?.delta?.content ?? payload.choices?.[0]?.message?.content;
+    if (token) {
+      onToken(token);
+    }
+    return "valid";
+  } catch {
+    return "malformed";
+  }
+}
+
 async function parseSseStream(response: Response, onToken: (token: string) => void): Promise<void> {
   if (!response.body) {
     throw new Error("Streaming response body is not available");
@@ -36,50 +67,69 @@ async function parseSseStream(response: Response, onToken: (token: string) => vo
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let pendingMalformedRecord = false;
+
+  const consume = (line: string): boolean => {
+    const outcome = consumeSseLine(line, onToken);
+    if (outcome === "malformed") {
+      pendingMalformedRecord = true;
+    } else if (outcome === "valid" || outcome === "done") {
+      pendingMalformedRecord = false;
+    }
+    return outcome === "done";
+  };
 
   while (true) {
     const { done, value } = await reader.read();
-
     if (done) {
+      buffer += decoder.decode();
       break;
     }
 
     buffer += decoder.decode(value, { stream: true });
     const lines = buffer.split("\n");
     buffer = lines.pop() ?? "";
-
     for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith("data:")) {
-        continue;
-      }
-
-      const raw = trimmed.slice(5).trim();
-      if (raw === "[DONE]") {
+      if (consume(line)) {
         return;
-      }
-
-      if (!raw) {
-        continue;
-      }
-
-      try {
-        const payload = JSON.parse(raw) as {
-          choices?: Array<{ delta?: { content?: string }; message?: { content?: string } }>;
-        };
-        const token = payload.choices?.[0]?.delta?.content ?? payload.choices?.[0]?.message?.content;
-
-        if (token) {
-          onToken(token);
-        }
-      } catch {
-        // Skip malformed SSE lines without killing the stream.
       }
     }
   }
+
+  if (buffer.trim()) {
+    consume(buffer);
+  }
+  if (pendingMalformedRecord) {
+    throw new Error("Malformed terminal SSE record");
+  }
 }
 
-async function parseJsonLineStream(response: Response, onToken: (token: string) => void): Promise<void> {
+function consumeJsonLine(line: string, onToken: (token: string) => void): StreamRecordOutcome {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return "ignored";
+  }
+
+  try {
+    const payload = JSON.parse(trimmed) as {
+      message?: { content?: string };
+      response?: string;
+      done?: boolean;
+    };
+    const token = payload.message?.content ?? payload.response;
+    if (token) {
+      onToken(token);
+    }
+    return payload.done === true ? "done" : "valid";
+  } catch {
+    return "malformed";
+  }
+}
+
+async function parseJsonLineStream(
+  response: Response,
+  onToken: (token: string) => void,
+): Promise<void> {
   if (!response.body) {
     throw new Error("Streaming response body is not available");
   }
@@ -87,43 +137,40 @@ async function parseJsonLineStream(response: Response, onToken: (token: string) 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let pendingMalformedRecord = false;
+
+  const consume = (line: string): boolean => {
+    const outcome = consumeJsonLine(line, onToken);
+    if (outcome === "malformed") {
+      pendingMalformedRecord = true;
+    } else if (outcome === "valid" || outcome === "done") {
+      pendingMalformedRecord = false;
+    }
+    return outcome === "done";
+  };
 
   while (true) {
     const { done, value } = await reader.read();
-
     if (done) {
+      buffer += decoder.decode();
       break;
     }
 
     buffer += decoder.decode(value, { stream: true });
     const lines = buffer.split("\n");
     buffer = lines.pop() ?? "";
-
     for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        continue;
-      }
-
-      try {
-        const payload = JSON.parse(trimmed) as {
-          message?: { content?: string };
-          response?: string;
-          done?: boolean;
-        };
-
-        const token = payload.message?.content ?? payload.response;
-        if (token) {
-          onToken(token);
-        }
-
-        if (payload.done) {
-          return;
-        }
-      } catch {
-        // ignore bad line
+      if (consume(line)) {
+        return;
       }
     }
+  }
+
+  if (buffer.trim()) {
+    consume(buffer);
+  }
+  if (pendingMalformedRecord) {
+    throw new Error("Malformed terminal JSONL record");
   }
 }
 
@@ -214,7 +261,7 @@ const providersById: Record<LLMProviderId, LLMStreamProvider> = {
   ollama: {
     definition: definitions[1],
     async stream(config: LLMProviderConfig, request: LLMStreamRequest): Promise<void> {
-      const response = await fetch(`${trimSlash(config.baseUrl)}/api/chat`, {
+      const response = await fetch(buildLocalEndpointUrl(config.baseUrl, "/api/chat", "Ollama"), {
         method: "POST",
         signal: request.signal,
         headers: {
@@ -237,18 +284,21 @@ const providersById: Record<LLMProviderId, LLMStreamProvider> = {
   lmstudio: {
     definition: definitions[2],
     async stream(config: LLMProviderConfig, request: LLMStreamRequest): Promise<void> {
-      const response = await fetch(`${trimSlash(config.baseUrl)}/v1/chat/completions`, {
-        method: "POST",
-        signal: request.signal,
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        buildLocalEndpointUrl(config.baseUrl, "/v1/chat/completions", "LM Studio"),
+        {
+          method: "POST",
+          signal: request.signal,
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: config.model,
+            stream: true,
+            messages: buildMessages(request.prompt, request.contextSnippets),
+          }),
         },
-        body: JSON.stringify({
-          model: config.model,
-          stream: true,
-          messages: buildMessages(request.prompt, request.contextSnippets),
-        }),
-      });
+      );
 
       if (!response.ok) {
         throw new Error(`Provider request failed (${response.status})`);
@@ -267,6 +317,7 @@ const providersById: Record<LLMProviderId, LLMStreamProvider> = {
       const manager = getWebLLMEngineManager();
       await manager.ensureReady(config.model, {
         allowDownload: config.allowModelDownload === true,
+        signal: request.signal,
         onProgress: (progress, text) => {
           request.onInitProgress?.(progress, text);
         },

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -91,6 +91,9 @@ async function parseSseStream(response: Response, onToken: (token: string) => vo
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       if (consume(line)) {
+        // Release the underlying transport instead of leaving the connection
+        // draining after the terminal record has already been observed.
+        await reader.cancel().catch(() => undefined);
         return;
       }
     }
@@ -161,6 +164,9 @@ async function parseJsonLineStream(
     buffer = lines.pop() ?? "";
     for (const line of lines) {
       if (consume(line)) {
+        // Release the underlying transport instead of leaving the connection
+        // draining after the terminal record has already been observed.
+        await reader.cancel().catch(() => undefined);
         return;
       }
     }

--- a/src/llm/usageGenerationAdapter.test.ts
+++ b/src/llm/usageGenerationAdapter.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChatMessageRecord } from "../db/types";
+import { createPendingGeneration, createProviderRequestConfig } from "./generationState";
+import {
+  createUsageGenerationDependencies,
+  executeUsageGeneration,
+  type UsageGenerationBindings,
+} from "./usageGenerationAdapter";
+
+const providerDefinition = {
+  id: "lmstudio" as const,
+  label: "LM Studio",
+  kind: "local" as const,
+  defaultBaseUrl: "http://localhost:1234",
+  defaultModel: "local-model",
+  requiresApiKey: false,
+};
+
+function createStateSetter<T>(initial: T) {
+  let current = initial;
+  const setter = vi.fn((value: T | ((previous: T) => T)) => {
+    current = typeof value === "function" ? (value as (previous: T) => T)(current) : value;
+  });
+  return { setter, value: () => current };
+}
+
+function createBindings() {
+  const answer = createStateSetter("");
+  const prompt = createStateSetter("question");
+  const sessionMessages = createStateSetter<Record<string, ChatMessageRecord[]>>({});
+  const runtimeState = createStateSetter<
+    "idle" | "probing" | "ready" | "needs-consent" | "downloading" | "failed"
+  >("ready");
+  const error = createStateSetter<string | null>("old error");
+  const providerStream = vi.fn(async (_config, request) => {
+    request.onInitProgress?.(0.5, "loading");
+    request.onToken("token");
+  });
+  const bindings: UsageGenerationBindings = {
+    controllerRef: { current: null },
+    pendingGenerationRef: { current: null },
+    fallbackWebLLMModelId: "fallback-web-model",
+    providerDefinitions: [providerDefinition],
+    getDatabase: vi.fn().mockResolvedValue({
+      getNextChatMessageSequence: vi.fn().mockReturnValue(1),
+      addChatMessage: vi.fn().mockResolvedValue(undefined),
+    }),
+    getProvider: vi.fn(() => ({ definition: providerDefinition, stream: providerStream })),
+    createId: vi.fn(() => "message-id"),
+    now: vi.fn(() => 1234),
+    setGenerating: vi.fn(),
+    setAnswer: answer.setter,
+    setPrompt: prompt.setter,
+    setSessionMessages: sessionMessages.setter,
+    sortMessages: vi.fn((messages) => messages),
+    setRuntimeState: runtimeState.setter,
+    setDownloadProgress: vi.fn(),
+    setProgressText: vi.fn(),
+    setDownloadDialogOpen: vi.fn(),
+    setAllowModelDownload: vi.fn(),
+    setProviderId: vi.fn(),
+    setProviderModel: vi.fn(),
+    setProviderBaseUrl: vi.fn(),
+    setSelectedWebLLMModel: vi.fn(),
+    setError: error.setter,
+    reportError: vi.fn(),
+  };
+  return { answer, bindings, error, prompt, providerStream, runtimeState, sessionMessages };
+}
+
+function generation() {
+  return createPendingGeneration({
+    requestId: "request-id",
+    sessionId: "session-id",
+    promptText: "question",
+    snippets: ["context"],
+    providerConfig: createProviderRequestConfig({
+      providerId: "lmstudio",
+      baseUrl: "http://127.0.0.1:1234",
+      model: "local-model",
+      apiKey: "",
+      allowModelDownload: false,
+    }),
+    executionPolicy: {
+      allowLocalProvider: true,
+      allowRemoteProvider: false,
+      webllmConsent: false,
+      ollamaBaseUrl: "http://localhost:11434",
+      lmStudioBaseUrl: "http://127.0.0.1:1234",
+    },
+    userMessagePersisted: false,
+  });
+}
+
+describe("usage generation adapter", () => {
+  it("maps generation lifecycle events to page state without live provider reads", async () => {
+    const { answer, bindings, error, prompt, providerStream, runtimeState, sessionMessages } =
+      createBindings();
+    const dependencies = createUsageGenerationDependencies(bindings);
+    const message: ChatMessageRecord = {
+      id: "message-id",
+      sessionId: "session-id",
+      role: "user",
+      content: "question",
+      sequence: 1,
+      createdAt: 1234,
+    };
+
+    dependencies.onResetAnswer();
+    dependencies.onClearPrompt();
+    dependencies.onToken("first");
+    dependencies.onMessage(message);
+    dependencies.onRuntimeState("needs-consent");
+    dependencies.onDownloadRequired(generation());
+    dependencies.onWebLLMModelFallback("fallback-web-model");
+    dependencies.onProviderFallback(
+      createProviderRequestConfig({
+        providerId: "lmstudio",
+        baseUrl: "http://127.0.0.1:1234",
+        model: "local-model",
+        apiKey: "",
+        allowModelDownload: false,
+      }),
+      "LM Studio",
+    );
+    dependencies.onError(new Error("failed"), "lmstudio");
+    await dependencies.stream({
+      config: generation().providerConfig,
+      promptText: "question",
+      snippets: ["context"],
+      controller: dependencies.controller,
+      onToken: vi.fn(),
+    });
+    dependencies.onFinished();
+
+    expect(answer.value()).toBe("first");
+    expect(prompt.value()).toBe("");
+    expect(sessionMessages.value()["session-id"]).toEqual([message]);
+    expect(runtimeState.value()).toBe("downloading");
+    expect(error.value()).toBe("WebLLM failed, switched to LM Studio.");
+    expect(bindings.pendingGenerationRef.current?.requestId).toBe("request-id");
+    expect(bindings.setDownloadDialogOpen).toHaveBeenCalledWith(true);
+    expect(bindings.setProviderModel).toHaveBeenCalledWith("fallback-web-model");
+    expect(bindings.setSelectedWebLLMModel).toHaveBeenCalledWith("fallback-web-model");
+    expect(bindings.reportError).toHaveBeenCalledOnce();
+    expect(bindings.setDownloadProgress).toHaveBeenCalledWith(0.5);
+    expect(bindings.setProgressText).toHaveBeenCalledWith("loading");
+    expect(providerStream).toHaveBeenCalledOnce();
+    expect(bindings.controllerRef.current).toBeNull();
+    expect(bindings.setAllowModelDownload).toHaveBeenCalledWith(false);
+  });
+
+  it("executes a complete generation through the adapter", async () => {
+    const { bindings, sessionMessages } = createBindings();
+
+    await expect(executeUsageGeneration(generation(), bindings)).resolves.toBe("completed");
+
+    expect(sessionMessages.value()["session-id"]?.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(bindings.setGenerating).toHaveBeenNthCalledWith(1, true);
+    expect(bindings.setGenerating).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/llm/usageGenerationAdapter.test.ts
+++ b/src/llm/usageGenerationAdapter.test.ts
@@ -150,6 +150,18 @@ describe("usage generation adapter", () => {
     expect(bindings.setAllowModelDownload).toHaveBeenCalledWith(false);
   });
 
+  it("aborts a stale controller before installing a new one", () => {
+    const { bindings } = createBindings();
+    const staleController = new AbortController();
+    bindings.controllerRef.current = staleController;
+
+    const dependencies = createUsageGenerationDependencies(bindings);
+
+    expect(staleController.signal.aborted).toBe(true);
+    expect(bindings.controllerRef.current).toBe(dependencies.controller);
+    expect(bindings.controllerRef.current).not.toBe(staleController);
+  });
+
   it("executes a complete generation through the adapter", async () => {
     const { bindings, sessionMessages } = createBindings();
 

--- a/src/llm/usageGenerationAdapter.ts
+++ b/src/llm/usageGenerationAdapter.ts
@@ -44,6 +44,7 @@ export type UsageGenerationBindings = {
 export function createUsageGenerationDependencies(
   bindings: UsageGenerationBindings,
 ): GenerationExecutionDependencies {
+  bindings.controllerRef.current?.abort();
   const controller = new AbortController();
   bindings.controllerRef.current = controller;
 

--- a/src/llm/usageGenerationAdapter.ts
+++ b/src/llm/usageGenerationAdapter.ts
@@ -1,0 +1,114 @@
+import type { ChatMessageRecord } from "../db/types";
+import {
+  checkLocalProviderReachability,
+  executeGeneration,
+  streamProviderRequest,
+  type GenerationDatabase,
+  type GenerationExecutionDependencies,
+  type GenerationExecutionOutcome,
+} from "./generationExecution";
+import type { PendingGeneration } from "./generationState";
+import type { LLMProviderDefinition, LLMProviderId, LLMStreamProvider } from "./types";
+
+type StateSetter<T> = (value: T | ((previous: T) => T)) => void;
+type RuntimeState = "idle" | "probing" | "ready" | "needs-consent" | "downloading" | "failed";
+type SessionMessages = Record<string, ChatMessageRecord[]>;
+
+export type UsageGenerationBindings = {
+  controllerRef: { current: AbortController | null };
+  pendingGenerationRef: { current: PendingGeneration | null };
+  fallbackWebLLMModelId: string;
+  providerDefinitions: readonly LLMProviderDefinition[];
+  getDatabase(): Promise<GenerationDatabase>;
+  getProvider(providerId: LLMProviderId): LLMStreamProvider;
+  createId(): string;
+  now(): number;
+  setGenerating: StateSetter<boolean>;
+  setAnswer: StateSetter<string>;
+  setPrompt: StateSetter<string>;
+  setSessionMessages: StateSetter<SessionMessages>;
+  sortMessages(messages: ChatMessageRecord[]): ChatMessageRecord[];
+  setRuntimeState: StateSetter<RuntimeState>;
+  setDownloadProgress: StateSetter<number>;
+  setProgressText: StateSetter<string | null>;
+  setDownloadDialogOpen: StateSetter<boolean>;
+  setAllowModelDownload: StateSetter<boolean>;
+  setProviderId: StateSetter<LLMProviderId>;
+  setProviderModel: StateSetter<string>;
+  setProviderBaseUrl: StateSetter<string>;
+  setSelectedWebLLMModel: StateSetter<string>;
+  setError: StateSetter<string | null>;
+  reportError(error: unknown, providerId: LLMProviderId): void;
+};
+
+export function createUsageGenerationDependencies(
+  bindings: UsageGenerationBindings,
+): GenerationExecutionDependencies {
+  const controller = new AbortController();
+  bindings.controllerRef.current = controller;
+
+  return {
+    controller,
+    fallbackWebLLMModelId: bindings.fallbackWebLLMModelId,
+    getDatabase: bindings.getDatabase,
+    providerDefinitions: bindings.providerDefinitions,
+    canReachLocalProvider: checkLocalProviderReachability,
+    createId: bindings.createId,
+    now: bindings.now,
+    stream: (args) =>
+      streamProviderRequest(
+        args,
+        bindings.getProvider(args.config.providerId),
+        (progress, text) => {
+          bindings.setDownloadProgress(progress);
+          bindings.setProgressText(text);
+          bindings.setRuntimeState("downloading");
+        },
+      ),
+    onGeneratingChange: bindings.setGenerating,
+    onResetAnswer: () => {
+      bindings.setError(null);
+      bindings.setAnswer("");
+    },
+    onClearPrompt: () => bindings.setPrompt(""),
+    onToken: (token) => bindings.setAnswer((previous) => previous + token),
+    onMessage: (message) =>
+      bindings.setSessionMessages((previous) => ({
+        ...previous,
+        [message.sessionId]: bindings.sortMessages([
+          ...(previous[message.sessionId] ?? []),
+          message,
+        ]),
+      })),
+    onRuntimeState: bindings.setRuntimeState,
+    onDownloadRequired: (pending) => {
+      bindings.pendingGenerationRef.current = pending;
+      bindings.setDownloadDialogOpen(true);
+      bindings.setError(null);
+    },
+    onWebLLMModelFallback: (model) => {
+      bindings.setProviderModel(model);
+      bindings.setSelectedWebLLMModel(model);
+    },
+    onProviderFallback: (config, label) => {
+      bindings.setProviderId(config.providerId);
+      bindings.setProviderModel(config.model);
+      bindings.setProviderBaseUrl(config.baseUrl);
+      bindings.setError(`WebLLM failed, switched to ${label}.`);
+    },
+    onError: bindings.reportError,
+    onFinished: () => {
+      if (bindings.controllerRef.current === controller) {
+        bindings.controllerRef.current = null;
+      }
+      bindings.setAllowModelDownload(false);
+    },
+  };
+}
+
+export function executeUsageGeneration(
+  generation: PendingGeneration,
+  bindings: UsageGenerationBindings,
+): Promise<GenerationExecutionOutcome> {
+  return executeGeneration(generation, createUsageGenerationDependencies(bindings));
+}

--- a/src/llm/webllm/engine.test.ts
+++ b/src/llm/webllm/engine.test.ts
@@ -1,5 +1,5 @@
 import { CreateMLCEngine } from "@mlc-ai/web-llm";
-import type { MLCEngine } from "@mlc-ai/web-llm";
+import type { InitProgressReport, MLCEngine } from "@mlc-ai/web-llm";
 import { WebLLMEngineManager } from "./engine";
 
 vi.mock("@mlc-ai/web-llm", () => ({
@@ -262,6 +262,131 @@ describe("WebLLMEngineManager", () => {
     expect(onProgress).toHaveBeenNthCalledWith(1, 1, "initializing");
     expect(onProgress).toHaveBeenNthCalledWith(2, 0, "Preparing model");
     expect(engine.reload).toHaveBeenCalledWith("model-b");
+  });
+
+  test("forwards ongoing initialization progress to a joined waiter after the initiator aborts", async () => {
+    const engine = mockEngine();
+    const initialization = deferred<MLCEngine>();
+    let emitProgress: ((report: InitProgressReport) => void) | undefined;
+    vi.mocked(CreateMLCEngine).mockImplementation(async (_modelId, options) => {
+      emitProgress = options?.initProgressCallback;
+      return initialization.promise;
+    });
+    const manager = new WebLLMEngineManager();
+    const initiator = new AbortController();
+    const joiner = new AbortController();
+    const initiatorProgress = vi.fn();
+    const joinerProgress = vi.fn();
+
+    const initiatorWaiter = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: initiator.signal,
+      onProgress: initiatorProgress,
+    });
+    const joinerWaiter = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: joiner.signal,
+      onProgress: joinerProgress,
+    });
+
+    // The caller that started the shared load abandons it before it finishes.
+    initiator.abort();
+    await expect(initiatorWaiter).rejects.toMatchObject({ name: "AbortError" });
+
+    // The joined waiter must still receive ongoing initialization progress from
+    // the shared load, which is not restarted.
+    emitProgress?.({ progress: 0.5, text: "loading shards", timeElapsed: 0 });
+    expect(joinerProgress).toHaveBeenCalledWith(0.5, "loading shards");
+    expect(initiatorProgress).not.toHaveBeenCalled();
+
+    initialization.resolve(engine);
+    await expect(joinerWaiter).resolves.toBeUndefined();
+    expect(CreateMLCEngine).toHaveBeenCalledOnce();
+  });
+
+  test("scopes shared-load progress to the loading model so a queued waiter for another model is not fed the first model's progress", async () => {
+    const engine = mockEngine();
+    const initialization = deferred<MLCEngine>();
+    let emitInitProgress: ((report: InitProgressReport) => void) | undefined;
+    vi.mocked(CreateMLCEngine).mockImplementation(async (_modelId, options) => {
+      emitInitProgress = options?.initProgressCallback;
+      return initialization.promise;
+    });
+    const reloadStarted = deferred<void>();
+    vi.mocked(engine.reload).mockImplementation(async () => {
+      const reloadProgress = vi.mocked(engine.setInitProgressCallback).mock.calls[0]?.[0];
+      reloadProgress?.({ progress: 0.8, text: "loading model-b", timeElapsed: 0 });
+      reloadStarted.resolve();
+    });
+    const manager = new WebLLMEngineManager();
+    const aProgress = vi.fn();
+    const bProgress = vi.fn();
+
+    const aWaiter = manager.ensureReady("model-a", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+      onProgress: aProgress,
+    });
+    // A waiter for a different model joins while model-a's shared load is in flight.
+    const bWaiter = manager.ensureReady("model-b", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+      onProgress: bProgress,
+    });
+
+    // model-a's progress must reach only the model-a waiter, never the queued
+    // model-b waiter.
+    emitInitProgress?.({ progress: 0.5, text: "loading model-a", timeElapsed: 0 });
+    expect(aProgress).toHaveBeenCalledWith(0.5, "loading model-a");
+    expect(bProgress).not.toHaveBeenCalled();
+
+    // model-a finishes without being restarted; the model-b waiter then drives
+    // the reload to model-b and must still receive its own progress.
+    initialization.resolve(engine);
+    await aWaiter;
+    await reloadStarted.promise;
+    await bWaiter;
+
+    expect(bProgress).toHaveBeenCalledWith(0.8, "loading model-b");
+    expect(aProgress).toHaveBeenCalledTimes(1);
+    expect(engine.reload).toHaveBeenCalledWith("model-b");
+    expect(CreateMLCEngine).toHaveBeenCalledOnce();
+  });
+
+  test("a throwing progress listener neither breaks initialization nor starves other listeners", async () => {
+    const engine = mockEngine();
+    const boom = vi.fn(() => {
+      throw new Error("listener boom");
+    });
+    const healthy = vi.fn();
+    vi.mocked(CreateMLCEngine).mockImplementation(async (_modelId, options) => {
+      // Defer emission by a microtask so both waiters register before progress
+      // fans out, then emit as WebLLM would during initialization.
+      await Promise.resolve();
+      options?.initProgressCallback?.({ progress: 0.5, text: "loading", timeElapsed: 0 });
+      return engine;
+    });
+    const manager = new WebLLMEngineManager();
+
+    const throwingWaiter = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+      onProgress: boom,
+    });
+    const healthyWaiter = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+      onProgress: healthy,
+    });
+
+    // A misbehaving listener must not fail the shared initialization for either
+    // caller, and must not prevent the healthy listener from observing progress.
+    await expect(Promise.all([throwingWaiter, healthyWaiter])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(boom).toHaveBeenCalledWith(0.5, "loading");
+    expect(healthy).toHaveBeenCalledWith(0.5, "loading");
   });
 
   test("clears a rejected initialization so a later attempt can recover", async () => {

--- a/src/llm/webllm/engine.test.ts
+++ b/src/llm/webllm/engine.test.ts
@@ -1,0 +1,293 @@
+import { CreateMLCEngine } from "@mlc-ai/web-llm";
+import type { MLCEngine } from "@mlc-ai/web-llm";
+import { WebLLMEngineManager } from "./engine";
+
+vi.mock("@mlc-ai/web-llm", () => ({
+  CreateMLCEngine: vi.fn(),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function mockEngine(): MLCEngine {
+  return {
+    chat: { completions: { create: vi.fn() } },
+    interruptGenerate: vi.fn(),
+    reload: vi.fn(),
+    setInitProgressCallback: vi.fn(),
+    unload: vi.fn(),
+  } as unknown as MLCEngine;
+}
+
+describe("WebLLMEngineManager", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", { gpu: {} });
+    vi.mocked(CreateMLCEngine).mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("an initialization waiter rejects promptly when aborted", async () => {
+    const initialization = deferred<MLCEngine>();
+    vi.mocked(CreateMLCEngine).mockReturnValue(initialization.promise);
+    const manager = new WebLLMEngineManager();
+    const controller = new AbortController();
+
+    const pending = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(CreateMLCEngine).toHaveBeenCalledOnce();
+
+    initialization.resolve(mockEngine());
+    await initialization.promise;
+  });
+
+  test("an aborted waiter does not clear initialization shared by another caller", async () => {
+    const initialization = deferred<MLCEngine>();
+    vi.mocked(CreateMLCEngine).mockReturnValue(initialization.promise);
+    const manager = new WebLLMEngineManager();
+    const cancelled = new AbortController();
+    const active = new AbortController();
+
+    const cancelledWaiter = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: cancelled.signal,
+    });
+    const activeWaiter = manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: active.signal,
+    });
+    cancelled.abort();
+
+    await expect(cancelledWaiter).rejects.toMatchObject({ name: "AbortError" });
+    initialization.resolve(mockEngine());
+    await expect(activeWaiter).resolves.toBeUndefined();
+    expect(CreateMLCEngine).toHaveBeenCalledOnce();
+  });
+
+  test("a pre-aborted stream never invokes chat completion creation", async () => {
+    const engine = mockEngine();
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      manager.stream(
+        "test-model",
+        [{ role: "user", content: "hello" }],
+        controller.signal,
+        vi.fn(),
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(engine.chat.completions.create).not.toHaveBeenCalled();
+  });
+
+  test("aborts promptly while stream creation is pending", async () => {
+    const engine = mockEngine();
+    const creation = deferred<AsyncIterable<never>>();
+    vi.mocked(engine.chat.completions.create).mockReturnValue(creation.promise as never);
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+    const controller = new AbortController();
+    const onToken = vi.fn();
+
+    const pending = manager.stream(
+      "test-model",
+      [{ role: "user", content: "hello" }],
+      controller.signal,
+      onToken,
+    );
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(engine.interruptGenerate).toHaveBeenCalledOnce();
+    expect(onToken).not.toHaveBeenCalled();
+    creation.resolve({
+      async *[Symbol.asyncIterator]() {
+        yield undefined as never;
+      },
+    });
+    await creation.promise;
+  });
+
+  test("aborts promptly while an iterator read is stalled and emits no later token", async () => {
+    const engine = mockEngine();
+    const read = deferred<IteratorResult<{ choices: Array<{ delta: { content: string } }> }>>();
+    const iterator = {
+      next: vi.fn(() => read.promise),
+      return: vi.fn(async () => ({ done: true, value: undefined })),
+    };
+    vi.mocked(engine.chat.completions.create).mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    } as never);
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+    const controller = new AbortController();
+    const onToken = vi.fn();
+    const pending = manager.stream(
+      "test-model",
+      [{ role: "user", content: "hello" }],
+      controller.signal,
+      onToken,
+    );
+    await vi.waitFor(() => expect(iterator.next).toHaveBeenCalledOnce());
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(engine.interruptGenerate).toHaveBeenCalledOnce();
+    expect(iterator.return).toHaveBeenCalledOnce();
+    read.resolve({
+      done: false,
+      value: { choices: [{ delta: { content: "too late" } }] },
+    });
+    await read.promise;
+    expect(onToken).not.toHaveBeenCalled();
+  });
+
+  test("removes the abort listener after a successful stream", async () => {
+    const engine = mockEngine();
+    vi.mocked(engine.chat.completions.create).mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { choices: [{ delta: { content: "done" } }] };
+      },
+    } as never);
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    const controller = new AbortController();
+    const onToken = vi.fn();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: controller.signal,
+    });
+
+    await manager.stream(
+      "test-model",
+      [{ role: "user", content: "hello" }],
+      controller.signal,
+      onToken,
+    );
+    controller.abort();
+
+    expect(onToken).toHaveBeenCalledOnce();
+    expect(onToken).toHaveBeenCalledWith("done");
+    expect(engine.interruptGenerate).not.toHaveBeenCalled();
+  });
+
+  test("interrupt rejection cannot replace AbortError or become unhandled", async () => {
+    const engine = mockEngine();
+    const read = deferred<IteratorResult<never>>();
+    const iterator = { next: vi.fn(() => read.promise) };
+    vi.mocked(engine.chat.completions.create).mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    } as never);
+    vi.mocked(engine.interruptGenerate).mockRejectedValue(new Error("interrupt failed"));
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+    const controller = new AbortController();
+    const pending = manager.stream(
+      "test-model",
+      [{ role: "user", content: "hello" }],
+      controller.signal,
+      vi.fn(),
+    );
+    await vi.waitFor(() => expect(iterator.next).toHaveBeenCalledOnce());
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(engine.interruptGenerate).toHaveBeenCalledOnce();
+    await Promise.resolve();
+    read.resolve({ done: true, value: undefined as never });
+  });
+
+  test("reports unsupported WebGPU before attempting initialization", async () => {
+    vi.stubGlobal("navigator", {});
+    const manager = new WebLLMEngineManager();
+
+    await expect(
+      manager.ensureReady("test-model", {
+        allowDownload: true,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ code: "WEBLLM_UNSUPPORTED" });
+    expect(CreateMLCEngine).not.toHaveBeenCalled();
+  });
+
+  test("forwards bounded initialization and reload progress", async () => {
+    const engine = mockEngine();
+    const onProgress = vi.fn();
+    vi.mocked(CreateMLCEngine).mockImplementation(async (_modelId, options) => {
+      options?.initProgressCallback?.({ progress: 2, text: "initializing", timeElapsed: 0 });
+      return engine;
+    });
+    vi.mocked(engine.reload).mockImplementation(async () => {
+      const progressCallback = vi.mocked(engine.setInitProgressCallback).mock.calls[0]?.[0];
+      progressCallback?.({ progress: Number.NaN, text: "", timeElapsed: 0 });
+    });
+    const manager = new WebLLMEngineManager();
+    const signal = new AbortController().signal;
+
+    await manager.ensureReady("model-a", { allowDownload: true, signal, onProgress });
+    await manager.ensureReady("model-b", { allowDownload: true, signal, onProgress });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, 1, "initializing");
+    expect(onProgress).toHaveBeenNthCalledWith(2, 0, "Preparing model");
+    expect(engine.reload).toHaveBeenCalledWith("model-b");
+  });
+
+  test("clears a rejected initialization so a later attempt can recover", async () => {
+    vi.mocked(CreateMLCEngine)
+      .mockRejectedValueOnce(new Error("download failed"))
+      .mockResolvedValueOnce(mockEngine());
+    const manager = new WebLLMEngineManager();
+    const options = { allowDownload: true, signal: new AbortController().signal };
+
+    await expect(manager.ensureReady("test-model", options)).rejects.toMatchObject({
+      code: "WEBLLM_INIT_FAILED",
+    });
+    await expect(manager.ensureReady("test-model", options)).resolves.toBeUndefined();
+    expect(CreateMLCEngine).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects streaming before the selected model is initialized", async () => {
+    const manager = new WebLLMEngineManager();
+
+    await expect(
+      manager.stream(
+        "test-model",
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        vi.fn(),
+      ),
+    ).rejects.toMatchObject({ code: "WEBLLM_INIT_FAILED" });
+  });
+});

--- a/src/llm/webllm/engine.test.ts
+++ b/src/llm/webllm/engine.test.ts
@@ -199,6 +199,98 @@ describe("WebLLMEngineManager", () => {
     expect(engine.interruptGenerate).not.toHaveBeenCalled();
   });
 
+  test("closes the iterator via return when an iterator read rejects", async () => {
+    const engine = mockEngine();
+    const iterator = {
+      next: vi.fn().mockRejectedValue(new Error("stream boom")),
+      return: vi.fn(async () => ({ done: true, value: undefined })),
+    };
+    vi.mocked(engine.chat.completions.create).mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    } as never);
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+
+    await expect(
+      manager.stream(
+        "test-model",
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        vi.fn(),
+      ),
+    ).rejects.toMatchObject({ code: "WEBLLM_STREAM_FAILED" });
+    expect(iterator.return).toHaveBeenCalledOnce();
+    expect(engine.interruptGenerate).not.toHaveBeenCalled();
+  });
+
+  test("closes the iterator via return when the token sink throws", async () => {
+    const engine = mockEngine();
+    const iterator = {
+      next: vi
+        .fn()
+        .mockResolvedValue({ done: false, value: { choices: [{ delta: { content: "tok" } }] } }),
+      return: vi.fn(async () => ({ done: true, value: undefined })),
+    };
+    vi.mocked(engine.chat.completions.create).mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    } as never);
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+    const onToken = vi.fn(() => {
+      throw new Error("sink boom");
+    });
+
+    await expect(
+      manager.stream(
+        "test-model",
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        onToken,
+      ),
+    ).rejects.toMatchObject({ code: "WEBLLM_STREAM_FAILED" });
+    expect(onToken).toHaveBeenCalledOnce();
+    expect(iterator.return).toHaveBeenCalledOnce();
+  });
+
+  test("does not close the iterator via return after normal completion", async () => {
+    const engine = mockEngine();
+    const iterator = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: { choices: [{ delta: { content: "tok" } }] } })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      return: vi.fn(async () => ({ done: true, value: undefined })),
+    };
+    vi.mocked(engine.chat.completions.create).mockResolvedValue({
+      [Symbol.asyncIterator]: () => iterator,
+    } as never);
+    vi.mocked(CreateMLCEngine).mockResolvedValue(engine);
+    const manager = new WebLLMEngineManager();
+    await manager.ensureReady("test-model", {
+      allowDownload: true,
+      signal: new AbortController().signal,
+    });
+    const onToken = vi.fn();
+
+    await manager.stream(
+      "test-model",
+      [{ role: "user", content: "hello" }],
+      new AbortController().signal,
+      onToken,
+    );
+
+    expect(onToken).toHaveBeenCalledExactlyOnceWith("tok");
+    expect(iterator.return).not.toHaveBeenCalled();
+  });
+
   test("interrupt rejection cannot replace AbortError or become unhandled", async () => {
     const engine = mockEngine();
     const read = deferred<IteratorResult<never>>();

--- a/src/llm/webllm/engine.ts
+++ b/src/llm/webllm/engine.ts
@@ -1,8 +1,4 @@
-import type {
-  ChatCompletionChunk,
-  InitProgressReport,
-  MLCEngineInterface,
-} from "@mlc-ai/web-llm";
+import type { ChatCompletionChunk, InitProgressReport, MLCEngineInterface } from "@mlc-ai/web-llm";
 import { CreateMLCEngine } from "@mlc-ai/web-llm";
 
 export type WebLLMErrorCode =
@@ -23,10 +19,44 @@ export class WebLLMProviderError extends Error {
 
 export type WebLLMEnsureReadyOptions = {
   allowDownload: boolean;
+  signal: AbortSignal;
   onProgress?: (progress: number, text: string) => void;
 };
 
-class WebLLMEngineManager {
+function abortError(): DOMException {
+  return new DOMException("aborted", "AbortError");
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw abortError();
+  }
+}
+
+async function waitWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  throwIfAborted(signal);
+
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = () => finish(() => reject(abortError()));
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => finish(() => resolve(value)),
+      (error: unknown) => finish(() => reject(error)),
+    );
+  });
+}
+
+export class WebLLMEngineManager {
   private engine: MLCEngineInterface | null = null;
 
   private activeModelId: string | null = null;
@@ -46,8 +76,13 @@ class WebLLMEngineManager {
   }
 
   async ensureReady(modelId: string, options: WebLLMEnsureReadyOptions): Promise<void> {
+    throwIfAborted(options.signal);
+
     if (!this.supportsWebGPU()) {
-      throw new WebLLMProviderError("WEBLLM_UNSUPPORTED", "WebGPU is not available in this browser.");
+      throw new WebLLMProviderError(
+        "WEBLLM_UNSUPPORTED",
+        "WebGPU is not available in this browser.",
+      );
     }
 
     if (this.engine && this.activeModelId === modelId) {
@@ -62,19 +97,23 @@ class WebLLMEngineManager {
     }
 
     if (this.loadingPromise) {
-      await this.loadingPromise;
+      await waitWithAbort(this.loadingPromise, options.signal);
+      throwIfAborted(options.signal);
       if (this.engine && this.activeModelId === modelId) {
         return;
       }
     }
 
-    this.loadingPromise = (async () => {
+    throwIfAborted(options.signal);
+    const loadingPromise = (async () => {
       try {
         if (!this.engine) {
           this.engine = await CreateMLCEngine(modelId, {
             initProgressCallback: (report) => {
               const next = this.toProgress(report);
-              options.onProgress?.(next.progress, next.text);
+              if (!options.signal.aborted) {
+                options.onProgress?.(next.progress, next.text);
+              }
             },
             logLevel: "INFO",
           });
@@ -84,7 +123,9 @@ class WebLLMEngineManager {
 
         this.engine.setInitProgressCallback((report) => {
           const next = this.toProgress(report);
-          options.onProgress?.(next.progress, next.text);
+          if (!options.signal.aborted) {
+            options.onProgress?.(next.progress, next.text);
+          }
         });
         await this.engine.reload(modelId);
         this.activeModelId = modelId;
@@ -93,12 +134,21 @@ class WebLLMEngineManager {
         throw new WebLLMProviderError("WEBLLM_INIT_FAILED", `WebLLM init failed: ${message}`);
       }
     })();
+    this.loadingPromise = loadingPromise;
+    void loadingPromise.then(
+      () => {
+        if (this.loadingPromise === loadingPromise) {
+          this.loadingPromise = null;
+        }
+      },
+      () => {
+        if (this.loadingPromise === loadingPromise) {
+          this.loadingPromise = null;
+        }
+      },
+    );
 
-    try {
-      await this.loadingPromise;
-    } finally {
-      this.loadingPromise = null;
-    }
+    await waitWithAbort(loadingPromise, options.signal);
   }
 
   async stream(
@@ -107,6 +157,8 @@ class WebLLMEngineManager {
     signal: AbortSignal,
     onToken: (token: string) => void,
   ): Promise<void> {
+    throwIfAborted(signal);
+
     if (!this.engine || this.activeModelId !== modelId) {
       throw new WebLLMProviderError(
         "WEBLLM_INIT_FAILED",
@@ -114,20 +166,44 @@ class WebLLMEngineManager {
       );
     }
 
-    try {
-      const chunkStream = await this.engine.chat.completions.create({
-        model: modelId,
-        messages,
-        stream: true,
-        temperature: 0.2,
-        max_tokens: 700,
-      });
+    const engine = this.engine;
+    let interrupted = false;
+    let iterator: AsyncIterator<ChatCompletionChunk> | null = null;
+    const interrupt = () => {
+      if (interrupted) {
+        return;
+      }
+      interrupted = true;
+      try {
+        void Promise.resolve(engine.interruptGenerate()).catch(() => undefined);
+      } catch {
+        // Cancellation must still settle even if the runtime cannot interrupt cleanly.
+      }
+    };
+    const onAbort = () => interrupt();
+    signal.addEventListener("abort", onAbort, { once: true });
 
-      for await (const chunk of chunkStream as AsyncIterable<ChatCompletionChunk>) {
-        if (signal.aborted) {
-          throw new DOMException("aborted", "AbortError");
+    try {
+      throwIfAborted(signal);
+      const chunkStream = await waitWithAbort(
+        engine.chat.completions.create({
+          model: modelId,
+          messages,
+          stream: true,
+          temperature: 0.2,
+          max_tokens: 700,
+        }),
+        signal,
+      );
+      iterator = (chunkStream as AsyncIterable<ChatCompletionChunk>)[Symbol.asyncIterator]();
+
+      while (true) {
+        const result = await waitWithAbort(iterator.next(), signal);
+        if (result.done) {
+          break;
         }
-        const token = chunk.choices?.[0]?.delta?.content ?? "";
+        throwIfAborted(signal);
+        const token = result.value.choices?.[0]?.delta?.content ?? "";
         if (token.length > 0) {
           onToken(token);
         }
@@ -139,6 +215,15 @@ class WebLLMEngineManager {
 
       const message = error instanceof Error ? error.message : String(error);
       throw new WebLLMProviderError("WEBLLM_STREAM_FAILED", `WebLLM stream failed: ${message}`);
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+      if (signal.aborted && iterator?.return) {
+        try {
+          void Promise.resolve(iterator.return()).catch(() => undefined);
+        } catch {
+          // The abort result remains authoritative even if iterator cleanup fails.
+        }
+      }
     }
   }
 

--- a/src/llm/webllm/engine.ts
+++ b/src/llm/webllm/engine.ts
@@ -199,6 +199,7 @@ export class WebLLMEngineManager {
 
     const engine = this.engine;
     let interrupted = false;
+    let completed = false;
     let iterator: AsyncIterator<ChatCompletionChunk> | null = null;
     const interrupt = () => {
       if (interrupted) {
@@ -231,6 +232,7 @@ export class WebLLMEngineManager {
       while (true) {
         const result = await waitWithAbort(iterator.next(), signal);
         if (result.done) {
+          completed = true;
           break;
         }
         throwIfAborted(signal);
@@ -248,11 +250,14 @@ export class WebLLMEngineManager {
       throw new WebLLMProviderError("WEBLLM_STREAM_FAILED", `WebLLM stream failed: ${message}`);
     } finally {
       signal.removeEventListener("abort", onAbort);
-      if (signal.aborted && iterator?.return) {
+      // Close the underlying generator whenever iteration exits abnormally (abort,
+      // a rejected read, or a throwing token sink) so its resources are released.
+      // Normal completion already exhausts the iterator, so return() is skipped.
+      if (!completed && iterator?.return) {
         try {
           void Promise.resolve(iterator.return()).catch(() => undefined);
         } catch {
-          // The abort result remains authoritative even if iterator cleanup fails.
+          // The stream failure remains authoritative even if iterator cleanup fails.
         }
       }
     }

--- a/src/llm/webllm/engine.ts
+++ b/src/llm/webllm/engine.ts
@@ -63,6 +63,21 @@ export class WebLLMEngineManager {
 
   private loadingPromise: Promise<void> | null = null;
 
+  private readonly progressListeners = new Set<
+    (modelId: string, progress: number, text: string) => void
+  >();
+
+  private emitProgress(modelId: string, progress: number, text: string): void {
+    for (const listener of this.progressListeners) {
+      try {
+        listener(modelId, progress, text);
+      } catch {
+        // A misbehaving progress sink must neither abort the shared load nor
+        // prevent the remaining listeners from observing progress.
+      }
+    }
+  }
+
   private supportsWebGPU(): boolean {
     const nav = navigator as Navigator & { gpu?: object };
     return typeof nav.gpu !== "undefined";
@@ -96,59 +111,75 @@ export class WebLLMEngineManager {
       );
     }
 
-    if (this.loadingPromise) {
-      await waitWithAbort(this.loadingPromise, options.signal);
-      throwIfAborted(options.signal);
-      if (this.engine && this.activeModelId === modelId) {
-        return;
+    // Every caller that waits on the shared load registers its own progress
+    // sink. The engine forwards a single progress stream (see emitProgress) to
+    // all live waiters, so a caller that joins an in-flight load still receives
+    // ongoing progress even after the caller that started the load aborts. Each
+    // sink is scoped to the model it is waiting for: a waiter queued for model B
+    // ignores model A's progress while A loads, and starts receiving progress
+    // once B's reload begins — the shared load is never restarted. The listener
+    // is removed once this caller stops waiting, keeping cleanup deterministic
+    // and preventing forwarding to an aborted caller.
+    const listener = (loadedModelId: string, progress: number, text: string) => {
+      if (loadedModelId === modelId && !options.signal.aborted) {
+        options.onProgress?.(progress, text);
       }
-    }
+    };
+    this.progressListeners.add(listener);
 
-    throwIfAborted(options.signal);
-    const loadingPromise = (async () => {
-      try {
-        if (!this.engine) {
-          this.engine = await CreateMLCEngine(modelId, {
-            initProgressCallback: (report) => {
-              const next = this.toProgress(report);
-              if (!options.signal.aborted) {
-                options.onProgress?.(next.progress, next.text);
-              }
-            },
-            logLevel: "INFO",
-          });
-          this.activeModelId = modelId;
+    try {
+      if (this.loadingPromise) {
+        await waitWithAbort(this.loadingPromise, options.signal);
+        throwIfAborted(options.signal);
+        if (this.engine && this.activeModelId === modelId) {
           return;
         }
-
-        this.engine.setInitProgressCallback((report) => {
-          const next = this.toProgress(report);
-          if (!options.signal.aborted) {
-            options.onProgress?.(next.progress, next.text);
-          }
-        });
-        await this.engine.reload(modelId);
-        this.activeModelId = modelId;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new WebLLMProviderError("WEBLLM_INIT_FAILED", `WebLLM init failed: ${message}`);
       }
-    })();
-    this.loadingPromise = loadingPromise;
-    void loadingPromise.then(
-      () => {
-        if (this.loadingPromise === loadingPromise) {
-          this.loadingPromise = null;
-        }
-      },
-      () => {
-        if (this.loadingPromise === loadingPromise) {
-          this.loadingPromise = null;
-        }
-      },
-    );
 
-    await waitWithAbort(loadingPromise, options.signal);
+      throwIfAborted(options.signal);
+      const loadingPromise = (async () => {
+        try {
+          if (!this.engine) {
+            this.engine = await CreateMLCEngine(modelId, {
+              initProgressCallback: (report) => {
+                const next = this.toProgress(report);
+                this.emitProgress(modelId, next.progress, next.text);
+              },
+              logLevel: "INFO",
+            });
+            this.activeModelId = modelId;
+            return;
+          }
+
+          this.engine.setInitProgressCallback((report) => {
+            const next = this.toProgress(report);
+            this.emitProgress(modelId, next.progress, next.text);
+          });
+          await this.engine.reload(modelId);
+          this.activeModelId = modelId;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new WebLLMProviderError("WEBLLM_INIT_FAILED", `WebLLM init failed: ${message}`);
+        }
+      })();
+      this.loadingPromise = loadingPromise;
+      void loadingPromise.then(
+        () => {
+          if (this.loadingPromise === loadingPromise) {
+            this.loadingPromise = null;
+          }
+        },
+        () => {
+          if (this.loadingPromise === loadingPromise) {
+            this.loadingPromise = null;
+          }
+        },
+      );
+
+      await waitWithAbort(loadingPromise, options.signal);
+    } finally {
+      this.progressListeners.delete(listener);
+    }
   }
 
   async stream(

--- a/src/ollama/modelCatalog.test.ts
+++ b/src/ollama/modelCatalog.test.ts
@@ -15,7 +15,11 @@ describe("buildOllamaModelCatalogFromPayload", () => {
       "llama3.1:8b",
     );
 
-    expect(catalog.embedding).toEqual(["qwen3-embedding:0.6b", "mxbai-embed-large", "nomic-embed-text"]);
+    expect(catalog.embedding).toEqual([
+      "qwen3-embedding:0.6b",
+      "mxbai-embed-large",
+      "nomic-embed-text",
+    ]);
     expect(catalog.llm).toEqual(["llama3.1:8b"]);
     expect(catalog.recommendedEmbedding).toBe("qwen3-embedding:0.6b");
     expect(catalog.recommendedLlm).toBe("llama3.1:8b");
@@ -50,11 +54,7 @@ describe("buildOllamaModelCatalogFromPayload", () => {
   test("deduplicates and sorts model names", () => {
     const catalog = buildOllamaModelCatalogFromPayload(
       {
-        models: [
-          { name: "llama3.1:8b" },
-          { name: "llama3.1:8b" },
-          { name: "nomic-embed-text" },
-        ],
+        models: [{ name: "llama3.1:8b" }, { name: "llama3.1:8b" }, { name: "nomic-embed-text" }],
       },
       null,
     );
@@ -67,10 +67,7 @@ describe("fetchOllamaModelCatalog", () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
-          models: [
-            { name: "nomic-embed-text" },
-            { name: "llama3.1:8b" },
-          ],
+          models: [{ name: "nomic-embed-text" }, { name: "llama3.1:8b" }],
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       ),
@@ -78,22 +75,36 @@ describe("fetchOllamaModelCatalog", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const catalog = await fetchOllamaModelCatalog({
-      baseUrl: "http://localhost:11434",
+      baseUrl: "http://127.99.42.7:11434/proxy/",
       timeoutMs: 10_000,
       preferredLlmModel: "llama3.1:8b",
     });
 
     expect(catalog.embedding).toContain("nomic-embed-text");
     expect(catalog.llm).toContain("llama3.1:8b");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.99.42.7:11434/proxy/api/tags",
+      expect.objectContaining({ method: "GET" }),
+    );
   });
 
-  test("rejects non-local endpoint", async () => {
+  test.each([
+    "https://example.com",
+    "http://localhost.example.com:11434",
+    "http://127.0.0.1.example.com",
+    "http://user@localhost:11434",
+    "ftp://localhost:11434",
+  ])("rejects unsafe endpoint %s before model discovery", async (baseUrl) => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
     await expect(
       fetchOllamaModelCatalog({
-        baseUrl: "https://example.com",
+        baseUrl,
         timeoutMs: 10_000,
         preferredLlmModel: null,
       }),
-    ).rejects.toThrow("localhost");
+    ).rejects.toThrow(/endpoint/u);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/ollama/modelCatalog.ts
+++ b/src/ollama/modelCatalog.ts
@@ -1,4 +1,5 @@
-const LOCAL_ENDPOINT_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/i;
+import { buildLocalEndpointUrl, normalizeLocalEndpoint } from "../llm/localEndpoint";
+
 const DEFAULT_EMBEDDING_MODEL = "qwen3-embedding:0.6b";
 const EMBEDDING_RECOMMENDATION_ORDER = [
   "qwen3-embedding:4b",
@@ -45,10 +46,6 @@ function asString(value: JsonValue | null | undefined): string | null {
   return value;
 }
 
-function isLocalEndpoint(baseUrl: string): boolean {
-  return LOCAL_ENDPOINT_PATTERN.test(baseUrl);
-}
-
 function normalizeModelName(name: string): string {
   return name.trim();
 }
@@ -58,10 +55,11 @@ function parseFamilies(details: JsonObject | null): string[] {
     return [];
   }
   const family = asString(details.family);
-  const families = asArray(details.families)
-    ?.map((value) => asString(value))
-    .filter((value): value is string => Boolean(value && value.trim()))
-    .map((value) => value.trim()) ?? [];
+  const families =
+    asArray(details.families)
+      ?.map((value) => asString(value))
+      .filter((value): value is string => Boolean(value && value.trim()))
+      .map((value) => value.trim()) ?? [];
 
   if (family && family.trim()) {
     return Array.from(new Set([family.trim(), ...families]));
@@ -153,8 +151,12 @@ export function buildOllamaModelCatalogFromPayload(
 ): OllamaModelCatalog {
   const entries = parseModelEntries(payload);
   const all = uniqueSorted(entries.map((entry) => entry.name));
-  const embedding = orderEmbeddingModels(entries.filter((entry) => isEmbeddingModel(entry)).map((entry) => entry.name));
-  const llm = uniqueSorted(entries.filter((entry) => !isEmbeddingModel(entry)).map((entry) => entry.name));
+  const embedding = orderEmbeddingModels(
+    entries.filter((entry) => isEmbeddingModel(entry)).map((entry) => entry.name),
+  );
+  const llm = uniqueSorted(
+    entries.filter((entry) => !isEmbeddingModel(entry)).map((entry) => entry.name),
+  );
   const normalizedPreferredLlm = preferredLlmModel ? preferredLlmModel.trim() : "";
 
   return {
@@ -162,7 +164,10 @@ export function buildOllamaModelCatalogFromPayload(
     embedding,
     llm,
     recommendedEmbedding: pickRecommendedEmbedding(embedding),
-    recommendedLlm: normalizedPreferredLlm && llm.includes(normalizedPreferredLlm) ? normalizedPreferredLlm : llm[0] ?? null,
+    recommendedLlm:
+      normalizedPreferredLlm && llm.includes(normalizedPreferredLlm)
+        ? normalizedPreferredLlm
+        : (llm[0] ?? null),
   };
 }
 
@@ -182,14 +187,14 @@ async function extractErrorMessage(response: Response): Promise<string> {
 
 async function fetchWithTimeout(
   baseUrl: string,
-  path: string,
+  path: `/${string}`,
   timeoutMs: number,
   init: RequestInit,
 ): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(`${baseUrl}${path}`, {
+    return await fetch(buildLocalEndpointUrl(baseUrl, path, "Ollama"), {
       ...init,
       signal: controller.signal,
     });
@@ -208,14 +213,16 @@ export async function fetchOllamaModelCatalog(args: {
   timeoutMs: number;
   preferredLlmModel: string | null;
 }): Promise<OllamaModelCatalog> {
-  const normalizedBaseUrl = args.baseUrl.trim().replace(/\/+$/, "");
-  if (!isLocalEndpoint(normalizedBaseUrl)) {
-    throw new Error("Ollama endpoint must use localhost / 127.0.0.1 / [::1]");
-  }
+  const normalizedBaseUrl = normalizeLocalEndpoint(args.baseUrl, "Ollama");
 
-  const response = await fetchWithTimeout(normalizedBaseUrl, "/api/tags", Math.max(1_000, Math.trunc(args.timeoutMs)), {
-    method: "GET",
-  });
+  const response = await fetchWithTimeout(
+    normalizedBaseUrl,
+    "/api/tags",
+    Math.max(1_000, Math.trunc(args.timeoutMs)),
+    {
+      method: "GET",
+    },
+  );
   if (!response.ok) {
     const reason = await extractErrorMessage(response);
     throw new Error(`Ollama model list request failed: ${reason}`);

--- a/src/pages/UsagePage.tsx
+++ b/src/pages/UsagePage.tsx
@@ -77,8 +77,14 @@ import {
   getProviderDefinitions,
   isWebLLMEnabled,
 } from "../llm/providers";
-import { resolveProviderFallback } from "../llm/fallback";
 import type { LLMProviderDefinition, LLMProviderId } from "../llm/types";
+import {
+  cancelPendingGeneration,
+  createSelectedProviderGeneration,
+  resumePendingWebLLMGeneration,
+  type PendingGeneration,
+} from "../llm/generationState";
+import { executeUsageGeneration } from "../llm/usageGenerationAdapter";
 import { useProviderSettingsPersistence } from "../hooks/useProviderSettingsPersistence";
 import {
   getWebLLMSelectableModels,
@@ -90,7 +96,6 @@ import {
   resolveHermesModelSelection,
   type WebLLMRecommendation,
 } from "../llm/webllm/capability";
-import { WebLLMProviderError } from "../llm/webllm/engine";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -726,8 +731,7 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
   const [llmError, setLlmError] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const generationControllerRef = useRef<AbortController | null>(null);
-  const pendingWebllmGenerationRef = useRef(false);
-  const generateAnswerRef = useRef<() => Promise<void>>(async () => undefined);
+  const pendingWebllmGenerationRef = useRef<PendingGeneration | null>(null);
   const ollamaCatalogRequestIdRef = useRef(0);
   const ollamaEmbeddingModelManuallySetRef = useRef(false);
   const ollamaChatModelManuallySetRef = useRef(false);
@@ -2928,65 +2932,38 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
     });
   };
 
-  const canReachLocalProvider = useCallback(async (provider: "ollama" | "lmstudio"): Promise<boolean> => {
-    const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), 2000);
-    try {
-      const url =
-        provider === "ollama"
-          ? `${(ollamaBaseUrl.trim() || "http://localhost:11434").replace(/\/+$/, "")}/api/tags`
-          : `${(
-              providerDefinitions.find((item) => item.id === "lmstudio")?.defaultBaseUrl ||
-              "http://localhost:1234"
-            ).replace(/\/+$/, "")}/v1/models`;
-      const response = await fetch(url, { method: "GET", signal: controller.signal });
-      return response.ok;
-    } catch {
-      return false;
-    } finally {
-      window.clearTimeout(timeout);
-    }
-  }, [ollamaBaseUrl]);
-
-  const runProviderStream = useCallback(async (args: {
-    provider: LLMProviderId;
-    model: string;
-    promptText: string;
-    snippets: string[];
-    controller: AbortController;
-    onToken: (token: string) => void;
-    allowModelDownload: boolean;
-  }): Promise<void> => {
-    const provider = getProviderById(args.provider);
-    const lmStudioDefaultBase =
-      providerDefinitions.find((item) => item.id === "lmstudio")?.defaultBaseUrl ||
-      "http://localhost:1234";
-    const providerBase =
-      args.provider === "ollama"
-        ? (ollamaBaseUrl.trim() || "http://localhost:11434")
-        : args.provider === "lmstudio"
-          ? lmStudioDefaultBase
-          : providerBaseUrl.trim();
-    await provider.stream(
-      {
-        baseUrl: providerBase,
-        model: args.model,
-        apiKey: providerApiKey.trim(),
-        allowModelDownload: args.allowModelDownload,
+  const executePendingGeneration = async (generation: PendingGeneration): Promise<void> => {
+    await executeUsageGeneration(generation, {
+      controllerRef: generationControllerRef,
+      pendingGenerationRef: pendingWebllmGenerationRef,
+      fallbackWebLLMModelId: WEBLLM_FALLBACK_MODEL_ID,
+      getDatabase: getLocalDatabase,
+      providerDefinitions,
+      getProvider: getProviderById,
+      createId: () => crypto.randomUUID(),
+      now: Date.now,
+      setGenerating: setIsGenerating,
+      setAnswer: setLlmAnswer,
+      setPrompt: setLlmPrompt,
+      setSessionMessages: setSessionMessagesById,
+      sortMessages: sortChatMessages,
+      setRuntimeState: setWebllmRuntimeState,
+      setDownloadProgress: setWebllmDownloadProgress,
+      setProgressText: setWebllmProgressText,
+      setDownloadDialogOpen: setWebllmDialogOpen,
+      setAllowModelDownload: setWebllmAllowModelDownload,
+      setProviderId,
+      setProviderModel,
+      setProviderBaseUrl,
+      setSelectedWebLLMModel: setWebllmSelectedModel,
+      setError: setLlmError,
+      reportError: (error, failedProviderId) => {
+        captureLocalError("llm_generation_failed", error);
+        const providerKind = getProviderById(failedProviderId).definition.kind;
+        setLlmError(formatProviderError(error, providerKind));
       },
-      {
-        prompt: args.promptText,
-        contextSnippets: args.snippets,
-        signal: args.controller.signal,
-        onToken: args.onToken,
-        onInitProgress: (progress, text) => {
-          setWebllmDownloadProgress(progress);
-          setWebllmProgressText(text);
-          setWebllmRuntimeState("downloading");
-        },
-      },
-    );
-  }, [ollamaBaseUrl, providerApiKey, providerBaseUrl]);
+    });
+  };
 
   const handleGenerateAnswer = async () => {
     if (!activeSession) {
@@ -3011,13 +2988,6 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
 
     if (providerId === "webllm" && !webLLMEnabled) {
       setLlmError("WebLLM is disabled. Enable VITE_WEBLLM_ENABLED=1 to use browser models.");
-      return;
-    }
-
-    if (providerId === "webllm" && !webllmConsent) {
-      setWebllmRuntimeState("needs-consent");
-      setWebllmDialogOpen(true);
-      setLlmError(null);
       return;
     }
 
@@ -3053,184 +3023,62 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
     }
 
     const promptText = llmPrompt.trim();
-    try {
+    const generation = createSelectedProviderGeneration({
+      requestId: crypto.randomUUID(),
+      sessionId: activeSession.id,
+      promptText,
+      snippets,
+      providerSelection: {
+        providerId,
+        providerBaseUrl,
+        ollamaBaseUrl: ollamaBaseUrl.trim(),
+        model: resolveHermesModelSelection(providerModel.trim() || WEBLLM_PRIMARY_MODEL_ID),
+        apiKey: providerApiKey,
+        allowModelDownload: webllmAllowModelDownload,
+      },
+      executionPolicy: {
+        allowLocalProvider,
+        allowRemoteProvider,
+        webllmConsent,
+        ollamaBaseUrl: ollamaBaseUrl.trim(),
+        lmStudioBaseUrl: providerBaseUrl.trim(),
+      },
+    });
+
+    if (providerId === "webllm" && !webllmConsent) {
+      pendingWebllmGenerationRef.current = generation;
+      setWebllmRuntimeState("needs-consent");
+      setWebllmDialogOpen(true);
       setLlmError(null);
-      setLlmAnswer("");
-      setIsGenerating(true);
-      setLlmPrompt("");
-      let streamedAnswer = "";
-      const controller = new AbortController();
-      generationControllerRef.current = controller;
-
-      const database = await getLocalDatabase();
-      const userSequence = database.getNextChatMessageSequence(activeSessionId!);
-      const userMessage: ChatMessageRecord = {
-        id: crypto.randomUUID(),
-        sessionId: activeSessionId!,
-        role: "user",
-        content: promptText,
-        sequence: userSequence,
-        createdAt: Date.now(),
-      };
-      await database.addChatMessage(userMessage);
-      setSessionMessagesById((previous) => {
-        const current = previous[activeSessionId!] ?? [];
-        return {
-          ...previous,
-          [activeSessionId!]: sortChatMessages([...current, userMessage]),
-        };
-      });
-
-      const streamToken = (token: string) => {
-        streamedAnswer += token;
-        setLlmAnswer((previous) => previous + token);
-      };
-
-      const activeModel = resolveHermesModelSelection(providerModel.trim() || WEBLLM_PRIMARY_MODEL_ID);
-      let effectiveProviderId = providerId;
-      let effectiveModel = activeModel;
-
-      try {
-        await runProviderStream({
-          provider: effectiveProviderId,
-          model: effectiveModel,
-          promptText,
-          snippets,
-          controller,
-          onToken: streamToken,
-          allowModelDownload: webllmAllowModelDownload,
-        });
-        if (effectiveProviderId === "webllm") {
-          setWebllmRuntimeState("ready");
-        }
-      } catch (streamError) {
-        if (effectiveProviderId === "webllm" && streamError instanceof WebLLMProviderError) {
-          if (streamError.code === "WEBLLM_DOWNLOAD_REQUIRED") {
-            setWebllmRuntimeState("needs-consent");
-            setWebllmDialogOpen(true);
-            setLlmError(null);
-            return;
-          }
-
-          if (effectiveModel !== WEBLLM_FALLBACK_MODEL_ID) {
-            effectiveModel = WEBLLM_FALLBACK_MODEL_ID;
-            setProviderModel(effectiveModel);
-            setWebllmSelectedModel(effectiveModel);
-            try {
-              setWebllmRuntimeState("downloading");
-              await runProviderStream({
-                provider: "webllm",
-                model: effectiveModel,
-                promptText,
-                snippets,
-                controller,
-                onToken: streamToken,
-                allowModelDownload: true,
-              });
-              setWebllmRuntimeState("ready");
-            } catch {
-              setWebllmRuntimeState("failed");
-            }
-          } else {
-            setWebllmRuntimeState("failed");
-          }
-
-          if (streamedAnswer.trim().length === 0) {
-            const fallbackProviderId = resolveProviderFallback({
-              canUseOllama: allowLocalProvider && await canReachLocalProvider("ollama"),
-              canUseLmStudio: allowLocalProvider && await canReachLocalProvider("lmstudio"),
-              canUseOpenAICompatible: allowRemoteProvider && providerApiKey.trim().length > 0,
-            });
-            if (fallbackProviderId == null) {
-              throw streamError;
-            }
-
-            effectiveProviderId = fallbackProviderId;
-            const fallbackDefinition =
-              providerDefinitions.find((provider) => provider.id === fallbackProviderId) ?? null;
-            const fallbackModel = fallbackDefinition?.defaultModel ?? "gpt-4o-mini";
-            setProviderId(fallbackProviderId);
-            setProviderModel(fallbackModel);
-            setProviderBaseUrl(fallbackDefinition?.defaultBaseUrl ?? providerBaseUrl);
-            setLlmError(`WebLLM failed, switched to ${fallbackDefinition?.label ?? fallbackProviderId}.`);
-
-            await runProviderStream({
-              provider: fallbackProviderId,
-              model: fallbackModel,
-              promptText,
-              snippets,
-              controller,
-              onToken: streamToken,
-              allowModelDownload: false,
-            });
-          } else {
-            throw streamError;
-          }
-        } else {
-          throw streamError;
-        }
-      }
-
-      if (activeSessionId && streamedAnswer.trim()) {
-        const assistantSequence = database.getNextChatMessageSequence(activeSessionId);
-        const assistantMessage: ChatMessageRecord = {
-          id: crypto.randomUUID(),
-          sessionId: activeSessionId,
-          role: "assistant",
-          content: streamedAnswer,
-          sequence: assistantSequence,
-          createdAt: Date.now(),
-        };
-        await database.addChatMessage(assistantMessage);
-        setSessionMessagesById((previous) => {
-          const current = previous[activeSessionId] ?? [];
-          return {
-            ...previous,
-            [activeSessionId]: sortChatMessages([...current, assistantMessage]),
-          };
-        });
-      }
-    } catch (err) {
-      captureLocalError("llm_generation_failed", err);
-      setLlmError(formatProviderError(err, selectedProvider.kind));
-    } finally {
-      setIsGenerating(false);
-      generationControllerRef.current = null;
-      setWebllmAllowModelDownload(false);
+      return;
     }
+
+    await executePendingGeneration(generation);
   };
 
-  generateAnswerRef.current = handleGenerateAnswer;
-
   const handleCancelGeneration = () => {
+    pendingWebllmGenerationRef.current = cancelPendingGeneration();
     generationControllerRef.current?.abort();
   };
 
-  useEffect(() => {
-    if (!pendingWebllmGenerationRef.current) {
-      return;
-    }
-
-    if (providerId !== "webllm" || !webllmConsent || !webllmAllowModelDownload) {
-      return;
-    }
-
-    pendingWebllmGenerationRef.current = false;
-    void generateAnswerRef.current();
-  }, [providerId, webllmAllowModelDownload, webllmConsent]);
-
   const handleConfirmWebllmDownload = () => {
-    pendingWebllmGenerationRef.current = true;
+    const resumed = resumePendingWebLLMGeneration(
+      pendingWebllmGenerationRef.current,
+      resolveHermesModelSelection(webllmSelectedModel),
+    );
+    pendingWebllmGenerationRef.current = resumed.nextPending;
+    if (!resumed.generation) return;
     setWebllmConsent(true);
     setWebllmAllowModelDownload(true);
     setProviderId("webllm");
     setProviderModel(resolveHermesModelSelection(webllmSelectedModel));
     setWebllmDialogOpen(false);
     setWebllmRuntimeState("downloading");
+    void executePendingGeneration(resumed.generation);
   };
 
   const handleCancelWebllmDownload = () => {
-    pendingWebllmGenerationRef.current = false;
+    pendingWebllmGenerationRef.current = cancelPendingGeneration();
     setWebllmDialogOpen(false);
     setWebllmRuntimeState("idle");
   };

--- a/src/pages/UsagePage.tsx
+++ b/src/pages/UsagePage.tsx
@@ -81,7 +81,9 @@ import type { LLMProviderDefinition, LLMProviderId } from "../llm/types";
 import {
   cancelPendingGeneration,
   createSelectedProviderGeneration,
+  resolveLmStudioPolicyUrl,
   resumePendingWebLLMGeneration,
+  shouldResetRuntimeAfterEmptyResume,
   type PendingGeneration,
 } from "../llm/generationState";
 import { executeUsageGeneration } from "../llm/usageGenerationAdapter";
@@ -3041,7 +3043,7 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
         allowRemoteProvider,
         webllmConsent,
         ollamaBaseUrl: ollamaBaseUrl.trim(),
-        lmStudioBaseUrl: providerBaseUrl.trim(),
+        lmStudioBaseUrl: resolveLmStudioPolicyUrl(providerId, providerBaseUrl),
       },
     });
 
@@ -3067,7 +3069,13 @@ export default function UsagePage({ view = "legacy" }: UsagePageProps) {
       resolveHermesModelSelection(webllmSelectedModel),
     );
     pendingWebllmGenerationRef.current = resumed.nextPending;
-    if (!resumed.generation) return;
+    if (!resumed.generation) {
+      setWebllmDialogOpen(false);
+      if (shouldResetRuntimeAfterEmptyResume(generationControllerRef.current?.signal ?? null)) {
+        setWebllmRuntimeState("idle");
+      }
+      return;
+    }
     setWebllmConsent(true);
     setWebllmAllowModelDownload(true);
     setProviderId("webllm");


### PR DESCRIPTION
## Summary

Closes the lean PR 4 provider-transport, WebLLM, and worker-reliability program without changing routes, layout, or stored-data schemas.

- executes immutable provider request and fallback snapshots instead of React-state closures
- honors configured LM Studio endpoints and enforces strict loopback validation at every local request sink
- preserves valid terminal SSE/JSONL records and rejects malformed final records with or without trailing newlines
- resumes WebLLM consent/download requests exactly once and propagates cancellation through initialization, active streaming, and fallback probes
- rejects and cleans every failed embedding-worker request, replaces fatal workers, and retires surplus workers only when idle

## Finding coverage

Covers review findings #5, #6, #13, #24, #25, #33, #38, and duplicate stream item #40.

## Before / after proof

Before this branch, fallback execution could read stale provider state, LM Studio ignored its configured URL, final non-newline stream records were dropped, malformed newline-terminal records were silently accepted, WebLLM resume could duplicate work, active cancellation waited on model/stream operations, worker crashes leaked pending jobs, and a fatal worker could poison the retained pool slot.

Focused regressions now re-exercise each original path, including arbitrary UTF-8 byte splits, adversarial endpoint literals, double-consume/cancel state transitions, deferred WebLLM initialization and iterator reads, ignored-signal fallback fetches, worker crash/messageerror/malformed/timeout/termination, fatal-slot replacement, and five-job in-flight downshift recovery.

## Verification

- Node 24 full `pnpm run ci`: passed
- format and ESLint `--max-warnings=0`: passed
- TypeScript: passed
- component tests: 6 files / 15 tests
- complete tests: 56 files / 391 tests
- changed-line coverage: 975/1063 = 91.72%
- production build and bundle budgets: passed
- Chromium smoke, visual, reduced-motion, and accessibility: 12/12 passed
- Node 22: typecheck, 391 tests, and production build passed
- Luna xhigh adversarial review: original and follow-up cancellation/worker findings repaired
- Claude Code Opus 4.8 high audit: effectively clean; its one low fallback-error-attribution finding was fixed by Claude Code and verified by the full suite

## Security and privacy

Local Ollama and LM Studio traffic now accepts only explicit HTTP(S) loopback literals (`localhost`, canonical `127.0.0.0/8`, and `[::1]`) and rejects credentials, suffix tricks, ambiguous numeric hosts, query/fragment injection, remote hosts, and non-HTTP schemes before `fetch`.

## UI / UX

No route, layout, CSS, or public-surface change. The only copy correction consistently classifies LM Studio as local and OpenAI-compatible endpoints as remote. Existing visual snapshots remain unchanged.

## Migration and rollback

No database, storage, or settings-format migration. Roll back through the PR merge commit; browser storage must not be deleted. The three focused commits remain independently bisectable.

## Performance

Bundle budget passes. Main application JavaScript increased by roughly 0.3% raw for the lifecycle and validation logic; model/WASM assets are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more reliable generation workflow with provider fallback, cancellation, resume support, and WebLLM download handling.
  * Added stricter protection for local provider connections and safer endpoint handling.
  * Improved embedding processing with request timeouts, clearer errors, and worker recovery.

* **Bug Fixes**
  * Improved streaming response handling for LM Studio and Ollama, including malformed or incomplete responses.
  * Fixed provider consent messaging to clearly distinguish remote and local providers.
  * Improved cleanup of inactive or failed embedding workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->