### PR TITLE
v0.14.0: lazy-load authenticated routes and align release docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 VITE_GITHUB_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
+# Must exactly match VITE_GITHUB_REDIRECT_URI and the callback URL configured in GitHub.
+GITHUB_OAUTH_REDIRECT_URI=
 # Must exactly match one callback URL configured in your GitHub OAuth app
 # Example: http://localhost:5173/auth/callback
 VITE_GITHUB_REDIRECT_URI=
@@ -28,6 +30,10 @@ VITE_README_BATCH_PIPELINE_V2=1
 VITE_README_BATCH_SIZE=40
 VITE_EMBED_TRIGGER_THRESHOLD=256
 VITE_EMBED_WINDOW_SIZE=512
+
+# Optional durable-write checkpoint controls (positive integers).
+VITE_DB_CHECKPOINT_EVERY_EMBEDDINGS=100
+VITE_DB_CHECKPOINT_EVERY_MS=30000
 
 # Optional Ollama embedding defaults.
 # Ollama usage is controlled by in-app user toggle.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,18 @@ If a proposed change improves UX but weakens security or privacy defaults, it sh
 ## Before You Start
 
 Read these first:
+
 - `CODE_OF_CONDUCT.md`
 - `SECURITY.md`
-- `docs/Usage.md`
-- `docs/tech-stack-architecture-security-prd.md`
+- `docs/Usage.md` - canonical runtime, configuration, storage, and troubleshooting reference
+- `docs/adr/README.md` - current multi-tab storage decision
 - `docs/threat-modeling-stride.md`
 - `docs/security-review-stride.md`
 - `docs/embedding-acceleration-plan.md`
+
+`docs/tech-stack-architecture-security-prd.md` and `docs/codex-claude-build-guide.md` are retained for
+provenance only. Both are marked HISTORICAL and describe an architecture that was never shipped (most
+notably `sqlite-vec` for vector search). Do not treat either as a description of the current system.
 
 If your change affects authentication, storage, or data flow, include a short threat-impact note in the PR description.
 
@@ -44,8 +49,9 @@ pnpm dev
 ```
 
 Required runtime assumptions:
-- Node.js 20+
-- pnpm 9+
+
+- Node.js 22 or 24 (active LTS lines; enforced by `engines`)
+- pnpm 11.17.0 (pinned via `packageManager`)
 - Browser with modern Worker and Indexed storage support
 
 ---
@@ -58,6 +64,7 @@ Required runtime assumptions:
 - If you change user-facing or security behavior, update docs in same PR.
 
 Suggested commit style:
+
 - `feat: ...`
 - `fix: ...`
 - `perf: ...`
@@ -75,21 +82,38 @@ Suggested commit style:
 
 ## Code Quality Gate (Required)
 
-Run this before opening a PR:
-
-```bash
-pnpm lint
-pnpm test
-pnpm build
-```
-
-Or run the combined check:
+Run the full gate before opening a PR. It is the same sequence CI runs in
+`.github/workflows/quality.yml`:
 
 ```bash
 pnpm ci
 ```
 
-PRs that fail lint/test/build should not be merged.
+`pnpm ci` expands to, in order:
+
+| Step                       | Command               |
+| -------------------------- | --------------------- |
+| Formatting                 | `pnpm format:check`   |
+| Lint (zero warnings)       | `pnpm lint`           |
+| Types                      | `pnpm typecheck`      |
+| Component tests (jsdom)    | `pnpm test:component` |
+| Unit tests with coverage   | `pnpm test:coverage`  |
+| Coverage gates             | `pnpm check:coverage` |
+| Production build           | `pnpm build`          |
+| Bundle budget              | `pnpm check:bundle`   |
+| Browser smoke (Playwright) | `pnpm test:e2e`       |
+
+The last step needs a browser binary. Install it once before your first `pnpm ci` run, or that step
+fails on a clean checkout:
+
+```bash
+pnpm exec playwright install --with-deps chromium
+```
+
+For a faster inner loop while developing, `pnpm lint`, `pnpm test`, and `pnpm build` are the useful
+subset. `pnpm ci` is what must pass before review.
+
+PRs that fail any gate step should not be merged.
 
 ---
 
@@ -109,6 +133,7 @@ When touching auth/storage/network code, add or update tests.
 ## Performance Rules
 
 For embedding/indexing changes:
+
 - Measure impact, do not assume impact.
 - Avoid regressions in throughput or UI responsiveness.
 - Keep fallback behavior deterministic.
@@ -116,6 +141,7 @@ For embedding/indexing changes:
 - For retrieval changes, include dense candidate policy, lexical trigger policy, and MMR/per-repo cap rationale.
 
 When changing worker/batching/checkpoint logic:
+
 - add or adjust unit tests.
 - include benchmark notes in PR description (quick local numbers are acceptable).
 
@@ -124,6 +150,7 @@ When changing worker/batching/checkpoint logic:
 ## Testing Guidance
 
 Add tests for:
+
 - deterministic behavior,
 - schema/data integrity,
 - failure paths and fallback paths,
@@ -137,6 +164,7 @@ Add integration-style tests only where unit tests are insufficient.
 ## Documentation Requirements
 
 You must update docs when any of these change:
+
 - architecture or data flow,
 - security controls,
 - env variables,
@@ -144,8 +172,9 @@ You must update docs when any of these change:
 - operational usage instructions.
 
 Likely docs to touch:
+
 - `docs/Usage.md`
-- `docs/tech-stack-architecture-security-prd.md`
+- `docs/adr/0005-single-writer-web-locks-lease.md` when changing multi-tab storage behavior
 - `docs/embedding-acceleration-plan.md`
 - `docs/dfd-diagrams.md`
 - `docs/threat-modeling-stride.md`
@@ -153,43 +182,26 @@ Likely docs to touch:
 - `docs/changelogs.md`
 - `README.md` architecture Mermaid snapshot
 
+Do not update `docs/tech-stack-architecture-security-prd.md` or `docs/codex-claude-build-guide.md`. Both
+are frozen historical records.
+
 ---
 
 ## PR Template
 
-GitHub now preloads the repository PR template automatically. Keep those sections filled in for any non-trivial change.
+GitHub preloads [`.github/pull_request_template.md`](./.github/pull_request_template.md) automatically.
+Fill in every applicable section for any non-trivial change.
 
-Current template structure:
+Read that file directly rather than a copy reproduced here, so the two cannot drift. It asks for, among
+other things:
 
-```md
-## Summary
+- finding IDs, baseline commit, and the baseline failure or risk,
+- a regression proof that fails before the fix and passes after,
+- migration, compatibility, and rollback notes, including evidence that rollback does not delete user data,
+- security, privacy, storage-scope, and dependency impact,
+- exact verification commands with pasted results.
 
-## Problem
-
-## Solution
-
-## Security Impact
-- [ ] No change
-- [ ] Change (details below)
-
-## Performance Impact
-- [ ] No change
-- [ ] Improved
-- [ ] Regressed (explain)
-
-## Tests
-- [ ] pnpm lint
-- [ ] pnpm test
-- [ ] pnpm build
-
-## Docs Updated
-- [ ] Yes
-- [ ] Not needed (reason)
-
-## Threat / Data-Flow Notes
-- [ ] Not applicable
-- [ ] Included in this PR description
-```
+"CI is green" is explicitly not accepted in place of pasted evidence.
 
 ---
 
@@ -199,6 +211,7 @@ Do not open public exploit details in regular issues.
 Follow `SECURITY.md` and use the private disclosure path for sensitive reports.
 
 Include:
+
 - attack preconditions,
 - reproduction steps,
 - impact,
@@ -218,4 +231,5 @@ Include:
 ## Maintainer Notes
 
 Author:
+
 - [Abhinandan-Khurana](https://github.com/Abhinandan-Khurana)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <strong>Find your starred repos by memory, not by name.</strong>
 </p>
 
-
 <p align="center">
   <a href="https://deepwiki.com/Abhinandan-Khurana/GitStarRecall"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="./docs/Usage.md"><img alt="Usage Guide" src="https://img.shields.io/badge/docs-Usage_Guide-0ea5e9"></a>
@@ -18,7 +17,6 @@
   <a href="./docs/security-review-stride.md"><img alt="Security Review" src="https://img.shields.io/badge/security-STRIDE_Reviewed-059669"></a>
 </p>
 
-
 **GitStarRecall** is a local-first web app that turns your GitHub stars into a searchable memory system.
 
 ### Ask it like this
@@ -26,7 +24,7 @@
 - "I starred a GraphQL security testing repo months ago, what was it?"
 - "TypeScript auth starter with clear boundaries."
 
-***TIP: add specific details for better results.***
+**_TIP: add specific details for better results._**
 
 ### LLM chat
 
@@ -162,13 +160,19 @@ flowchart LR
     F --> R[Remote OpenAI-Compatible - opt-in]
 ```
 
-
-
 Notes:
 
 - Star sync is user-triggered via `Fetch Stars`; search runs on existing local embeddings.
-- Vector data is stored as Float32 blobs in local SQLite tables.
-- Retrieval/search is local; no server-side vector index is required.
+- Persistence is a single sql.js (SQLite WASM) database exported and written whole to OPFS, with a
+  base64 localStorage snapshot as the fallback when OPFS is unavailable. There is no `sqlite-vec`
+  or other native vector extension.
+- Vector data is stored as Float32 blobs in ordinary SQLite tables and read back into `Float32Array`
+  views for ranking.
+- Ranking is exact and in-process: brute-force cosine similarity over every candidate vector,
+  followed by MMR with a per-repo cap. There is no approximate-nearest-neighbour index, and no
+  server-side vector index is required.
+- Chat history is backed up per authenticated identity into a scoped IndexedDB store, falling back
+  to scoped localStorage keys; clearing one identity never touches another's backup.
 - The authenticated app now uses a route-based shell: `/app` auto-navigates first-time users to `/app/setup`; returning users see a home dashboard with onboarding stepper (if indexing incomplete), interactive workspace guide, and quick-nav cards.
 - Browser embedding model is capability-driven (`embeddinggemma` on strong desktop, `Xenova/all-MiniLM-L6-v2` on mobile/weak/no-WebGPU); local Ollama embedding is opt-in.
 - Retrieval path uses dense fetch + confidence gate + conditional lexical safety net + MMR with per-repo cap.
@@ -180,8 +184,8 @@ Notes:
 
 ### Prerequisites
 
-- Node.js 20+
-- pnpm 9+
+- Node.js 22 or 24 (active LTS lines; enforced by `engines`)
+- pnpm 11.17.0 (pinned via `packageManager`; run `corepack enable` to use it automatically)
 - A GitHub OAuth app (recommended) or GitHub PAT with read access to the repositories you want to import
 
 ### Install
@@ -207,6 +211,17 @@ Then follow the complete setup and environment guide:
 ```bash
 pnpm dev
 ```
+
+`pnpm dev` starts the Vite dev server and serves the UI only. It does **not** serve
+`api/github/oauth/exchange.js`, so the OAuth code exchange returns 404 under `pnpm dev`.
+To exercise the full OAuth login flow locally, run the Vercel dev server instead, which
+serves both the UI and the serverless API route:
+
+```bash
+vercel dev
+```
+
+A GitHub PAT still works under `pnpm dev`, because the PAT path never calls the exchange API.
 
 ### Production build
 
@@ -270,4 +285,3 @@ We prioritize:
 ## Author
 
 - Made with <3 by [Abhinandan-Khurana](https://github.com/Abhinandan-Khurana)
-

--- a/README.md
+++ b/README.md
@@ -2,133 +2,103 @@
   <img src="./static/gitstarrecall-logo.png" width="220" alt="GitStarRecall logo">
 </p>
 
-<!-- <h1 align="center">GitStarRecall</h1> -->
-
 <p align="center">
   <strong>Find your starred repos by memory, not by name.</strong>
 </p>
 
 <p align="center">
+  <a href="https://git-star-recall.vercel.app/"><img alt="Live Demo" src="https://img.shields.io/badge/demo-live-ff4d4d"></a>
+  <a href="https://github.com/Abhinandan-Khurana/GitStarRecall/actions/workflows/quality.yml"><img alt="Quality" src="https://github.com/Abhinandan-Khurana/GitStarRecall/actions/workflows/quality.yml/badge.svg?branch=main"></a>
+  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue"></a>
   <a href="https://deepwiki.com/Abhinandan-Khurana/GitStarRecall"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="./docs/Usage.md"><img alt="Usage Guide" src="https://img.shields.io/badge/docs-Usage_Guide-0ea5e9"></a>
-  <a href="./docs/changelogs.md"><img alt="Changelogs" src="https://img.shields.io/badge/docs-Changelogs-1d4ed8"></a>
-  <a href="./CODE_OF_CONDUCT.md"><img alt="Code of Conduct" src="https://img.shields.io/badge/community-Code_of_Conduct-15803d"></a>
-  <a href="./SECURITY.md"><img alt="Security Policy" src="https://img.shields.io/badge/security-Policy-166534"></a>
   <a href="./docs/security-review-stride.md"><img alt="Security Review" src="https://img.shields.io/badge/security-STRIDE_Reviewed-059669"></a>
 </p>
 
-**GitStarRecall** is a local-first web app that turns your GitHub stars into a searchable memory system.
+**GitStarRecall** turns your GitHub stars into a searchable memory system. It runs in your browser, and
+your data stays there.
+
+> **This project exists because starred repos are great until your brain says, "I know what it does, but
+> not what it is called."**
 
 ### Ask it like this
 
 - "I starred a GraphQL security testing repo months ago, what was it?"
 - "TypeScript auth starter with clear boundaries."
+- "Recommend the best-fit repos for my use case." (LLM chat)
 
 **_TIP: add specific details for better results._**
 
-### LLM chat
+---
 
-- "Recommend the best-fit repos for my use case."
+## Try It
 
-> **This project exists because starred repos are great until your brain says, "I know what it does, but not what it is called."**
+Hosted, runs entirely in your browser: **<https://git-star-recall.vercel.app/>**
 
-### Keywords
+Continue with GitHub (read-only), click `Fetch Stars`, then search once indexing finishes. The app does not
+store your stars, READMEs, embeddings, or chats on an application server; they stay on your device unless
+you explicitly enable a remote LLM.
 
-`github stars search` · `semantic search` · `local-first rag` · `browser embeddings` · `webllm` · `ollama` · `privacy-focused ai` · `vector search` · `MMR`
+<!-- Demo GIF slot: record a vague query -> ranked results -> follow-up chat, ~20-40s, silent.
+     Use a scrubbed demo account: the recording shows real starred repos and a real GitHub identity. -->
+
+<!-- Discoverability: these belong in the repository's GitHub "topics" field, not the rendered README:
+     github-stars, semantic-search, local-first, rag, browser-embeddings, webllm, ollama,
+     privacy, vector-search, mmr -->
 
 ---
 
 ## Why This Exists
 
-People star a lot of useful repos.
-Later, they remember functionality, not names.
-GitHub search is good, but semantic memory search is better for this exact problem.
+People star a lot of useful repos, then later remember functionality rather than names. GitHub search is
+good, but semantic memory search fits this exact problem better.
 
-GitStarRecall solves this by:
+GitStarRecall fetches your starred public repositories, pulls README content and metadata, chunks and
+embeds it locally, lets you search in natural language, and optionally generates an LLM answer from the
+top local matches.
 
-- Fetching your starred public repositories.
-- Pulling README content and metadata.
-- Chunking and embedding content locally.
-- Letting you search in natural language.
-- Optionally generating an LLM answer from the top local matches.
-
-Full usage instructions:
-
-- [Usage Docs](./docs/Usage.md)
+Principles: local-first by default, security before convenience, explainability over magic, and practical
+performance at real star counts (1k+ repos).
 
 ---
 
-## Core Principles
+## What You Get
 
-- Local-first by default.
-- Security before convenience.
-- Explainability over magic.
-- Practical performance for real star counts (1k+ repos).
+- Natural-language search with dense retrieval, a confidence gate, a conditional lexical safety net with
+  RRF fusion, then MMR reranking with a per-repo cap — plus local diagnostics explaining each result.
+- Star sync with checksum-based diffing, README fetch with retry, and local chunking and embedding on a
+  worker pool with checkpoint resume.
+- Capability-driven browser embeddings (WebGPU with WASM fallback), or opt-in local Ollama embeddings.
+- Chat sessions over your local index, answered by local, in-browser (WebLLM), or remote
+  OpenAI-compatible providers — every path opt-in behind explicit consent.
+- Per-GitHub-identity scoping of every local store, confirmed five-category data deletion, and
+  single-writer tab enforcement where Web Locks are available.
+
+Full inventory: [docs/features.md](./docs/features.md).
 
 ---
 
 ## Security Model (Short Version)
 
-GitStarRecall is designed to keep your data in the browser unless you explicitly opt into remote LLM usage.
+Your data stays in the browser unless you explicitly opt into a remote LLM.
 
-What stays local by default:
+**Local by default:** star metadata, README content, chunks and embeddings, chat history, and settings —
+each scoped to the authenticated GitHub account, so one identity never reuses another's local index.
 
-- GitHub star metadata.
-- README content.
-- Chunks and embeddings.
-- Chat sessions and message history.
-- GitHub-account-scoped local databases and settings, so one GitHub identity does not silently reuse another identity's local index.
+**Remote only when you enable it:** prompt context sent to a remote LLM provider, top-K snippets only.
 
-What can go remote (opt-in only):
-
-- Prompt context sent to a remote LLM provider when you enable it.
-
-Built-in security posture:
-
-- Strict CSP with explicit allowlist.
-- OAuth code exchange via backend endpoint to avoid exposing client secret.
-- Public landing now spells out that OAuth and PAT are both read-only paths for reading authorized public repositories.
-- PAT fallback supported for power users who want a manual access path.
-- Local data delete flow for cleanup/reset.
-- Threat-model-driven docs in `docs/`.
+**Built-in posture:** strict CSP with an explicit allowlist; OAuth code exchange through a stateless
+backend endpoint so the client secret never reaches the browser; OAuth requests only `read:user` and
+indexing filters private repositories out; PAT fallback for manual access; confirmed local-data deletion;
+and threat-model-driven documentation.
 
 Read more:
 
-- [Architecture and PRD](./docs/tech-stack-architecture-security-prd.md)
-- [STRIDE Review](./docs/threat-modeling-stride.md)
-- [DFD diagram](./docs/dfd-diagrams.md)
-
----
-
-## Product Capabilities
-
-- Public landing page redesigned with a "Midnight Minimal" design system:
-  - CSS atmospheric gradient background with ambient drift animation (Raycast-inspired),
-  - Bricolage Grotesque / Outfit / JetBrains Mono font stack,
-  - solid card surfaces with hot coral accent, scroll-triggered entrance animations,
-  - hero contains a direct "Continue with GitHub" OAuth button (zero-click auth) plus a "Use a PAT instead" secondary CTA,
-  - compact auth section one scroll below the hero with OAuth and PAT side-by-side,
-  - lean static "How it works" 3-step section downstream of auth,
-  - minimal footer with brand lockup, Star on GitHub pill, categorized resource and security link columns, theme-native badge pills (DeepWiki, MIT, STRIDE), and author attribution,
-  - explicit read-only access trust badge in hero and auth section.
-- GitHub OAuth and PAT authentication paths.
-- Route-based workspace with dedicated `Setup`, `Recall`, `Library`, `Sessions`, and `Settings` surfaces.
-- Persistent app shell with workspace health, keyboard navigation, and command palette (`Cmd/Ctrl+K`).
-- First-time users are auto-routed from `/app` to `/app/setup`; returning users see a compact onboarding stepper and collapsible interactive workspace guide on the home dashboard.
-- Star sync with pagination handling (manual via `Fetch Stars`).
-- Checksum-based diff sync for changed/new/removed stars.
-- README fetch pipeline with missing/failure tracking.
-- Adaptive batched README ingestion pipeline (feature-flagged rollout).
-- Local chunking + embedding generation.
-- GitHub-account-scoped local database/storage isolation for repos, embeddings, chat state, and runtime preferences.
-- Browser embedding capability test with model recommendation (mobile-safe fallback).
-- Persistent chat sessions with ordered messages.
-- Library browsing and session transcript views outside the main Recall workflow.
-- Session-aware search and follow-up flow on existing local embeddings.
-- Local and remote LLM answer modes.
-- Browser-local LLM mode via WebLLM (feature-flagged, explicit download consent).
-- Embedding acceleration controls (batching, worker pool, backend fallback).
-- Sync status that distinguishes first sync from incremental sync and keeps embedding generation as the primary active stage during overlap.
+- [Storage Decision Record](./docs/adr/README.md)
+- [Threat Model (STRIDE)](./docs/threat-modeling-stride.md)
+- [Security Review (STRIDE alignment)](./docs/security-review-stride.md)
+- [DFD diagrams](./docs/dfd-diagrams.md)
+- [v0.14.0 hardening evidence](./docs/remediation/v0.14.0.md)
 
 ---
 
@@ -136,143 +106,96 @@ Read more:
 
 ```mermaid
 flowchart LR
-    A[Browser UI] --> B[GitHub API]
-    A --> X[OAuth Exchange API]
-    A --> C[Local DB: sql.js + OPFS]
-    A --> C2[Chat Backup: IndexedDB/localStorage]
-    A --> D[Embedding Runtime Selector]
-    D --> D1[Browser Capability Test]
-    D1 -->|strong desktop + WebGPU| E[Browser Embeddings: embeddinggemma]
-    D1 -->|mobile / weak / no-WebGPU| E2[Browser Embeddings: Xenova/all-MiniLM-L6-v2]
-    D --> G[Ollama Embeddings: qwen3-embedding:4b / qwen3-embedding:0.6b / mxbai-embed-large :opt-in]
-    C --> Q[Search Pipeline v2]
-    Q --> Q1[Dense Retrieval fetchK]
-    Q1 --> Q2[Dense Confidence Check]
-    Q2 -->|dense suspicious| Q3[Lexical Safety Net conditional]
-    Q2 -->|dense healthy| Q5[MMR plus Repo Cap]
-    Q3 --> Q4[Fusion RRF conditional]
-    Q4 --> Q5[MMR plus Repo Cap]
-    Q5 --> S[Final Top-K Search Results]
-    Q --> M[Retrieval Diagnostics local]
-    A --> F[LLM Provider Adapter]
-    F --> W[WebLLM in Browser - opt-in]
-    F --> L[Local LLM: Ollama/LM Studio - opt-in]
-    F --> R[Remote OpenAI-Compatible - opt-in]
+    UI[Browser UI] --> GH[GitHub REST API]
+    UI --> EX["OAuth Exchange API (stateless)"]
+    UI --> DB[("Local DB: sql.js exported to OPFS")]
+    UI --> EMB[Embedding Runtime Selector]
+    EMB -->|WebGPU or WASM| BR[Browser embeddings]
+    EMB -.->|opt-in, localhost only| OL[Ollama embeddings]
+    BR --> DB
+    OL --> DB
+    DB --> SE["Dense scan, confidence gate, conditional lexical + RRF, MMR + per-repo cap"]
+    SE --> TK[Top-K results and local diagnostics]
+    TK -.->|opt-in, top-K snippets only| LLM[WebLLM / Ollama / LM Studio / Remote]
 ```
+
+Full data-flow diagrams with trust boundaries: [docs/dfd-diagrams.md](./docs/dfd-diagrams.md).
 
 Notes:
 
 - Star sync is user-triggered via `Fetch Stars`; search runs on existing local embeddings.
-- Persistence is a single sql.js (SQLite WASM) database exported and written whole to OPFS, with a
-  base64 localStorage snapshot as the fallback when OPFS is unavailable. There is no `sqlite-vec`
-  or other native vector extension.
-- Vector data is stored as Float32 blobs in ordinary SQLite tables and read back into `Float32Array`
-  views for ranking.
-- Ranking is exact and in-process: brute-force cosine similarity over every candidate vector,
-  followed by MMR with a per-repo cap. There is no approximate-nearest-neighbour index, and no
-  server-side vector index is required.
-- Chat history is backed up per authenticated identity into a scoped IndexedDB store, falling back
-  to scoped localStorage keys; clearing one identity never touches another's backup.
-- The authenticated app now uses a route-based shell: `/app` auto-navigates first-time users to `/app/setup`; returning users see a home dashboard with onboarding stepper (if indexing incomplete), interactive workspace guide, and quick-nav cards.
-- Browser embedding model is capability-driven (`embeddinggemma` on strong desktop, `Xenova/all-MiniLM-L6-v2` on mobile/weak/no-WebGPU); local Ollama embedding is opt-in.
-- Retrieval path uses dense fetch + confidence gate + conditional lexical safety net + MMR with per-repo cap.
-- WebLLM/local/remote generation paths are explicit opt-in with consent controls.
+- Persistence is a single sql.js (SQLite WASM) database exported whole to a scoped OPFS file, with a
+  base64 localStorage snapshot as fallback. Embeddings are Float32 blobs in ordinary tables. There is no
+  `sqlite-vec`, no vector virtual table, and no approximate-nearest-neighbour index.
+- Ranking is exact and in-process: brute-force cosine similarity over every candidate vector, then MMR
+  with a per-repo cap. The lexical safety net and RRF fusion engage only when dense confidence is weak.
+- Every local store is scoped per authenticated GitHub identity, and exactly one tab holds the write lease.
+- WebLLM, local, and remote generation paths are opt-in with explicit consent controls.
+
+The storage trade-off is recorded in the [Storage Decision Record](./docs/adr/README.md); the release ledger
+lists the other deferred work.
 
 ---
 
 ## Getting Started
 
-### Prerequisites
+For development or self-hosting. To just use the app, the
+[hosted version](https://git-star-recall.vercel.app/) needs no install.
 
-- Node.js 22 or 24 (active LTS lines; enforced by `engines`)
-- pnpm 11.17.0 (pinned via `packageManager`; run `corepack enable` to use it automatically)
-- A GitHub OAuth app (recommended) or GitHub PAT with read access to the repositories you want to import
-
-### Install
+**Prerequisites:** Node.js 22 or 24 (enforced by `engines`), pnpm 11.17.0 (pinned via `packageManager`;
+`corepack enable` selects it), and a GitHub OAuth app or a PAT with read access.
 
 ```bash
 pnpm install
-```
-
-### Configure environment
-
-Copy `.env.example` to `.env` and set values:
-
-```bash
 cp .env.example .env
+pnpm dev          # UI only, on http://localhost:5173
 ```
 
-Then follow the complete setup and environment guide:
+`pnpm dev` does **not** serve `api/github/oauth/exchange.js`, so OAuth code exchange returns 404 under it.
+A PAT works fine, because the PAT path never calls the exchange endpoint. For the full OAuth flow locally,
+run `vercel dev`, which serves the UI and the serverless route together.
 
-- `docs/Usage.md`
-
-### Run dev server
-
-```bash
-pnpm dev
-```
-
-`pnpm dev` starts the Vite dev server and serves the UI only. It does **not** serve
-`api/github/oauth/exchange.js`, so the OAuth code exchange returns 404 under `pnpm dev`.
-To exercise the full OAuth login flow locally, run the Vercel dev server instead, which
-serves both the UI and the serverless API route:
-
-```bash
-vercel dev
-```
-
-A GitHub PAT still works under `pnpm dev`, because the PAT path never calls the exchange API.
-
-### Production build
-
-```bash
-pnpm build
-pnpm preview
-```
+Environment variables, OAuth app setup, and deployment: [docs/Usage.md](./docs/Usage.md).
 
 ---
 
 ## Developer Commands
 
 - `pnpm dev` - start Vite dev server
-- `pnpm lint` - run ESLint
-- `pnpm test` - run Vitest test suite
+- `pnpm lint` - ESLint at `--max-warnings=0`
+- `pnpm test` - Vitest suite
 - `pnpm build` - typecheck + production build
-- `pnpm ci` - lint + test + build
+- `pnpm ci` - the full gate CI runs (format, lint, types, component, coverage, build, bundle budget, e2e)
+
+`pnpm ci` needs a browser binary once per checkout:
+`pnpm exec playwright install --with-deps chromium`. Full gate breakdown:
+[CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ---
 
-## Usage Guide
+## Docs
 
-For full setup, auth, deployment, runtime modes, tuning, and troubleshooting:
-
-- `docs/Usage.md`
-
----
-
-## Product Docs
-
-- [CODE OF CONDUCT](./CODE_OF_CONDUCT.md)
-- [SECURITY](./SECURITY.md)
-- [Usage](./docs/Usage.md)
-- [Embedding Acceleration Plan](./docs/embedding-acceleration-plan.md)
-- [Architecture and PRD](./docs/tech-stack-architecture-security-prd.md)
-- [Threat Modelling doc using STRIDE](./docs/threat-modeling-stride.md)
-- [STRIDE Review](./docs/threat-modeling-stride.md)
+- [Usage Guide](./docs/Usage.md) - setup, configuration, runtime modes, tuning, troubleshooting
+- [Feature Inventory](./docs/features.md)
+- [Storage Decision Record](./docs/adr/README.md)
+- [DFD Diagrams](./docs/dfd-diagrams.md)
+- [Threat Model (STRIDE)](./docs/threat-modeling-stride.md)
+- [Security Review (STRIDE alignment)](./docs/security-review-stride.md)
+- [v0.14.0 Hardening Evidence](./docs/remediation/v0.14.0.md) - what shipped, what was deferred
+- [Embedding Acceleration Plan](./docs/embedding-acceleration-plan.md) - live performance roadmap
 - [Changelogs](./docs/changelogs.md)
+- [Contributing](./CONTRIBUTING.md) · [Security Policy](./SECURITY.md) · [Code of Conduct](./CODE_OF_CONDUCT.md)
+
+Retained for provenance only, describing an architecture that was never shipped:
+[Tech Stack / PRD](./docs/tech-stack-architecture-security-prd.md) and
+[Build Guide](./docs/codex-claude-build-guide.md).
 
 ---
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
-
-We prioritize:
-
-- security correctness,
-- local-first behavior,
-- deterministic tests,
-- clear operational diagnostics.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR. We prioritize security correctness,
+local-first behavior, deterministic tests, and clear operational diagnostics.
 
 ---
 
@@ -280,8 +203,6 @@ We prioritize:
 
 [MIT](./LICENSE)
 
----
-
 ## Author
 
-- Made with <3 by [Abhinandan-Khurana](https://github.com/Abhinandan-Khurana)
+Made with <3 by [Abhinandan-Khurana](https://github.com/Abhinandan-Khurana)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -55,7 +55,7 @@ serve on, and register that exact callback URL on the GitHub OAuth app.
 
 ## 4) Environment Configuration
 
-## 4.1 Required (OAuth client-side)
+### 4.1 Required (OAuth client-side)
 
 - `VITE_GITHUB_CLIENT_ID`
 - `VITE_GITHUB_REDIRECT_URI`
@@ -66,7 +66,7 @@ For local dev, typical values:
 - `VITE_GITHUB_REDIRECT_URI=http://localhost:5173/auth/callback`
 - `VITE_GITHUB_OAUTH_EXCHANGE_URL=/api/github/oauth/exchange`
 
-## 4.2 Required (OAuth server-side exchange endpoint)
+### 4.2 Required (OAuth server-side exchange endpoint)
 
 Used by `api/github/oauth/exchange.js`:
 
@@ -76,11 +76,17 @@ Used by `api/github/oauth/exchange.js`:
 
 These must match your GitHub OAuth app settings exactly.
 
-## 4.3 Optional Runtime Flags
+### 4.3 Optional Runtime Flags
 
 - `VITE_WEBLLM_ENABLED=1` enables Browser WebLLM provider.
 - `VITE_EMBEDDING_BACKEND_PREFERRED=webgpu|wasm`
 - `VITE_README_BATCH_PIPELINE_V2=1` enables staged README pipeline.
+- `VITE_DB_CHECKPOINT_EVERY_EMBEDDINGS` and `VITE_DB_CHECKPOINT_EVERY_MS` control how often the in-memory
+  database is exported and persisted during an embedding run. Code defaults are `256` embeddings and
+  `3000` ms (`src/db/client.ts`). Any positive integer is accepted; a non-numeric or non-positive value
+  silently falls back to the default. Lower values persist more often and lose less work if the tab dies,
+  at the cost of write throughput. Note that `.env.example` ships `100` and `30000`, so copying it
+  verbatim checkpoints about 10x less often by elapsed time than the built-in default.
 - `VITE_OLLAMA_BASE_URL`, `VITE_OLLAMA_TIMEOUT_MS`
 - `VITE_LLM_SETTINGS_ENCRYPTION_KEY` for encrypted provider API key storage. Keep this stable across deployments if users already have encrypted provider API keys stored locally; removing it prevents decrypt/re-encrypt migration of those saved keys.
 
@@ -130,7 +136,7 @@ The public landing page uses a conversion-first flow:
 - A lean "How it works" section sits downstream of auth, not upstream.
 - The landing copy uses a read-only trust badge in the hero and auth section.
 
-## 7.1 OAuth (recommended)
+### 7.1 OAuth (recommended)
 
 - Click "Continue with GitHub" in the hero or in the compact auth section below and complete the GitHub OAuth flow.
 - OAuth is a read-only access path for reading your starred public repositories.
@@ -138,7 +144,7 @@ The public landing page uses a conversion-first flow:
 - Token is held in memory; not persisted as raw token storage.
 - Browser-local data scope is derived from the authenticated GitHub account, so re-login with a refreshed OAuth token keeps the same local workspace.
 
-## 7.2 PAT fallback
+### 7.2 PAT fallback
 
 - Paste the token directly. Header-style prefixes such as `Bearer ` / `token `, surrounding quotes, and extra whitespace are normalized automatically before use.
 - Use a token with read access to `/user/starred` and the public repositories you want indexed.
@@ -173,13 +179,13 @@ Important:
 
 ## 9) LLM Modes
 
-## 9.1 Remote OpenAI-compatible
+### 9.1 Remote OpenAI-compatible
 
 - Requires API key.
 - Requires explicit remote consent toggle.
 - Top local snippets are sent when you generate an answer.
 
-## 9.2 Local providers (Ollama / LM Studio)
+### 9.2 Local providers (Ollama / LM Studio)
 
 - Requires explicit local consent toggle.
 - Endpoint must be reachable from browser.
@@ -204,7 +210,7 @@ Important:
   - Custom embedding models are supported but marked experimental with warning.
   - Namespaced Ollama models (for example `myorg/custom-embed:latest`) remain routed to Ollama, not browser embeddings.
 
-## 9.3 Browser WebLLM
+### 9.3 Browser WebLLM
 
 - Requires `VITE_WEBLLM_ENABLED=1`.
 - First run requires explicit model-download consent.
@@ -234,7 +240,7 @@ Recommended:
   - when lexical safety-net fusion triggers, fused relevance is used in MMR candidate scoring,
   - MMR rerank with per-repo cap.
 
-## 10.1 Retrieval Tuning (Sudo/Advanced)
+### 10.1 Retrieval Tuning (Sudo/Advanced)
 
 Developer advanced mode is available directly in UI as a checkbox (`Enable developer advanced mode (sudo)`).
 Settings are persisted per auth scope via `localStorage` using the authenticated account-scoped key (`gitstarrecall.sudo.<auth-scope>`).
@@ -270,6 +276,9 @@ Primary local storage:
   scoped localStorage key. There is no `sqlite-vec` or other native vector extension; embeddings are
   Float32 blobs in ordinary tables, ranked in-process with exact cosine similarity plus MMR.
 - The local database file/key is scoped per authenticated GitHub account identity, so different GitHub accounts do not share repo indexes or embedding stores, while the same account keeps the same local workspace across OAuth token refreshes or PAT re-entry.
+- Only one browser tab holds the write lease for a given identity at a time, acquired through the Web
+  Locks API. A second tab is refused write access rather than silently overwriting the first tab's
+  exported database. See section 12.10.
 
 Additional local persistence:
 
@@ -278,46 +287,74 @@ Additional local persistence:
   fails closed rather than reporting success if a known storage backend cannot be written.
 - Account-scoped settings for advanced retrieval mode, embedding preferences, and session continuity metadata.
 - Local runtime caches for model artifacts (WebLLM / embedding assets).
+- Local diagnostic logs under a per-identity `localStorage` key. Entries are redacted at capture: error
+  details are dropped entirely, and warning payloads are reduced to an allowlist of numeric and boolean
+  diagnostic fields. Logs are capped at 200 entries and expire after 7 days. They never contain GitHub
+  tokens, README content, or your query text.
 - If a legacy token-scoped settings record is malformed JSON during one-time migration, the app discards that unreadable historical record instead of repeatedly blocking login on the same parse failure.
 - If a legacy token-scoped DB snapshot is unreadable during one-time migration, the app discards that unreadable legacy copy and continues with a fresh account-scoped database instead of permanently blocking login.
 
 Reset actions in UI:
 
-- `Clear token`
-- `Delete local data`
-- `Clear token` signs out and clears the in-memory GitHub credential, but preserves the account-scoped local workspace and provider/settings state for that GitHub account.
-- `Delete local data` also clears browser cache entries used for WebLLM/model artifacts when the browser cache API is available.
+Both live in `Settings` under "Account and local data", and in the collapsible `Account` panel.
+
+- **Sign out** - labeled `Sign out of GitHub` for OAuth sessions, `Clear PAT session` for PAT sessions,
+  and `Clear token` in the compact account panel. This clears the in-memory GitHub credential only. The
+  account-scoped workspace, provider settings, and preferences for that GitHub account are preserved, so
+  signing back in returns you to the same index.
+- **Delete local data** - opens a confirmation dialog listing exactly what will be erased, then
+  permanently erases it. This cannot be undone.
+
+`Delete local data` attempts these five categories, in this order:
+
+1. Repository index, chunks, embeddings, and chats.
+2. Downloaded model caches (WebLLM and embedding artifacts, via the browser cache API where available).
+3. Provider settings, including endpoints and stored keys.
+4. Scoped preferences.
+5. Local logs - deliberately last, so the record of the deletion survives until every other category has
+   been attempted.
+
+Behavior worth knowing:
+
+- Every category is attempted even when an earlier one fails. The dialog then lists each failed category
+  with its reason instead of reporting success.
+- You are signed out only when every category succeeded. A partial failure leaves you signed in so you
+  can retry.
+- Deletion is blocked while a conflicting operation runs, and the dialog names it: an active GitHub sync,
+  embedding rebuild, search, chat-history restore, or WebLLM model download. It is also blocked when no
+  authenticated scope is present, because scoped deletion needs an identity.
+- Active LLM generation is cancelled and allowed to settle before deletion starts.
 
 ## 12) Troubleshooting
 
-## 12.1 PAT 401 / auth errors
+### 12.1 PAT 401 / auth errors
 
 - The app normalizes common pasted wrappers (`Bearer `, `token `, surrounding quotes, whitespace), but the underlying token still must be valid.
 - Most 401s come from invalid, expired, revoked, or incorrectly pasted tokens rather than missing extra scopes.
 - Verify the token can read `/user/starred` and any public repositories you expect to import.
 
-## 12.2 OAuth callback 404
+### 12.2 OAuth callback 404
 
 - Verify callback URL in GitHub OAuth app.
 - Verify `VITE_GITHUB_REDIRECT_URI` and `GITHUB_OAUTH_REDIRECT_URI` are exact.
 - Ensure production rewrite routes callback path to SPA entry.
 
-## 12.3 `/app` refresh 404 in production
+### 12.3 `/app` refresh 404 in production
 
 - Ensure the explicit rewrite for the affected known route is active.
 - Keep the allowlisted `vercel.json` rewrite entries configured.
 
-## 12.4 localStorage quota exceeded
+### 12.4 localStorage quota exceeded
 
 - App may enter memory-only fallback mode for that tab.
 - Use `Delete local data`, then re-index incrementally.
 
-## 12.5 WebLLM suggests low model on strong desktop
+### 12.5 WebLLM suggests low model on strong desktop
 
 - Check recommendation diagnostics in UI (`reason`, `webgpu`, `cores`, `mem`, `perf`).
 - Manual model selection is supported in chat settings.
 
-## 12.6 Semantic search relevance is weak
+### 12.6 Semantic search relevance is weak
 
 - Confirm indexed model and query model match.
 - If you switched model families, run full re-index.
@@ -328,13 +365,20 @@ Reset actions in UI:
 - If top results are from same repo, lower `maxChunksPerRepo` or increase `fetchK`.
 - Check diagnostics for lexical pool counters (`lexicalPoolRecentCount`, `lexicalPoolBroadCount`, `lexicalPoolOldestCount`) and trigger reason.
 
-## 12.7 Dimension mismatch error
+### 12.7 Dimension mismatch error
 
 - Error means query embedding dimension differs from indexed vectors.
 - Use same embedding model for indexing and searching.
 - Rebuild embeddings after model/profile changes.
 
-## 12.9 Score semantics (MMR vs dense)
+### 12.8 Browser embedding model keeps re-downloading
+
+- Verify browser cache is enabled (DevTools `Disable cache` should be off).
+- Avoid private/incognito mode if you want persistent model cache.
+- Confirm CSP allows required script/connect hosts (`https://cdn.jsdelivr.net`, `https://huggingface.co`, `https://*.huggingface.co`, `https://xethub.hf.co`).
+- Keep one stable recommended model path when possible; frequent model switching can trigger additional downloads.
+
+### 12.9 Score semantics (MMR vs dense)
 
 - Search result `score` reflects the rerank decision score (MMR objective).
 - `denseScore` reflects the relevance signal used by rerank:
@@ -343,28 +387,62 @@ Reset actions in UI:
 - UI display clamps negative rerank scores to `0.000` for readability.
 - UI keeps a compact band (`High/Medium/Low`) and a finite decimal score.
 
-## 12.8 Browser embedding model keeps re-downloading
+### 12.10 "Another tab is already writing local data"
 
-- Verify browser cache is enabled (DevTools `Disable cache` should be off).
-- Avoid private/incognito mode if you want persistent model cache.
-- Confirm CSP allows required script/connect hosts (`https://cdn.jsdelivr.net`, `https://huggingface.co`, `https://*.huggingface.co`, `https://xethub.hf.co`).
-- Keep one stable recommended model path when possible; frequent model switching can trigger additional downloads.
+The workspace allows one writing tab per GitHub identity. A second tab with the same account open is
+refused write access, so syncing, embedding, or deleting in that tab fails with:
+
+```text
+Another tab is already writing local data for scope <scope>. Close the other tab or finish its operation,
+then retry.
+```
+
+- Close or reload the other tab holding the workspace, then retry the action.
+- Reading and searching are unaffected; only writes are refused.
+- The lease is released when the owning tab is closed or reloaded, so no manual reset is needed.
+- Known limitation: the lease resolves as available when `navigator.locks` is unavailable, so a browser
+  without the Web Locks API does not fail closed for a second writer. Avoid running two tabs of the same
+  workspace on such a browser.
 
 ## 13) Developer Command Cheat Sheet
 
-- `pnpm dev` run local app
-- `pnpm test` run test suite
+- `pnpm dev` run local app (UI only; see section 3 for OAuth)
+- `pnpm lint` lint codebase at `--max-warnings=0`
+- `pnpm typecheck` TypeScript project build
+- `pnpm test` run unit test suite
+- `pnpm test:watch` unit tests in watch mode
+- `pnpm test:component` jsdom component interaction tests
+- `pnpm test:coverage` unit tests with coverage report
+- `pnpm test:e2e` Playwright browser smoke tests
+- `pnpm format` / `pnpm format:check` Prettier write / verify
+- `pnpm check:coverage` enforce coverage gates
+- `pnpm check:bundle` enforce bundle budgets
 - `pnpm build` typecheck + production build
-- `pnpm lint` lint codebase
+- `pnpm preview` serve the production build
+- `pnpm ci` full gate: `format:check`, `lint`, `typecheck`, `test:component`, `test:coverage`,
+  `check:coverage`, `build`, `check:bundle`, `test:e2e`
+
+`pnpm test:e2e` (and therefore `pnpm ci`) needs a browser binary once per checkout:
+
+```bash
+pnpm exec playwright install --with-deps chromium
+```
 
 ## 14) Related Docs
 
 - `README.md` (overview)
+- `docs/features.md` (full feature inventory)
+- `docs/adr/README.md` (the current multi-tab storage decision)
 - `docs/changelogs.md`
 - `docs/embedding-acceleration-plan.md`
-- `docs/tech-stack-architecture-security-prd.md`
+- `docs/dfd-diagrams.md`
 - `docs/threat-modeling-stride.md`
 - `docs/security-review-stride.md`
+- `docs/remediation/v0.14.0.md` (what shipped in the v0.14.0 hardening program, and what was deferred)
+
+`docs/tech-stack-architecture-security-prd.md` and `docs/codex-claude-build-guide.md` are historical
+pre-implementation documents, retained for provenance only. They describe an architecture that was never
+shipped; do not follow them for current behavior.
 
 ---
 
@@ -466,6 +544,8 @@ If connection fails from browser:
 - `VITE_EMBEDDING_WORKER_BATCH_SIZE` (1..32)
 - `VITE_EMBEDDING_DB_WRITE_BATCH_SIZE` (16..2048)
 - `VITE_EMBEDDING_UI_UPDATE_MS` (100..2000)
+- `VITE_DB_CHECKPOINT_EVERY_EMBEDDINGS` (positive integer, code default `256`)
+- `VITE_DB_CHECKPOINT_EVERY_MS` (positive integer, code default `3000`)
 - `VITE_EMBEDDING_LARGE_LIBRARY_MODE` (`1` or `0`)
 - `VITE_EMBEDDING_LARGE_LIBRARY_THRESHOLD` (default `500`)
 - `VITE_README_BATCH_PIPELINE_V2` (`1` enables staged README->chunk->embed pipeline)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -15,8 +15,8 @@ By default, data stays in-browser unless you explicitly enable remote providers.
 
 ## 2) Prerequisites
 
-- Node.js 20+
-- pnpm 9+
+- Node.js 22 or 24 (active LTS lines; enforced by `engines`)
+- pnpm 11.17.0 (pinned via `packageManager`; `corepack enable` selects it automatically)
 - GitHub account with:
   - OAuth app (recommended), or
   - Personal Access Token (PAT) fallback
@@ -35,6 +35,23 @@ pnpm dev
 ```
 
 Open: `http://localhost:5173`
+
+`pnpm dev` runs the Vite dev server and serves the UI only. Vite does not execute
+`api/github/oauth/exchange.js`, so `VITE_GITHUB_OAUTH_EXCHANGE_URL` resolves to a route that
+does not exist and OAuth login fails with a 404 from the exchange step.
+
+Two supported local paths:
+
+- **PAT only** — `pnpm dev` is sufficient, because the PAT path never calls the exchange endpoint.
+- **Full OAuth login** — run the Vercel dev server, which serves the UI and the serverless API
+  route together:
+
+```bash
+vercel dev
+```
+
+Match `VITE_GITHUB_REDIRECT_URI` and `GITHUB_OAUTH_REDIRECT_URI` to whichever port you actually
+serve on, and register that exact callback URL on the GitHub OAuth app.
 
 ## 4) Environment Configuration
 
@@ -247,13 +264,18 @@ Recommended starting points:
 
 Primary local storage:
 
-- SQLite (sql.js) with OPFS when available.
-- Fallback local storage modes when persistent quota/backends fail.
+- SQLite via sql.js (SQLite compiled to WASM), held in memory and persisted by exporting the whole
+  database and writing it to a scoped OPFS file when OPFS is available.
+- When OPFS is unavailable, the same exported bytes are persisted as a base64 snapshot under a
+  scoped localStorage key. There is no `sqlite-vec` or other native vector extension; embeddings are
+  Float32 blobs in ordinary tables, ranked in-process with exact cosine similarity plus MMR.
 - The local database file/key is scoped per authenticated GitHub account identity, so different GitHub accounts do not share repo indexes or embedding stores, while the same account keeps the same local workspace across OAuth token refreshes or PAT re-entry.
 
 Additional local persistence:
 
-- Chat backup in IndexedDB with localStorage fallback.
+- Chat backup in IndexedDB with localStorage fallback, scoped per authenticated identity. Clearing
+  or deleting one identity's backup leaves every other identity's records intact, and a scoped clear
+  fails closed rather than reporting success if a known storage backend cannot be written.
 - Account-scoped settings for advanced retrieval mode, embedding preferences, and session continuity metadata.
 - Local runtime caches for model artifacts (WebLLM / embedding assets).
 - If a legacy token-scoped settings record is malformed JSON during one-time migration, the app discards that unreadable historical record instead of repeatedly blocking login on the same parse failure.

--- a/docs/adr/0005-single-writer-web-locks-lease.md
+++ b/docs/adr/0005-single-writer-web-locks-lease.md
@@ -1,0 +1,69 @@
+# ADR-0005: One writing tab per identity, enforced by a Web Locks lease
+
+- **Status:** Accepted
+- **Recorded:** 2026-07-28
+
+## Context
+
+Each tab holds its own in-memory sql.js database and persists by overwriting the whole scoped snapshot. With two
+tabs open on the same identity, this is last-writer-wins over the _entire database_: the second tab's save
+silently discards everything the first tab did, including repositories, embeddings, and chat messages.
+
+This is a data-loss defect, not a stale-view annoyance. It needed resolving before public launch.
+
+Two shapes of solution exist. Make concurrent writers safe (a coordinator that merges or serializes across
+tabs), or make concurrent writers impossible (elect one writer). The first is a genuine distributed-systems
+problem implemented in application code over a non-transactional blob store.
+
+## Decision
+
+Elect a single writer per identity.
+
+On construction, each `LocalDatabase` requests an exclusive Web Lock named for its scope key, using
+`ifAvailable: true` so the request resolves immediately rather than queueing. The tab that obtains the lock
+is the writer and holds it for its lifetime. A tab that does not obtain it is a reader: it can read and
+render, but any write rejects with a typed `LocalDatabaseWriterLeaseError`.
+
+Within the writing tab, writes are additionally serialized through one persistence queue so ordering is
+deterministic.
+
+## Consequences
+
+- The whole-database clobber is eliminated for browsers with Web Locks. A second tab cannot destroy the
+  first tab's work.
+- **The lease deliberately does not fail closed.** When `navigator.locks` is absent — or in memory-only
+  storage mode — availability resolves `true`, so such a browser retains the original last-writer-wins
+  exposure. We accepted this because Web Locks is available across current browsers and failing closed
+  without a detection mechanism would deny writes to every user of such a browser, including the only tab.
+  Recorded as a residual risk rather than a solved problem.
+- Secondary tabs are refused writes but are **not** notified when the writer commits, so they can display a
+  stale view until reloaded.
+- The user-visible model is "one active tab per account". This is a real usability cost for anyone who works
+  in multiple tabs.
+- The lock is held for the tab's lifetime rather than per transaction, which is simple and cheap but means
+  ownership does not rotate opportunistically.
+- Web Locks releases automatically when the owning tab closes or crashes, so a crashed writer does not
+  permanently lock out the identity. This is precisely why the platform primitive was preferred over a
+  hand-rolled lease with heartbeats and expiry.
+
+## Alternatives considered
+
+- **Multi-writer coordinator** with per-mutation locking, revision refresh, and commit broadcast. Rejected:
+  it would reimplement distributed durability above a whole-database blob store without a demonstrated product
+  requirement for concurrent writers.
+- **Hand-rolled lease** in localStorage with timestamps and heartbeats. Rejected: it must reimplement crash
+  detection and expiry that Web Locks provides natively, and a bug there causes either permanent lockout or
+  the very corruption being prevented.
+- **Do nothing, warn the user.** Rejected: silent whole-database loss is not an acceptable default.
+
+## Evidence
+
+- Lock name: `src/db/client.ts:37` — `DATABASE_WRITER_LOCK_PREFIX = "gitstarrecall:database-writer"`.
+- Request: `src/db/client.ts:1347-1348` — `` `${DATABASE_WRITER_LOCK_PREFIX}:${this.scopeKey}` `` with
+  `{ mode: "exclusive", ifAvailable: true }`.
+- Typed refusal: `src/db/client.ts:51` — `export class LocalDatabaseWriterLeaseError extends Error`.
+- Enforcement on the destructive path: `src/db/client.ts:2440` —
+  `if (!(await this.writerLeaseAvailable)) throw new LocalDatabaseWriterLeaseError(...)`.
+- Does not fail closed without the API: `src/db/client.ts:1333-1335` — memory mode or absent
+  `navigator.locks` returns `Promise.resolve(true)`.
+- No `BroadcastChannel` anywhere in `src/`, confirming the absence of commit notification.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,10 @@
+# Architecture decision record
+
+The v0.14.0 release records its one material architectural trade-off: refusing a second browser tab's writes
+instead of building a multi-writer coordinator over whole-database snapshots.
+
+- [ADR-0005: One writing tab per identity, enforced by a Web Locks lease](0005-single-writer-web-locks-lease.md)
+
+The concise release ledger in [`../remediation/v0.14.0.md`](../remediation/v0.14.0.md) records the other
+implemented and deferred work. [`../../README.md`](../../README.md) and [`../Usage.md`](../Usage.md) are the
+current architecture and operational references.

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -1,5 +1,70 @@
 # Changelogs
 
+## 2026-07-28 (v0.14.0 - Public Launch Hardening)
+
+Lean remediation program, PRs #46, #47, #54, #55, #56. Full mapping with commits and deferred work:
+`docs/remediation/v0.14.0.md`.
+
+Toolchain and CI (#46):
+
+- Pinned supported runtimes: Node 22/24 via `engines`, pnpm 11.17.0 via `packageManager`, and an
+  explicit dependency build allowlist.
+- Added component and browser (Playwright) test harnesses, coverage and bundle-budget gates, and a
+  reproducible Node 24 + Node 22 CI workflow with SHA-pinned actions and least-privilege permissions.
+- Lint runs at `--max-warnings=0` with the baseline warnings removed.
+
+Public launch boundary (#47):
+
+- OAuth token exchange now enforces POST, a JSON content type, an 8 KiB body limit (413), exact field
+  validation, a bounded upstream timeout, bounded error bodies, and `Cache-Control: no-store, private`.
+- Added production security headers on Vercel: CSP, `X-Content-Type-Options`, `Referrer-Policy`,
+  `Permissions-Policy`, and `X-Frame-Options: DENY`. CSP still allows `unsafe-eval`, which the
+  in-browser model runtimes currently require.
+- Replaced the catch-all SPA rewrite with explicit entry-route rewrites, so unknown paths return a
+  real 404 instead of a 200 HTML shell.
+- Fixed MIT attribution, corrected the favicon MIME declaration, published social/favicon assets
+  under `public/static/`, removed an unreferenced 4.3 MB image, and dropped authenticated routes from
+  the sitemap.
+
+Sync, settings, and auth integrity (#54):
+
+- README fetches distinguish 404 from transient failures: a transient failure preserves stored README
+  bytes, validators, checksum, and chunks, then marks the repository for retry on the next sync.
+- Retry waits are abortable and honor rate limits; star and fork counts refresh even when other
+  repository metadata is unchanged.
+- Provider settings hydrate asynchronously and persist through an invocation-ordered queue, so a save
+  can no longer overwrite a stored encrypted key with a blank value; persistence failures are surfaced.
+- OAuth callback exchange is single-flight and retryable, and retains its state/verifier until success
+  or terminal validation failure.
+
+Provider and worker reliability (#55):
+
+- Generation executes against an immutable provider request config, including the fallback path, so a
+  later render cannot change the endpoint mid-request.
+- Hardened provider transport boundaries and stream finalization; suspended generations resume exactly
+  once.
+- Embedding workers recover from failed jobs, shared initialization failures, and queue drains.
+
+Storage, privacy, and UX (#56):
+
+- Workspace writes are serialized so the newest acknowledged mutation is the durable one.
+- Chat backups, local logs, and deletion are scoped per authenticated identity: clearing one identity
+  never touches another's records, logs are redacted and expired, and scoped clears fail closed rather
+  than reporting success when a known storage backend cannot be written.
+- Confirmed "Delete local data" surfaces enumerate every category, and legacy v1 chat records for the
+  cleared identity are erased rather than only marked migrated.
+- Enforced one current embedding per chunk with model/dimension readiness validation.
+- Fixed command-palette parsing and shortcut handling, and made theme resolution tolerate unavailable
+  browser storage.
+
+Release slice (this PR):
+
+- Authenticated app route pages load lazily behind an accessible Suspense boundary; `/` and
+  `/auth/callback` stay eager.
+- Version metadata aligned to 0.14.0 (`package.json`, JSON-LD `softwareVersion`).
+- Documentation corrected for supported runtimes, `pnpm dev` versus `vercel dev`, and the actual
+  persistence/search architecture. Pre-implementation planning documents are marked historical.
+
 ## 2026-04-07 (Footer Redesign and Stacking Fix)
 
 - Replaced the old card-style footer with a minimal two-column layout:
@@ -118,7 +183,7 @@
 ## 2026-03-08 (GitHub Auth 401 Fix and Token Normalization)
 
 - Hardened GitHub auth token handling for both OAuth tokens and pasted PATs:
-  - shared token normalization now strips accidental `Bearer`  / `token`  prefixes, surrounding quotes, and extra whitespace before the token is stored or reused,
+  - shared token normalization now strips accidental `Bearer` / `token` prefixes, surrounding quotes, and extra whitespace before the token is stored or reused,
   - reduces avoidable authorization failures when users paste tokens copied from shells, headers, or quoted env values.
 - Standardized GitHub API authorization behavior around normalized raw tokens and `Bearer` request headers so login/import flows consistently send the expected credential format.
 - Improved the GitHub 401 error guidance shown to users:
@@ -275,13 +340,13 @@
   - `denseSuspicious` reports dense-confidence concerns (`low_top1`, `low_top5_mean`, `low_repo_diversity`),
   - `lexicalTriggered` still reports whether lexical safety-net executed (including rare-token triggers).
 - Rare-token lexical trigger now has a confidence/alignment bypass:
-  - lexical safety-net is skipped when dense top-1 is highly confident *and* lexically aligned with the rare-token query,
+  - lexical safety-net is skipped when dense top-1 is highly confident _and_ lexically aligned with the rare-token query,
   - lexical safety-net still runs for high-confidence but lexically mismatched dense top-1 results.
 - Qwen3 retrieval prompting now follows model-card format:
   - queries use `Instruct: ...` + `Query: ...`,
   - passages/documents are embedded as raw text (no `passage:` prefix).
 - Lexical broad sampling now targets the corpus interior slice first (excluding oldest/newest windows) to reduce overlap and improve unique lexical candidate coverage.
-- Curated embedding warning logic now matches retrieval-profile model families (for example `mxbai-embed`*, `nomic-embed`*) to avoid false custom-model warnings on valid variants.
+- Curated embedding warning logic now matches retrieval-profile model families (for example `mxbai-embed`_, `nomic-embed`_) to avoid false custom-model warnings on valid variants.
 - `Rebuild Embeddings` now requires explicit user confirmation before clearing and regenerating the embedding index.
 - README section splitting for large-readme chunking is now code-fence-aware, so heading-like lines inside fenced code blocks do not create artificial section boundaries.
 - Chunk budgeting for large READMEs now intentionally under-fills when fewer than 120 windows clear the quality floor (no low-quality padding fallback).

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -61,9 +61,12 @@ Release slice (this PR):
 
 - Authenticated app route pages load lazily behind an accessible Suspense boundary; `/` and
   `/auth/callback` stay eager.
+- Lazy route failures preserve the app shell and expose an accessible reload action. The Setup, Recall, and
+  Settings routes share the `UsagePage` chunk directly instead of loading three wrapper chunks first.
 - Version metadata aligned to 0.14.0 (`package.json`, JSON-LD `softwareVersion`).
 - Documentation corrected for supported runtimes, `pnpm dev` versus `vercel dev`, and the actual
-  persistence/search architecture. Pre-implementation planning documents are marked historical.
+  persistence/search architecture. The multi-tab storage trade-off is recorded in one focused ADR, and
+  pre-implementation planning documents are marked historical.
 
 ## 2026-04-07 (Footer Redesign and Stacking Fix)
 

--- a/docs/codex-claude-build-guide.md
+++ b/docs/codex-claude-build-guide.md
@@ -1,15 +1,31 @@
 # GitStarRecall - Codex/Claude Build Guide (Starting Point + Prompting Workflow)
 
+> **HISTORICAL — original greenfield bootstrapping guide. Retained for provenance; superseded.**
+>
+> This describes how the project was first scaffolded from the planning documents and references
+> architecture that was never shipped. It is not a guide to working on the current codebase.
+>
+> For the current system, use these sources instead:
+>
+> - Architecture and setup: [`../README.md`](../README.md)
+> - Runtime, configuration, storage, and troubleshooting: [`Usage.md`](Usage.md)
+> - Security posture: [`security-review-stride.md`](security-review-stride.md) and
+>   [`threat-modeling-stride.md`](threat-modeling-stride.md)
+> - v0.14.0 remediation evidence: [`remediation/v0.14.0.md`](remediation/v0.14.0.md)
+
 This guide is a starting point for using Codex or Claude Code to build the GitHub Stars RAG app efficiently. It provides a recommended first prompt, a follow-up prompting pattern, and a reading strategy for the planning docs:
+
 - `docs/Usage.md`
 - `docs/tech-stack-architecture-security-prd.md`
 - `docs/embedding-acceleration-plan.md`
-It also references the UI baseline in `rought-UI-design`.
+  It also references the UI baseline in `rought-UI-design`.
 
 ---
 
 ## 1) Purpose of This Guide
+
 You are about to execute a multi-step build. The highest risk is skipping steps or mixing tasks. This guide ensures the agent:
+
 - Reads the right docs at the right time.
 - Works on one task at a time.
 - Verifies exit criteria before moving on.
@@ -20,8 +36,10 @@ You are about to execute a multi-step build. The highest risk is skipping steps 
 ## 2) How to Read the Planning Docs
 
 ### 2.1 `docs/tech-stack-architecture-security-prd.md`
+
 Read this first to lock design constraints and decisions.
 Focus on:
+
 - Tech stack and architecture flow
 - Security requirements and threat model
 - PRD requirements and MVP scope
@@ -37,15 +55,19 @@ Focus on:
 Use it as the "rules of the build" and cross-check any proposed change against it.
 
 ### 2.2 `docs/Usage.md`
+
 Read this second to align setup/runtime behavior.
 Focus on:
+
 - auth and environment setup
 - usage and runtime toggles
 - deployment and troubleshooting behavior
 
 ### 2.3 `docs/embedding-acceleration-plan.md`
+
 Read this when implementing performance tasks.
 Focus on:
+
 - Current vs proposed embedding pipeline
 - Micro-batching, checkpoint persistence, worker pool, backend fallback
 - Cross-platform validation matrix (Windows/macOS/Linux)
@@ -54,6 +76,7 @@ Focus on:
 ---
 
 ## 3) Starting Prompt (First Run)
+
 Copy-paste this as the first instruction to the agent:
 
 ```text
@@ -69,6 +92,7 @@ After finishing Step 1, report verification status.
 ```
 
 Why this works:
+
 - It anchors the agent on requirements.
 - It prevents scope creep.
 - It guarantees a single-task flow.
@@ -76,6 +100,7 @@ Why this works:
 ---
 
 ## 4) Ongoing Prompting Pattern (Each Next Step)
+
 Use this template for each next task:
 
 ```text
@@ -90,12 +115,15 @@ Replace `N` with the next step number.
 ---
 
 ## 5) When to Pause or Replan
+
 The agent must pause and ask for confirmation if:
+
 - A decision is needed that affects architecture or security.
 - The task requires adding dependencies not in the stack.
 - A task cannot meet exit criteria.
 
 Prompt example:
+
 ```text
 We need to choose between Next.js and Vite before proceeding.
 Please confirm which one to use.
@@ -104,6 +132,7 @@ Please confirm which one to use.
 ---
 
 ## 6) Rules for Efficient Execution
+
 - One task at a time.
 - Do not implement features from later tasks early.
 - If a task fails, undo only that task’s changes.
@@ -113,13 +142,16 @@ Please confirm which one to use.
 ---
 
 ## 7) Suggested Progress Log Format
+
 After each task, the agent should report:
+
 - Task name
 - Files changed
 - Exit criteria status
 - Any follow-up or risks
 
 Example:
+
 ```text
 Task 1 - Project Scaffolding
 Files changed: package.json, src/app/page.tsx
@@ -130,7 +162,9 @@ Risks: none
 ---
 
 ## 8) Lightweight Checkpoints
+
 At major milestones (Steps 1, 3, 5, 7), ask the agent for:
+
 - A short recap
 - Any deviations from plan
 - Updated next step
@@ -138,6 +172,7 @@ At major milestones (Steps 1, 3, 5, 7), ask the agent for:
 ---
 
 ## 9) Final Delivery Prompt
+
 Once your planned steps are done, use:
 
 ```text
@@ -150,9 +185,11 @@ We have completed the planned steps. Please provide:
 ---
 
 ## 10) Optional: If You Want Faster Iteration
+
 You can allow the agent to batch two tasks **only** if both are small and independent. Otherwise, stick to one task at a time.
 
 ---
 
 ## 11) Reminder
+
 If any new requirement appears, update the PRD doc first, then proceed.

--- a/docs/codex-claude-build-guide.md
+++ b/docs/codex-claude-build-guide.md
@@ -5,6 +5,10 @@
 > This describes how the project was first scaffolded from the planning documents and references
 > architecture that was never shipped. It is not a guide to working on the current codebase.
 >
+> Specifically: it cites `sqlite-vec` / `sqlite-vec-wasm` for vector search, TanStack Query for data
+> fetching, and an optional Next.js or Fastify backend — none of which exist. It also treats the
+> Next.js-versus-Vite choice as still open; the project uses Vite.
+>
 > For the current system, use these sources instead:
 >
 > - Architecture and setup: [`../README.md`](../README.md)

--- a/docs/dfd-diagrams.md
+++ b/docs/dfd-diagrams.md
@@ -74,7 +74,7 @@ flowchart LR
   Gate -.->|suspicious| Lex
   Lex -.-> Fuse
   Fuse --> Diversify
-  Diversify -->|KNN + Filters| DB
+  Diversify -->|"exact scan + filters"| DB
   Diversify --> Diag
   UI --> Query
   Query --> Chat
@@ -108,7 +108,7 @@ flowchart TD
   Orchestrator2[Embedding Orchestrator]
   Orchestrator2 --> Selector2[Backend Selector]
   Orchestrator2 --> Pool2[Worker Pool]
-  Pool2 --> VecStore[(SQLite vec0)]
+  Pool2 --> VecStore[("SQLite: embeddings (Float32 blobs)")]
   Orchestrator2 --> Checkpoint2[Checkpoint Writer]
   Checkpoint2 --> RepoStore
   Pool2 --> ModelCDN2["Model CDN/HF"]

--- a/docs/dfd-diagrams.md
+++ b/docs/dfd-diagrams.md
@@ -7,6 +7,7 @@ This doc includes a top-level Data Flow Diagram (DFD) with trust boundaries and 
 ## 1) Top-Level DFD (With Trust Boundaries)
 
 Trust boundaries:
+
 - TB1: User device / browser runtime
 - TB2: GitHub API boundary
 - TB3: External LLM providers (optional)
@@ -25,7 +26,7 @@ flowchart LR
     CapProbe[Browser Capability Probe]
     Selector["Backend Selector (WebGPU/WASM)"]
     Checkpoint[Checkpoint Writer]
-    DB[(SQLite WASM + sqlite-vec)]
+    DB[("SQLite WASM (sql.js) + Float32 vector blobs")]
     Chat[Chat Session Store]
     Query[Query + RAG]
     Dense[Dense Retrieval fetchK]
@@ -136,6 +137,7 @@ flowchart TD
 ---
 
 ## 3) DFD Notes
+
 - All repo data, embeddings, and chats live inside the browser (SQLite WASM).
 - External providers are optional and receive only top-K snippets if enabled.
 - Local providers are optional and may be blocked by CORS unless configured.

--- a/docs/embedding-acceleration-plan.md
+++ b/docs/embedding-acceleration-plan.md
@@ -2,6 +2,41 @@
 
 This document defines the performance roadmap for faster embedding generation while keeping GitStarRecall local-first and secure.
 
+## Delivery Status Addendum (2026-07-28)
+
+This document is a **live roadmap, not a completed record**. Section 2 ("Proposed Target State") is still
+written in the future tense, but most of it has shipped — in different shapes than proposed — and one item
+has been deliberately reversed. Read this addendum before treating Section 2 as outstanding work.
+
+Component mapping for §2.1:
+
+| Proposed component      | Status               | Shipped as                                                    |
+| ----------------------- | -------------------- | ------------------------------------------------------------- |
+| `WorkerPool`            | Shipped as named     | `src/embeddings/WorkerPool.ts`                                |
+| `BackendSelector`       | Shipped, other shape | `src/embeddings/backendSelection.ts` — functions, not a class |
+| `CheckpointWriter`      | Shipped, other shape | Checkpoint policy inline in `src/db/client.ts` (~`:1425`)     |
+| `BatchBuilder`          | Shipped, other shape | Micro-batching exists; no named builder component             |
+| `MetricsCollector`      | Partly shipped       | Embedding run metrics held in `UsagePage` state; no collector |
+| `EmbeddingOrchestrator` | **Not built**        | Orchestration lives in `src/pages/UsagePage.tsx`              |
+
+The execution model in §2.2 is substantially in force: pending chunks are gathered, micro-batched,
+dispatched across a bounded pool, upserted, and persisted on a checkpoint cadence rather than per insert.
+
+Two corrections to Section 2:
+
+- **`EmbeddingOrchestrator` was never built, and its absence has a cost.** `UsagePage.tsx` imports
+  `EmbeddingWorkerPool` directly and drives `generateEmbeddings` itself, which is one reason that component
+  is now ~4,100 lines. Extracting this orchestrator remains a legitimate improvement, but is deliberately
+  deferred from v0.14.0; see [`remediation/v0.14.0.md`](remediation/v0.14.0.md).
+- **The ETA metric in §2.1 was dropped.** The UI shows an indeterminate `Embedding in progress` loader plus
+  a fixed timing note rather than batch-level ETA maths (`Usage.md` §8), and no ETA computation exists in
+  `src/`. Treat the `ETA` entry in §2.1 as superseded, not pending. The reason for the reversal is not
+  recorded anywhere in the repository; only the outcome is verifiable, so it is stated without a rationale
+  here rather than reconstructed after the fact.
+
+For the shipped runtime behavior and its current controls, see [`Usage.md`](Usage.md) and the implementation in
+`src/embeddings/`.
+
 ## Retrieval v2 Addendum (2026-03-05)
 
 The indexing pipeline remains local-first, but query-time retrieval now uses a stronger ranking flow:
@@ -28,6 +63,7 @@ Safety controls:
 - Custom-model warning path for potentially incompatible retrieval assumptions.
 
 Scope requested:
+
 1. Micro-batch embeddings in one worker.
 2. Persist SQLite less frequently (checkpoint strategy).
 3. Small embedding worker pool (parallel workers).
@@ -36,6 +72,7 @@ Scope requested:
 ## Implementation Update (2026-02-23)
 
 Delivered in code:
+
 - Feature-flagged README batch pipeline (`VITE_README_BATCH_PIPELINE_V2`) with staged ingestion.
 - Adaptive README concurrency controller (`min/max/initial`) with rate-limit aware downshift.
 - Incremental README mini-batch callbacks wired to rolling chunk upserts.
@@ -54,6 +91,7 @@ Delivered in code:
 - Embedding model/backend are tracked in `index_meta` (`embedding_active_backend`, `embedding_active_model`) and old embeddings are reset when the active model changes.
 
 Current env controls:
+
 - `VITE_EMBEDDING_BACKEND_PREFERRED`
 - `VITE_EMBEDDING_POOL_SIZE`
 - `VITE_EMBEDDING_WORKER_BATCH_SIZE`
@@ -69,6 +107,7 @@ Current env controls:
 ## 1) Current State (As Implemented)
 
 Embedding pipeline today:
+
 - Worker API accepts `embedBatch(texts[])` and returns ordered vectors with per-item error slots.
 - Main thread uses a small worker pool (default 1-2 workers) with bounded queue and downshift-to-1 on errors/memory pressure.
 - Worker pool now dispatches micro-batches per worker task (`workerBatchSize`, default `8`) instead of one-text jobs.
@@ -76,11 +115,13 @@ Embedding pipeline today:
 - Runtime backend policy is explicit: preferred `webgpu`, automatic fallback to `wasm`, with fallback reason surfaced in UI telemetry.
 
 Strengths:
+
 - Local-first indexing with explicit backend diagnostics.
 - Better throughput from reduced worker-call overhead (micro-batch job dispatch).
 - Safer operational controls (fallback + downshift + checkpoint metrics).
 
 Known bottlenecks:
+
 - Initial model download/compile remains the largest one-time latency.
 - Multi-worker mode duplicates model memory footprint.
 - Throughput remains browser/driver dependent for WebGPU-capable systems.
@@ -92,6 +133,7 @@ Known bottlenecks:
 ### 2.1 New Embedding Architecture
 
 Add an `EmbeddingOrchestrator` in the main thread with:
+
 - `BatchBuilder`: groups chunk texts into micro-batches (`8..32`, adaptive).
 - `WorkerPool`: 1-2 workers by default (configurable upper cap).
 - `BackendSelector`: decides runtime backend (`webgpu` then `wasm`).
@@ -120,10 +162,12 @@ Add an `EmbeddingOrchestrator` in the main thread with:
 ## 3.1 Browser-Only Path (Primary for GitStarRecall)
 
 Backend strategy:
+
 - First try: `webgpu` when available and healthy.
 - Fallback: `wasm` CPU path.
 
 Important clarification:
+
 - In browser, you do not directly choose CUDA or MPS.
 - Browser WebGPU maps to OS/driver GPU stacks:
   - Windows: typically Direct3D 12 backend
@@ -134,6 +178,7 @@ Important clarification:
 ## 3.2 Local Runtime Path (Optional Advanced Mode)
 
 Current optional path via Ollama (UI opt-in):
+
 - Windows/Linux with NVIDIA GPU: CUDA path (runtime-managed).
 - macOS Apple Silicon: Metal path (often described as MPS/Metal acceleration at runtime level).
 - All platforms: CPU fallback when GPU unavailable.
@@ -142,13 +187,13 @@ Use this as optional enhancement, not baseline, to preserve pure in-browser comp
 
 ## 3.3 Compatibility Matrix
 
-| Mode | Windows | macOS (Apple Silicon) | Linux | Notes |
-|---|---|---|---|---|
-| Browser WebGPU | Yes (browser/driver dependent) | Yes (browser/driver dependent; Metal backend) | Yes (browser/driver dependent) | Primary acceleration path |
-| Browser WASM CPU | Yes | Yes | Yes | Guaranteed fallback |
-| Local runtime CUDA (optional) | Yes (NVIDIA) | No | Yes (NVIDIA) | Only via local Ollama runtime |
-| Local runtime Metal/MPS (optional) | No | Yes | No | Only via local Ollama runtime |
-| Local runtime CPU (optional) | Yes | Yes | Yes | Fallback for local runtime mode |
+| Mode                               | Windows                        | macOS (Apple Silicon)                         | Linux                          | Notes                           |
+| ---------------------------------- | ------------------------------ | --------------------------------------------- | ------------------------------ | ------------------------------- |
+| Browser WebGPU                     | Yes (browser/driver dependent) | Yes (browser/driver dependent; Metal backend) | Yes (browser/driver dependent) | Primary acceleration path       |
+| Browser WASM CPU                   | Yes                            | Yes                                           | Yes                            | Guaranteed fallback             |
+| Local runtime CUDA (optional)      | Yes (NVIDIA)                   | No                                            | Yes (NVIDIA)                   | Only via local Ollama runtime   |
+| Local runtime Metal/MPS (optional) | No                             | Yes                                           | No                             | Only via local Ollama runtime   |
+| Local runtime CPU (optional)       | Yes                            | Yes                                           | Yes                            | Fallback for local runtime mode |
 
 ---
 
@@ -157,6 +202,7 @@ Use this as optional enhancement, not baseline, to preserve pure in-browser comp
 ## 4.1 Item 1 - Micro-Batch Embedding
 
 Implementation:
+
 - Change worker API from `embed(text)` to `embedBatch(texts: string[])`.
 - Batch target starts at `16`; dynamic adaptation:
   - Increase batch size gradually if latency and memory are healthy.
@@ -164,15 +210,18 @@ Implementation:
 - Return ordered vectors aligned to input chunk IDs.
 
 Tradeoffs:
+
 - Pros: lower overhead, better throughput.
 - Cons: higher transient memory, more complex error handling for partial failures.
 
 Mitigation:
+
 - If one batch fails, bisect batch (binary split) to isolate problematic text and continue.
 
 ## 4.2 Item 2 - Checkpointed SQLite Persistence
 
 Implementation:
+
 - Keep transactional upsert behavior, but delay `persist()` by policy:
   - `checkpointEveryEmbeddings = 256` (default)
   - `checkpointEveryMs = 3000` (default)
@@ -180,15 +229,18 @@ Implementation:
 - Keep "durability window" visible in diagnostics (e.g., "last checkpoint: 2.1s ago").
 
 Tradeoffs:
+
 - Pros: major speedup by reducing DB export frequency.
 - Cons: small recent window may be lost on hard crash/tab close.
 
 Mitigation:
+
 - Short interval checkpoints + final forced flush.
 
 ## 4.3 Item 3 - Small Worker Pool
 
 Implementation:
+
 - Add orchestrator queue with bounded pool size:
   - Default `poolSize=2`
   - Auto-cap by device memory and hardware concurrency.
@@ -196,16 +248,19 @@ Implementation:
 - Central dedupe cache still in main thread for duplicate chunk text.
 
 Tradeoffs:
+
 - Pros: better CPU/GPU utilization, faster wall-clock indexing.
 - Cons: higher memory pressure (model loaded per worker), more coordination complexity.
 
 Mitigation:
+
 - Hard cap pool size at 2 by default.
 - Auto-downshift to 1 on memory pressure or mobile devices.
 
 ## 4.4 Item 4 - WebGPU + Fallback Policy
 
 Implementation:
+
 - At startup run backend probe:
   - Try `webgpu` backend for embeddings.
   - On probe failure, log reason and switch to `wasm`.
@@ -214,10 +269,12 @@ Implementation:
 - Keep feature flag to disable WebGPU quickly if regressions occur.
 
 Tradeoffs:
+
 - Pros: potentially large speedup on supported hardware.
 - Cons: backend variability by browser/driver, larger operational test matrix.
 
 Mitigation:
+
 - Conservative fallback and runtime telemetry.
 - Keep CPU path fully supported and tested.
 
@@ -226,11 +283,13 @@ Mitigation:
 ## 5) Security and Privacy Impacts
 
 New considerations:
+
 - More workers means larger in-memory footprint of private README-derived text.
 - Deferred persistence introduces a short durability window.
 - WebGPU reveals broader hardware execution path characteristics.
 
 Required controls:
+
 - Keep all embedding text local; never send to remote endpoints unless explicit LLM opt-in.
 - Keep CSP strict and lock model download hosts.
 - Add memory pressure guardrails (max queue size, max pool size).
@@ -241,6 +300,7 @@ Required controls:
 ## 6) Testing and Benchmark Plan
 
 Automated:
+
 - Unit tests for:
   - batch request ordering
   - scheduler fairness and completion
@@ -251,6 +311,7 @@ Automated:
   - chat/session behavior unaffected
 
 Manual benchmark protocol:
+
 - Dataset buckets: 200, 1k, 2k starred repos.
 - Measure:
   - time to first searchable chunk
@@ -262,6 +323,7 @@ Manual benchmark protocol:
   - optimized variants
 
 Acceptance target:
+
 - 30-60% indexing speed improvement on modern laptops without relevance regression.
 
 ---

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,106 @@
+# GitStarRecall Feature Inventory
+
+The complete product surface. `README.md` keeps a short summary; this document holds the detail.
+Operational instructions live in [Usage.md](./Usage.md); dated change history lives in
+[changelogs.md](./changelogs.md).
+
+## Search and recall
+
+- Natural-language search over starred repositories' README content.
+- Retrieval pipeline: dense candidate retrieval (`fetchK`), a dense confidence gate, a conditional
+  lexical safety net, conditional RRF fusion, then MMR reranking with a per-repo cap.
+- Rare-token lexical triggering, bypassed when dense top-1 is both highly confident and lexically
+  aligned with the query; tiny-corpus high-confidence queries skip the lexical branch entirely.
+- Lexical candidate pool is mixed (recent, oldest, and a broad deterministic window), not recency-only.
+- Dimension compatibility guard: a query whose vector length disagrees with the index is rejected rather
+  than scored meaninglessly.
+- Local retrieval diagnostics: query and index dimensions, dense score distribution, lexical trigger
+  reason, pool counters, corpus counts.
+- Session-aware search and follow-up flow over existing local embeddings.
+- Library browsing and session transcript views outside the main Recall workflow.
+
+## Retrieval tuning (developer advanced mode)
+
+Enabled by an explicit in-UI checkbox, persisted per auth scope. Exposes `fetchK`, `topK`, `mmrLambda`,
+`maxChunksPerRepo`, `lexicalTop1Threshold`, `lexicalTop5MeanThreshold`, and a `Rebuild Embeddings`
+action. Includes a guidance warning when `fetchK < topK * 6`, and a standing warning that advanced
+tuning can reduce relevance, speed, or efficiency. See [Usage §10.1](./Usage.md).
+
+## Indexing
+
+- GitHub OAuth and PAT authentication paths.
+- Star sync with pagination handling, user-triggered via `Fetch Stars`.
+- Checksum-based diff sync for new, changed, and removed stars.
+- README fetch pipeline with missing/failure tracking: a transient failure preserves stored text,
+  validators, checksum, and chunks, then marks the repository for retry; 404 is a stable known-empty
+  state; 304 preserves stored content.
+- Retry waits are abortable and honor GitHub rate limits; star and fork counts refresh even when other
+  repository metadata is unchanged.
+- Adaptive batched README ingestion pipeline (feature-flagged via `VITE_README_BATCH_PIPELINE_V2`).
+- Local chunking, normalization, quality filtering, and embedding generation.
+- Embedding worker pool with micro-batching, adaptive downshift under memory pressure, checkpoint
+  resume via `index_meta`, and deterministic WebGPU to WASM backend fallback.
+- Browser embedding capability probe with model recommendation: `onnx-community/embeddinggemma-300m-ONNX`
+  on strong desktop with WebGPU, `Xenova/all-MiniLM-L6-v2` on mobile, weak desktop, or no WebGPU.
+- Opt-in local Ollama embeddings, restricted to localhost endpoints, with automatic fallback to browser
+  embeddings when the endpoint is unhealthy.
+- Large-library mode above a configurable repo threshold: prioritizes high-value repos first and stores a
+  resume cursor so interrupted jobs continue without a full restart.
+- One current embedding per chunk enforced, with model, dimension, and coverage readiness validation.
+- Sync status distinguishes first sync from incremental sync and keeps embedding generation as the
+  primary active stage when stages overlap.
+
+## Answering
+
+- Persistent chat sessions with ordered message history.
+- Local providers: Ollama and LM Studio, behind an explicit local-provider consent toggle.
+- In-browser provider: WebLLM, feature-flagged via `VITE_WEBLLM_ENABLED`, with consent required before
+  the first model download and no GitHub token in any request.
+- Remote providers: OpenAI-compatible endpoints, behind an explicit remote-provider consent toggle, with
+  a visible "data is sent" notice in the composer.
+- Deterministic provider fallback chain, and generation against an immutable request config so a later
+  render cannot change the endpoint mid-request.
+- Provider API keys optionally encrypted at rest via `VITE_LLM_SETTINGS_ENCRYPTION_KEY`.
+
+## Workspace
+
+- Route-based shell with `Setup`, `Recall`, `Library`, `Sessions`, and `Settings` surfaces.
+- Authenticated route pages load lazily behind an accessible Suspense boundary at the shell outlet, so
+  shell chrome stays visible while a chunk resolves. `/` and `/auth/callback` remain eager.
+- Command palette (`Cmd/Ctrl+K`), `Cmd/Ctrl+,` for Settings, and `G` then `R`/`L`/`S` for
+  Recall/Library/Sessions.
+- First-time users are routed from `/app` to `/app/setup`. Users with repos but an incomplete index see a
+  3-step onboarding stepper; returning users land on a home dashboard with a collapsible workspace guide
+  and quick-nav cards.
+- Workspace health and embedding run telemetry surfaced in-app: backend selection and fallback reason,
+  throughput, checkpoint behavior, queue depth, worker pool downshift events.
+
+## Privacy and data controls
+
+- Every local store is scoped per authenticated GitHub identity: database, chat backups, provider
+  settings, scoped preferences, and local logs. One identity never reads another's index, and the same
+  identity keeps its workspace across OAuth token refreshes or PAT re-entry.
+- Single-writer enforcement where Web Locks is available: one tab holds a lease per scope; a second tab is
+  refused write access rather than silently last-writer-wins. Browsers without Web Locks retain the
+  documented residual multi-tab risk.
+- Confirmed local-data deletion across five categories (repository data, model caches, provider
+  settings, scoped preferences, logs), attempting every category and reporting partial failure rather
+  than false success. See [Usage §11](./Usage.md).
+- Local diagnostic logs are redacted at capture, capped, expire after 7 days, and are deletable.
+- Chat history backup in scoped IndexedDB with a scoped localStorage fallback; a scoped clear fails
+  closed rather than reporting success when a storage backend cannot be written.
+
+## Public landing page
+
+Design system: "Midnight Minimal".
+
+- CSS atmospheric gradient background with ambient drift animation.
+- Bricolage Grotesque / Outfit / JetBrains Mono font stack.
+- Solid card surfaces with a hot coral accent and scroll-triggered entrance animations.
+- Hero contains a direct "Continue with GitHub" OAuth button (zero-click auth) plus a "Use a PAT
+  instead" secondary CTA; authenticated visitors see "Open app".
+- Compact auth section one scroll below the hero, with OAuth and PAT side by side.
+- Lean static "How it works" 3-step section downstream of auth.
+- Minimal footer with brand lockup, Star on GitHub pill, categorized resource and security link columns,
+  theme-native badge pills (DeepWiki, MIT, STRIDE), and author attribution.
+- Explicit read-only access trust badge in both the hero and the auth section.

--- a/docs/remediation/v0.14.0.md
+++ b/docs/remediation/v0.14.0.md
@@ -9,14 +9,17 @@ Scope note: this document records what shipped. Where a planned item did not shi
 
 ## Merged program
 
-| Slice                                                                    | PR                                                                 | Merge commit       | Branch                                      |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------ | ------------------------------------------- |
-| PR 1 — reproducible tooling and quality foundation                       | [#46](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/46) | `6a0d229`          | `codex/remediation-01-quality-foundation`   |
-| PR 2 — public-launch security boundary and repository hygiene            | [#47](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/47) | `2f64105` (squash) | `codex/remediation-02-launch-boundary`      |
-| PR 3 — sync, provider-settings, and OAuth integrity                      | [#54](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/54) | `1d8e24a`          | `codex/remediation-03-core-integrity`       |
-| PR 4 — provider transport, WebLLM, and worker reliability                | [#55](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/55) | `5700cf4`          | `codex/remediation-04-provider-reliability` |
-| PR 5 — storage safety, scoped privacy, and small UX correctness          | [#56](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/56) | `ccaec77`          | `codex/remediation-05-storage-privacy-ux`   |
-| PR 6 — launch performance, current documentation, and the 0.14.0 release | pending                                                            | pending            | `codex/remediation-06-launch-release`       |
+| Slice                                                                    | PR                                                                 | Merge commit         | Branch                                      |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------ | -------------------- | ------------------------------------------- |
+| PR 1 — reproducible tooling and quality foundation                       | [#46](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/46) | `6a0d229`            | `codex/remediation-01-quality-foundation`   |
+| PR 2 — public-launch security boundary and repository hygiene            | [#47](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/47) | `2f64105` (squash)   | `codex/remediation-02-launch-boundary`      |
+| PR 3 — sync, provider-settings, and OAuth integrity                      | [#54](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/54) | `1d8e24a`            | `codex/remediation-03-core-integrity`       |
+| PR 4 — provider transport, WebLLM, and worker reliability                | [#55](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/55) | `5700cf4`            | `codex/remediation-04-provider-reliability` |
+| PR 5 — storage safety, scoped privacy, and small UX correctness          | [#56](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/56) | `ccaec77`            | `codex/remediation-05-storage-privacy-ux`   |
+| PR 6 — launch performance, current documentation, and the 0.14.0 release | [#57](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/57) | open, not yet merged | `codex/remediation-06-launch-release`       |
+
+PR 6 was still open when this document was written. Replace its merge-commit cell with the real commit
+once it lands; until then, treat every PR 6 claim below as describing the branch, not `main`.
 
 ## PR 1 — tooling and quality foundation (#46, `6a0d229`)
 
@@ -148,8 +151,8 @@ Dropped when the original twelve-PR program was reduced:
 
 Planned for lean PR 5 but not delivered:
 
-- **ADR selecting single-writer storage.** No ADR document exists in `docs/`. The single-writer lease
-  shipped, but the decision record justifying it against an OPFS SQLite VFS migration was not written.
+- ~~**ADR selecting single-writer storage.**~~ **Delivered in the release work** as
+  [`../adr/0005-single-writer-web-locks-lease.md`](../adr/0005-single-writer-web-locks-lease.md).
 - **Idempotent `PRAGMA user_version` migrations applied to a copy before replacing persisted bytes.**
   No `user_version` mechanism exists. Schema setup remains `runSchema`'s idempotent
   `CREATE TABLE IF NOT EXISTS` plus `ALTER TABLE ... ADD COLUMN` introspection, with drop/recreate

--- a/docs/remediation/v0.14.0.md
+++ b/docs/remediation/v0.14.0.md
@@ -1,0 +1,177 @@
+# v0.14.0 Lean Public-Launch Remediation — Evidence
+
+Maps the six-PR lean remediation program to the pull requests and commits that actually landed, and
+records what was deliberately deferred. Baseline for the program is `d5c071a` (tag `v0.13.2`), which
+is also the fixed baseline commit used by the bundle-budget policy.
+
+Scope note: this document records what shipped. Where a planned item did not ship, it is listed under
+"Deferred and not shipped" rather than described as complete.
+
+## Merged program
+
+| Slice                                                                    | PR                                                                 | Merge commit       | Branch                                      |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------ | ------------------------------------------- |
+| PR 1 — reproducible tooling and quality foundation                       | [#46](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/46) | `6a0d229`          | `codex/remediation-01-quality-foundation`   |
+| PR 2 — public-launch security boundary and repository hygiene            | [#47](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/47) | `2f64105` (squash) | `codex/remediation-02-launch-boundary`      |
+| PR 3 — sync, provider-settings, and OAuth integrity                      | [#54](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/54) | `1d8e24a`          | `codex/remediation-03-core-integrity`       |
+| PR 4 — provider transport, WebLLM, and worker reliability                | [#55](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/55) | `5700cf4`          | `codex/remediation-04-provider-reliability` |
+| PR 5 — storage safety, scoped privacy, and small UX correctness          | [#56](https://github.com/Abhinandan-Khurana/GitStarRecall/pull/56) | `ccaec77`          | `codex/remediation-05-storage-privacy-ux`   |
+| PR 6 — launch performance, current documentation, and the 0.14.0 release | pending                                                            | pending            | `codex/remediation-06-launch-release`       |
+
+## PR 1 — tooling and quality foundation (#46, `6a0d229`)
+
+Commits: `f1d4c0f`, `edc78d0`, `bd35f9e`, `5963d94`.
+
+- Pinned Node 22/24 in `engines` and pnpm 11.17.0 in `packageManager`; tracked
+  `pnpm-workspace.yaml` with an explicit dependency build allowlist (`strictDepBuilds`,
+  `minimumReleaseAge`, `blockExoticSubdeps`).
+- Added component (jsdom) and browser (Playwright) harnesses, coverage reporting, and bundle budgets.
+- Added `.github/workflows/quality.yml` with a Node 24 primary job and Node 22 compatibility job,
+  actions pinned to full commit SHAs, `permissions: contents: read`, and concurrency cancellation.
+- Lint enforced at `--max-warnings=0` with baseline warnings removed.
+
+## PR 2 — public launch boundary (#47, `2f64105`)
+
+Verified in-tree at `api/github/oauth/exchange.js`, `vercel.json`, `index.html`, `LICENSE`,
+`public/static/`, `public/sitemap.xml`.
+
+- OAuth exchange: POST-only, JSON content-type check, 8 KiB body cap returning 413, exact field
+  validation, `AbortController` upstream timeout, bounded error bodies, and
+  `Cache-Control: no-store, private`.
+- Production security headers added in `vercel.json`: CSP, `X-Content-Type-Options: nosniff`,
+  `Referrer-Policy: no-referrer`, `Permissions-Policy`, `X-Frame-Options: DENY`.
+- Catch-all SPA rewrite replaced with explicit entry-route rewrites, so unknown public paths return a
+  real 404 rather than a 200 HTML shell.
+- MIT attribution corrected to Abhinandan Khurana; favicon declared as `image/x-icon`; social and
+  favicon assets published under `public/static/`; an unreferenced 4.3 MB image removed;
+  authenticated routes removed from the sitemap.
+
+Known accepted residual: the production CSP still allows `'unsafe-eval'`, which the in-browser model
+runtimes require. This is a documented compromise, not an oversight.
+
+## PR 3 — sync, settings, and auth integrity (#54, `1d8e24a`)
+
+Commits include `8dc1565`, `cd7ca74`, `956ade2`, `abe2afe`, `991f4d6`, `f7a1572`, `df1e64d`,
+`e9f424c`, `995e6af`, `bcea1c6`, `cf89a77`.
+
+- Transient README failures preserve stored text, validators, checksum, and chunks, then mark the
+  repository for retry; 404 is a stable known-empty state and 304 preserves stored content.
+- Retry waits are abortable and honor rate limits; stars/forks refresh when other metadata is
+  unchanged.
+- Provider settings hydrate asynchronously and persist through an invocation-ordered queue, so a
+  pre-hydration save can no longer overwrite a stored encrypted key with a blank value.
+- OAuth callback exchange is single-flight under StrictMode and retryable, retaining state/verifier
+  until success or terminal validation failure.
+
+## PR 4 — provider and worker reliability (#55, `5700cf4`)
+
+Commits: `be9db6b`, `1496aa2`, `47ef401`, `060bb87`, `1a21ff6`.
+
+- Generation executes an immutable provider request config; the fallback path constructs and passes
+  its own config instead of depending on a later React render.
+- One shared loopback validator across Ollama chat, LM Studio chat, Ollama embeddings, and local
+  discovery; adversarial hostname forms rejected at the request boundary.
+- SSE and JSONL decoders finalize residual buffers at EOF without requiring a trailing newline.
+- One pending WebLLM generation resumes exactly once across consent/download; cancellation discards it.
+- Embedding worker requests reject on `error`, `messageerror`, timeout, malformed response, and
+  termination; surplus idle workers retire on downshift.
+
+## PR 5 — storage safety, scoped privacy, UX (#56, `ccaec77`)
+
+Commits: `b03b682`, `c9c8046`, `a83ed02`, `0788548`, `12a5b95`, `3f473af`, `51cabb6`, `15dc1ff`,
+`0b74de5`, `9561c8c`, `be14640`.
+
+- Workspace writes serialized through one persistence queue so the newest acknowledged mutation is the
+  durable one.
+- Single-writer ownership per scope via a Web Locks exclusive lease
+  (`acquireWriterLease`, `LocalDatabaseWriterLeaseError` in `src/db/client.ts`); a secondary tab is
+  refused write access rather than silently last-writer-wins.
+- Chat backups scoped per authenticated identity; clearing one identity leaves others byte-intact, and
+  a scoped clear fails closed when a captured storage backend cannot be written or disappears
+  mid-operation.
+- Legacy v1 chat records for the cleared identity are erased, not merely marked migrated, with
+  unrelated identities' entries preserved.
+- Local logs scoped, redacted, and expired; confirmed "Delete local data" enumerates every category and
+  reports partial failure instead of false success. OPFS removal failures propagate rather than being
+  swallowed.
+- One current embedding per chunk enforced, with model/dimension/coverage readiness validation.
+- Command-palette parsing/search, keyboard shortcuts in editable targets, listener cleanup, and
+  storage-resistant theme fallback corrected.
+
+## PR 6 — release slice (this PR)
+
+- Authenticated app route pages (`AppHomePage`, `SetupPage`, `RecallPage`, `LibraryPage`,
+  `SessionsPage`, `SettingsPage`) load via `React.lazy` behind an accessible `Suspense` boundary
+  placed at the shell outlet, so shell chrome stays visible while a chunk resolves. `/` and
+  `/auth/callback` remain eager; all paths, guards, and layouts unchanged.
+- Version metadata aligned to 0.14.0: `package.json` and the `softwareVersion` field of the JSON-LD
+  block in `index.html`. A targeted search found no other shipped version metadata.
+- Documentation corrected for supported runtimes (Node 22/24, pnpm 11.17.0), the `pnpm dev` versus
+  `vercel dev` distinction for the OAuth API, and the real persistence/search architecture.
+- Pre-implementation planning documents marked historical:
+  `docs/tech-stack-architecture-security-prd.md`, `docs/codex-claude-build-guide.md`.
+- Direct stale `sqlite-vec` claims corrected in `docs/dfd-diagrams.md` and
+  `docs/threat-modeling-stride.md`.
+
+## Architecture of record
+
+Corrects the most frequently repeated stale claim in the historical documents. The shipped system uses:
+
+- sql.js (SQLite compiled to WASM) held in memory, persisted by exporting the whole database.
+- OPFS as the primary persistence target, with a base64 localStorage snapshot as fallback; both scoped
+  per authenticated identity.
+- Embeddings stored as Float32 blobs in ordinary SQLite tables, read back as `Float32Array` views.
+- Exact in-process ranking: brute-force cosine similarity over all candidate vectors, then MMR with a
+  per-repo cap, with a conditional lexical safety net and RRF fusion.
+- Chat backup in a scoped IndexedDB store with scoped localStorage fallback.
+
+There is no `sqlite-vec`, no `sqlite-vec-wasm`, no vector virtual table, and no approximate-nearest-
+neighbour index anywhere in the shipped code.
+
+## Deferred and not shipped
+
+Deliberately out of scope for the lean program. Recorded so no reader assumes coverage.
+
+Dropped when the original twelve-PR program was reduced:
+
+- Behaviour-preserving decomposition of `UsagePage` (~4.2k lines) and `LocalDatabase` (~2.5k lines).
+  Both remain oversized.
+- Dedicated vector-ranking search worker; ranking still runs on the main thread.
+- 1k/10k/50k vector benchmarks and p95 latency budgets.
+- Fixed 40% initial-bundle reduction target. This release only lazy-loads authenticated routes; no
+  numeric reduction target is claimed.
+- Nightly Chromium/Firefox/WebKit, all-theme visual, and stream fuzz matrices.
+- Migration from sql.js to an OPFS SQLite VFS.
+- A global `OperationCoordinator` and pairwise operation-compatibility matrix.
+- Multi-writer database coordinator with interleaved-write stress testing. Superseded by the
+  single-writer lease.
+
+Planned for lean PR 5 but not delivered:
+
+- **ADR selecting single-writer storage.** No ADR document exists in `docs/`. The single-writer lease
+  shipped, but the decision record justifying it against an OPFS SQLite VFS migration was not written.
+- **Idempotent `PRAGMA user_version` migrations applied to a copy before replacing persisted bytes.**
+  No `user_version` mechanism exists. Schema setup remains `runSchema`'s idempotent
+  `CREATE TABLE IF NOT EXISTS` plus `ALTER TABLE ... ADD COLUMN` introspection, with drop/recreate
+  still used on the chat-table rebuild path.
+- **`BroadcastChannel` committed-revision broadcast** so non-writing tabs refresh after a commit. Not
+  present in `src/`; secondary tabs are refused writes but are not notified of another tab's commits.
+
+Not verifiable from this repository:
+
+- The Vercel firewall / rate-limit rule for `/api/github/oauth/exchange`. The lean plan allowed
+  enabling it only if the hosting plan supports it and explicitly forbade an in-memory serverless
+  limiter. No such limiter was added in-tree; whether a platform-side rule is enabled must be checked
+  in the Vercel dashboard.
+
+## Residual known issues
+
+Carried forward rather than silently closed:
+
+- The Web Locks lease resolves available when `navigator.locks` is absent, so a browser without Web
+  Locks does not fail closed for a second writer.
+- `migrateLocalDatabaseScope` still treats OPFS cleanup as best effort, so the stale-snapshot class of
+  bug remains on the scope-migration path even though `clearAllData` now propagates failures.
+- `clearAllData` swaps the in-memory database before removing persisted bytes, so a failed deletion
+  leaves an empty in-memory view against surviving persisted rows, reported as partial deletion.
+- The production CSP retains `'unsafe-eval'` for the model runtimes.

--- a/docs/security-review-stride.md
+++ b/docs/security-review-stride.md
@@ -2,6 +2,81 @@
 
 This document reviews the GitStarRecall codebase against the threats and mitigations in [threat-modeling-stride.md](./threat-modeling-stride.md). Each STRIDE category is mapped to current implementation status and concrete recommendations.
 
+> **Review currency.** The per-category tables in sections 1-8 were last re-derived on 2026-03-09. The
+> v0.14.0 update immediately below records what changed after that date and supersedes any older row it
+> contradicts. Where the two disagree, the v0.14.0 section is authoritative.
+
+## 2026-07-28 Update (v0.14.0 Public-Launch Hardening)
+
+Covers PRs #46, #47, #54, #55, and #56. Per-commit evidence and deferred work:
+[`remediation/v0.14.0.md`](./remediation/v0.14.0.md). Threat-side analysis:
+[`threat-modeling-stride.md` section 9](./threat-modeling-stride.md).
+
+Spoofing / auth:
+
+- OAuth callback exchange is single-flight under StrictMode and retryable, retaining state and verifier
+  until success or terminal validation failure, so a duplicated callback cannot burn the authorization code.
+- The exchange endpoint enforces POST, a JSON content type, an 8 KiB body cap returning 413, exact field
+  validation, an `AbortController` upstream timeout, bounded error bodies, and `Cache-Control: no-store, private`.
+
+Tampering:
+
+- **Mitigates the multi-tab gap where Web Locks is available.** One writing tab per scope via a Web Locks exclusive lease
+  (`acquireWriterLease`, `LocalDatabaseWriterLeaseError` in `src/db/client.ts`); a second tab is refused
+  write access rather than silently winning. Workspace writes are serialized through a single persistence
+  queue. Rationale and rejected alternatives:
+  [`adr/0005-single-writer-web-locks-lease.md`](./adr/0005-single-writer-web-locks-lease.md).
+- Production security headers now ship in `vercel.json` (CSP, `X-Content-Type-Options`,
+  `Referrer-Policy`, `Permissions-Policy`, `X-Frame-Options: DENY`), so CSP no longer depends on the Vite
+  dev/preview server. This resolves gap (3) in the Tampering table.
+- **Closes the embedding-reconciliation gap** listed as **Gap** in the Tampering table and as item 2 of
+  section 8: `src/db/embeddingIntegrity.ts` enforces one current embedding per chunk with model,
+  dimension, and coverage readiness validation.
+- Transient README failures preserve stored text, validators, checksum, and chunks, then mark the
+  repository for retry; 404 is a stable known-empty state and 304 preserves stored content.
+
+Information disclosure:
+
+- Local diagnostic logs are scoped per identity, redacted at capture (error details dropped entirely;
+  warning payloads reduced to an allowlist of numeric and boolean fields), capped at 200 entries, and
+  expired after 7 days. This directly addresses the standing Information Disclosure follow-up about
+  persisted message text.
+- Chat backups are scoped per authenticated identity; clearing one identity leaves others byte-intact,
+  and a scoped clear fails closed when a captured backend cannot be written.
+- The catch-all SPA rewrite was replaced with explicit entry-route rewrites, so unknown public paths
+  return a real 404 instead of a 200 HTML shell, and authenticated routes were removed from the sitemap.
+
+Repudiation:
+
+- `Delete local data` enumerates every category, attempts all of them even after a failure, reports
+  per-category failures, and signs out only on full success. OPFS removal failures propagate instead of
+  being swallowed.
+
+Denial of service / reliability:
+
+- Embedding worker requests reject on `error`, `messageerror`, timeout, malformed response, and
+  termination; surplus idle workers retire on downshift.
+- Retry waits are abortable and honor GitHub rate limits.
+- Generation executes an immutable provider request config, including on the fallback path.
+
+Residual and newly recorded:
+
+- The Web Locks lease resolves as available when `navigator.locks` is absent, so a second writer is not
+  refused on browsers lacking the API.
+- `migrateLocalDatabaseScope` still treats OPFS cleanup as best effort.
+- `clearAllData` swaps the in-memory database before removing persisted bytes, so a failed deletion is
+  reported as partial with an empty in-memory view over surviving rows.
+- Production CSP retains `'unsafe-eval'` for the in-browser model runtimes; this is a documented
+  runtime-compatibility trade-off, not a separate ADR.
+- Platform-side rate limiting for the exchange endpoint is not verifiable from this repository.
+
+Still open from section 8 after this release:
+
+- Item 1 is partially addressed: production CSP now ships in `vercel.json`, but a deployment that serves
+  the built assets from neither Vercel nor Vite still has no CSP of its own.
+- Item 3 (regression checks keeping docs and copy synchronized with `read:user` and public-only behavior)
+  remains unimplemented.
+
 ## 2026-02-24 Update (WebLLM Browser Provider)
 
 - Added feature-flagged Browser WebLLM provider (`VITE_WEBLLM_ENABLED=1`) with explicit consent-before-download gate.
@@ -79,31 +154,31 @@ Security posture notes:
 
 ## 1) S – Spoofing
 
-| Mitigation | Status | Evidence / Gap |
-|------------|--------|-----------------|
-| OAuth PKCE; avoid tokens in URL | **Done** | `src/auth/githubOAuth.ts`: `buildGitHubAuthorizeUrl` uses `code_challenge` (S256) and `code_verifier` in sessionStorage; token is obtained via `exchangeOAuthCode` (server-side exchange). Callback uses only `code` and `state` from URL; token never in URL. |
-| Clear separation public vs authenticated surfaces | **Done** | Public `LandingPage` remains at `/`, `AuthCallbackPage` remains at `/auth/callback`, and authenticated views now live behind `AppShell` routes (`/app/setup`, `/app/recall`, `/app/library`, `/app/sessions`, `/app/settings`). Auth token state remains in React memory; OAuth PKCE verifier/state use `sessionStorage` only for the OAuth handshake. |
-| Normalize pasted OAuth/PAT input before use | **Done** | `src/lib/normalizeGitHubToken.ts` strips header-style prefixes, surrounding quotes, and extra whitespace. `src/auth/AuthContext.tsx` applies it before storing the token in React state, then resolves the authenticated GitHub user before deriving account-scoped local keys. |
-| Warning banner when PAT is used; recommend OAuth | **Done** | Auth method is shown in the workspace account panel (`authMethod`: `oauth` / `pat`) and PAT sessions render an explicit warning with a GitHub OAuth action. Public landing/login copy also frames OAuth as the preferred path and PAT as a manual fallback. |
-| Strict CSP | **Done** | See Tampering / CSP below. |
-| Explicit opt-in for local endpoints; show endpoint origin | **Done** | `allowLocalProvider` is off by default; user must enable local providers in SessionChat model settings. Browser WebLLM additionally requires consent modal before first model download. |
+| Mitigation                                                | Status   | Evidence / Gap                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| OAuth PKCE; avoid tokens in URL                           | **Done** | `src/auth/githubOAuth.ts`: `buildGitHubAuthorizeUrl` uses `code_challenge` (S256) and `code_verifier` in sessionStorage; token is obtained via `exchangeOAuthCode` (server-side exchange). Callback uses only `code` and `state` from URL; token never in URL.                                                                                         |
+| Clear separation public vs authenticated surfaces         | **Done** | Public `LandingPage` remains at `/`, `AuthCallbackPage` remains at `/auth/callback`, and authenticated views now live behind `AppShell` routes (`/app/setup`, `/app/recall`, `/app/library`, `/app/sessions`, `/app/settings`). Auth token state remains in React memory; OAuth PKCE verifier/state use `sessionStorage` only for the OAuth handshake. |
+| Normalize pasted OAuth/PAT input before use               | **Done** | `src/lib/normalizeGitHubToken.ts` strips header-style prefixes, surrounding quotes, and extra whitespace. `src/auth/AuthContext.tsx` applies it before storing the token in React state, then resolves the authenticated GitHub user before deriving account-scoped local keys.                                                                        |
+| Warning banner when PAT is used; recommend OAuth          | **Done** | Auth method is shown in the workspace account panel (`authMethod`: `oauth` / `pat`) and PAT sessions render an explicit warning with a GitHub OAuth action. Public landing/login copy also frames OAuth as the preferred path and PAT as a manual fallback.                                                                                            |
+| Strict CSP                                                | **Done** | See Tampering / CSP below.                                                                                                                                                                                                                                                                                                                             |
+| Explicit opt-in for local endpoints; show endpoint origin | **Done** | `allowLocalProvider` is off by default; user must enable local providers in SessionChat model settings. Browser WebLLM additionally requires consent modal before first model download.                                                                                                                                                                |
 
 ---
 
 ## 2) T – Tampering
 
-| Mitigation | Status | Evidence / Gap |
-|------------|--------|-----------------|
-| Sanitize README rendering | **Done** | `src/components/SafeMarkdown.tsx`: all README and chat markdown is rendered via `ReactMarkdown` with `rehypeSanitize` (no `dangerouslySetInnerHTML`). |
-| CSP + no inline scripts | **Partial** | `vite.config.ts`: CSP is set in server/preview headers. `script-src` includes a pinned transformers jsDelivr dist path (instead of broad jsDelivr host access) because browser embedding runtime loads ORT JSEP module from that path. **Gaps:** (1) Production still has `script-src 'self' 'unsafe-eval'` (needed for runtime/tooling; document if intentional). (2) `style-src` includes `'unsafe-inline'` for fonts/styles. (3) No CSP in `index.html` for static hosting without Vite – if the app is deployed without Vite’s server/preview, CSP may not apply. |
-| Checksum format and integrity | **Done** | `src/github/checksum.ts`: `sha256Hex` and `canonicalChecksumInput`; used in `github/client.ts` for repo/README checksums. DB stores `checksum` and uses it for diffing (e.g. `UsagePage` “Diffing repos with checksum state”). |
-| Write operations only through controlled paths | **Done** | DB writes go through `src/db/client.ts` (e.g. `upsertRepos`, `upsertChunks`, etc.); no raw SQL from user input. |
-| Pin model source / versions | **Context** | Embedding model is loaded from Hugging Face / CDN; CSP `connect-src` restricts to known hosts. Version pinning is build/deploy concern. |
-| End-to-end embedding count reconciliation | **Gap** | Threat model suggests “chunks_pending + embeddings_created” reconciliation. Code has `getPendingEmbeddingChunkCount`, batch processing, and embedding run metrics, but no explicit reconciliation step that asserts `chunks_pending + embeddings_created` consistency. |
+| Mitigation                                     | Status      | Evidence / Gap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ---------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Sanitize README rendering                      | **Done**    | `src/components/SafeMarkdown.tsx`: all README and chat markdown is rendered via `ReactMarkdown` with `rehypeSanitize` (no `dangerouslySetInnerHTML`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| CSP + no inline scripts                        | **Partial** | `vite.config.ts`: CSP is set in server/preview headers. `script-src` includes a pinned transformers jsDelivr dist path (instead of broad jsDelivr host access) because browser embedding runtime loads ORT JSEP module from that path. **Gaps:** (1) Production still has `script-src 'self' 'unsafe-eval'`, a documented runtime compatibility trade-off; production headers are served from `vercel.json`, not only Vite. (2) `style-src` includes `'unsafe-inline'` for fonts/styles. (3) No CSP in `index.html` for static hosting without Vite – if the app is deployed without Vite’s server/preview, CSP may not apply. |
+| Checksum format and integrity                  | **Done**    | `src/github/checksum.ts`: `sha256Hex` and `canonicalChecksumInput`; used in `github/client.ts` for repo/README checksums. DB stores `checksum` and uses it for diffing (e.g. `UsagePage` “Diffing repos with checksum state”).                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Write operations only through controlled paths | **Done**    | DB writes go through `src/db/client.ts` (e.g. `upsertRepos`, `upsertChunks`, etc.); no raw SQL from user input.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Pin model source / versions                    | **Context** | Embedding model is loaded from Hugging Face / CDN; CSP `connect-src` restricts to known hosts. Version pinning is build/deploy concern.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| End-to-end embedding count reconciliation      | **Gap**     | Threat model suggests “chunks_pending + embeddings_created” reconciliation. Code has `getPendingEmbeddingChunkCount`, batch processing, and embedding run metrics, but no explicit reconciliation step that asserts `chunks_pending + embeddings_created` consistency.                                                                                                                                                                                                                                                                                                                                                         |
 
 **Recommendations:**
 
-- Document why `unsafe-eval` is required in production CSP, or remove it if no longer needed.
+- Document why `unsafe-eval` is required in production CSP in the release record, and revisit if the model runtimes stop requiring it, at which point tighten to `wasm-unsafe-eval`.
 - If the app is served without Vite (e.g. static export), add CSP via meta tag or server config and keep it aligned with `vite.config.ts`.
 - Consider adding a reconciliation check (e.g. after sync/embedding run) that verifies pending vs created counts and surfaces or logs mismatches.
 
@@ -111,11 +186,11 @@ Security posture notes:
 
 ## 3) R – Repudiation
 
-| Mitigation | Status | Evidence / Gap |
-|------------|--------|-----------------|
-| Store audit metadata locally | **Done** | Last sync and indexing state are reflected in UI (e.g. `indexingStatus`, `starsSummary`, sync phase). LLM usage is gated by `allowRemoteProvider` / `allowLocalProvider` (opt-in). |
+| Mitigation                                  | Status   | Evidence / Gap                                                                                                                                                                        |
+| ------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Store audit metadata locally                | **Done** | Last sync and indexing state are reflected in UI (e.g. `indexingStatus`, `starsSummary`, sync phase). LLM usage is gated by `allowRemoteProvider` / `allowLocalProvider` (opt-in).    |
 | “Data sent” notice when remote LLMs enabled | **Done** | `src/components/SessionChat.tsx` renders a visible composer-adjacent notice when `allowRemoteProvider` is enabled: data is sent to the remote provider when the user sends a message. |
-| Embedding run metadata | **Done** | `UsagePage` stores and displays embedding run metadata: backend, pool size, downshift, batch count, latency, queue depth, etc. |
+| Embedding run metadata                      | **Done** | `UsagePage` stores and displays embedding run metadata: backend, pool size, downshift, batch count, latency, queue depth, etc.                                                        |
 
 No material repudiation gaps identified beyond keeping local audit/status metadata aligned with future provider surfaces.
 
@@ -123,13 +198,13 @@ No material repudiation gaps identified beyond keeping local audit/status metada
 
 ## 4) I – Information Disclosure
 
-| Mitigation | Status | Evidence / Gap |
-|------------|--------|-----------------|
-| External LLM off by default; explicit opt-in | **Done** | `allowRemoteProvider` and `allowLocalProvider` default to `false` in `UsagePage.tsx`; sending requires enabling the matching checkbox. |
-| Send only top-K snippets to LLM | **Done** | `src/llm/providers.ts`: `TOP_K_LIMIT = 8`; `buildContextBlock` uses `snippets.slice(0, TOP_K_LIMIT)`. `UsagePage` passes `filteredResults.slice(0, 8)`. |
-| Token in memory or scoped key derivation only | **Done** | `AuthContext` keeps the raw GitHub token in React state only; no token value is written to `localStorage` or SQLite. Local namespacing is derived from the authenticated GitHub account identity instead of the raw token, so token rotation does not change the persisted scope. |
-| Chat backup and runtime caches remain local-only and wipeable | **Done** | Chat sessions/messages are backed up client-side (`src/db/chatBackup.ts`) using IndexedDB with localStorage fallback. No token is written to backup. `handleClearLocalData` clears scoped OPFS/localStorage DB bytes, chat backup copy, and browser cache entries used for WebLLM/model artifacts. |
-| “Clear all data” and “Clear token” | **Done** | UsagePage: “Clear token” (logout) clears the in-memory GitHub credential only, preserving account-scoped local settings/workspace state for the same GitHub identity. “Delete local data” (`handleClearLocalData` → `database.clearAllData()`) is the destructive reset path for scoped DB/chat/cache state. |
+| Mitigation                                                    | Status          | Evidence / Gap                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External LLM off by default; explicit opt-in                  | **Done**        | `allowRemoteProvider` and `allowLocalProvider` default to `false` in `UsagePage.tsx`; sending requires enabling the matching checkbox.                                                                                                                                                                                                                                                                      |
+| Send only top-K snippets to LLM                               | **Done**        | `src/llm/providers.ts`: `TOP_K_LIMIT = 8`; `buildContextBlock` uses `snippets.slice(0, TOP_K_LIMIT)`. `UsagePage` passes `filteredResults.slice(0, 8)`.                                                                                                                                                                                                                                                     |
+| Token in memory or scoped key derivation only                 | **Done**        | `AuthContext` keeps the raw GitHub token in React state only; no token value is written to `localStorage` or SQLite. Local namespacing is derived from the authenticated GitHub account identity instead of the raw token, so token rotation does not change the persisted scope.                                                                                                                           |
+| Chat backup and runtime caches remain local-only and wipeable | **Done**        | Chat sessions/messages are backed up client-side (`src/db/chatBackup.ts`) using IndexedDB with localStorage fallback. No token is written to backup. `handleClearLocalData` clears scoped OPFS/localStorage DB bytes, chat backup copy, and browser cache entries used for WebLLM/model artifacts.                                                                                                          |
+| “Clear all data” and “Clear token”                            | **Done**        | UsagePage: “Clear token” (logout) clears the in-memory GitHub credential only, preserving account-scoped local settings/workspace state for the same GitHub identity. “Delete local data” (`handleClearLocalData` → `database.clearAllData()`) is the destructive reset path for scoped DB/chat/cache state.                                                                                                |
 | Restrict debug logs (IDs/counts/timings; no README plaintext) | **Mostly done** | GitHub client logger (DEV-only) logs page/count/total/remaining, repo `full_name`, status, and README **length** only – not token or README content. `UsagePage.tsx` now logs full error objects only in `import.meta.env.DEV`; production console output and local observability keep message-only payloads. **Residual:** sensitive material must still never be embedded into error messages themselves. |
 
 **Recommendations:**
@@ -140,15 +215,15 @@ No material repudiation gaps identified beyond keeping local audit/status metada
 
 ## 5) D – Denial of Service
 
-| Mitigation | Status | Evidence / Gap |
-|------------|--------|-----------------|
-| Rate limit handling with backoff | **Done** | `src/github/client.ts`: `requestWithBackoff`, `shouldRetry` (429 and 403 with remaining=0), `getRetryDelayMs` (Retry-After, x-ratelimit-reset, exponential backoff with cap 30s). |
-| Concurrency caps for README fetch | **Done** | `DEFAULT_README_CONCURRENCY = 6`; pool of workers processes repos with that concurrency. |
-| Chunking and truncation of huge READMEs | **Done** | `src/chunking/chunker.ts`: `MAX_README_LENGTH = 100_000`; chunk sizes and overlaps defined. |
-| Web Worker for embedding | **Done** | Embeddings run in worker (`src/embeddings/worker.ts`); `Embedder` uses worker; `EmbeddingWorkerPool` uses multiple embedders. |
-| Cap worker pool size and queue depth | **Done** | `EmbeddingWorkerPool`: `maxQueueSize` (default 1024), `configuredPoolSize`, `workerBatchSize`; `embedBatch` throws if `texts.length > maxQueueSize`. |
-| Adaptive micro-batch downshift on failures | **Done** | Pool downshifts on memory-pressure-style errors; `WorkerPool` and `UsagePage` track downshift state and reason. |
-| Deterministic fallback webgpu → wasm | **Done** | Worker/embedder supports backend preference and fallback; fallback reason is tracked in run metadata. |
+| Mitigation                                 | Status   | Evidence / Gap                                                                                                                                                                    |
+| ------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rate limit handling with backoff           | **Done** | `src/github/client.ts`: `requestWithBackoff`, `shouldRetry` (429 and 403 with remaining=0), `getRetryDelayMs` (Retry-After, x-ratelimit-reset, exponential backoff with cap 30s). |
+| Concurrency caps for README fetch          | **Done** | `DEFAULT_README_CONCURRENCY = 6`; pool of workers processes repos with that concurrency.                                                                                          |
+| Chunking and truncation of huge READMEs    | **Done** | `src/chunking/chunker.ts`: `MAX_README_LENGTH = 100_000`; chunk sizes and overlaps defined.                                                                                       |
+| Web Worker for embedding                   | **Done** | Embeddings run in worker (`src/embeddings/worker.ts`); `Embedder` uses worker; `EmbeddingWorkerPool` uses multiple embedders.                                                     |
+| Cap worker pool size and queue depth       | **Done** | `EmbeddingWorkerPool`: `maxQueueSize` (default 1024), `configuredPoolSize`, `workerBatchSize`; `embedBatch` throws if `texts.length > maxQueueSize`.                              |
+| Adaptive micro-batch downshift on failures | **Done** | Pool downshifts on memory-pressure-style errors; `WorkerPool` and `UsagePage` track downshift state and reason.                                                                   |
+| Deterministic fallback webgpu → wasm       | **Done** | Worker/embedder supports backend preference and fallback; fallback reason is tracked in run metadata.                                                                             |
 
 No material gaps identified for DoS mitigations.
 
@@ -156,10 +231,10 @@ No material gaps identified for DoS mitigations.
 
 ## 6) E – Elevation of Privilege
 
-| Mitigation | Status | Evidence / Gap |
-|------------|--------|-----------------|
-| Minimal GitHub scopes / fine-grained PAT | **Done** | OAuth now uses `["read:user"]` in `getOAuthConfig()`, and runtime sync filters private repositories before indexing so the app remains public-repo read-only. |
-| Local endpoints clearly labeled; explicit opt-in | **Done** | Local provider is labeled “Local (Ollama)” in SessionChat; base URL is user-editable in the same panel; use requires `allowLocalProvider`. |
+| Mitigation                                            | Status   | Evidence / Gap                                                                                                                                                                       |
+| ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Minimal GitHub scopes / fine-grained PAT              | **Done** | OAuth now uses `["read:user"]` in `getOAuthConfig()`, and runtime sync filters private repositories before indexing so the app remains public-repo read-only.                        |
+| Local endpoints clearly labeled; explicit opt-in      | **Done** | Local provider is labeled “Local (Ollama)” in SessionChat; base URL is user-editable in the same panel; use requires `allowLocalProvider`.                                           |
 | Browser embedding path default; local Ollama explicit | **Done** | Default embedding flow is in-browser worker embedding; optional Ollama embedding is explicit and localhost-restricted. Browser WebLLM LLM path is feature-flagged and consent-gated. |
 
 **Recommendation:** Keep docs and landing copy aligned with the public-repo-only policy and continue to steer PAT users toward minimal read-only permissions.
@@ -168,14 +243,14 @@ No material gaps identified for DoS mitigations.
 
 ## 7) Summary Table
 
-| STRIDE | Overall | Gaps / Follow-ups |
-|--------|--------|-------------------|
-| **S** Spoofing | Aligned | PAT warning banner; recommend OAuth when PAT is used. |
-| **T** Tampering | Aligned | Document CSP (`unsafe-eval`); ensure CSP when not using Vite; optional embedding reconciliation. |
-| **R** Repudiation | Aligned | Keep disclosure/audit copy aligned as new provider surfaces are added. |
-| **I** Information Disclosure | Mostly aligned | Keep sensitive material out of error messages because local/prod logging persists message text. |
-| **D** Denial of Service | Aligned | — |
-| **E** Elevation of Privilege | Aligned | Keep OAuth scope at `read:user` and enforce public-repo-only indexing behavior. |
+| STRIDE                       | Overall        | Gaps / Follow-ups                                                                                |
+| ---------------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| **S** Spoofing               | Aligned        | PAT warning banner; recommend OAuth when PAT is used.                                            |
+| **T** Tampering              | Aligned        | Document CSP (`unsafe-eval`); ensure CSP when not using Vite; optional embedding reconciliation. |
+| **R** Repudiation            | Aligned        | Keep disclosure/audit copy aligned as new provider surfaces are added.                           |
+| **I** Information Disclosure | Mostly aligned | Keep sensitive material out of error messages because local/prod logging persists message text.  |
+| **D** Denial of Service      | Aligned        | —                                                                                                |
+| **E** Elevation of Privilege | Aligned        | Keep OAuth scope at `read:user` and enforce public-repo-only indexing behavior.                  |
 
 ---
 

--- a/docs/tech-stack-architecture-security-prd.md
+++ b/docs/tech-stack-architecture-security-prd.md
@@ -1,8 +1,25 @@
 # GitStarRecall - Tech Stack, Architecture, Security, Threat Model, PRD
 
+> **HISTORICAL — pre-implementation planning document. Retained for provenance; not accurate for the
+> shipped system.**
+>
+> This was written before implementation and describes choices that were never shipped — most
+> notably `sqlite-vec` / `sqlite-vec-wasm` for vector search. The shipped app uses sql.js with
+> Float32 vector blobs in ordinary SQLite tables, ranked in-process with exact cosine similarity plus
+> MMR, persisted to OPFS with a scoped localStorage snapshot fallback.
+>
+> For the current system, use these sources instead:
+>
+> - Architecture and setup: [`../README.md`](../README.md)
+> - Runtime, configuration, storage, and troubleshooting: [`Usage.md`](Usage.md)
+> - Security posture: [`security-review-stride.md`](security-review-stride.md) and
+>   [`threat-modeling-stride.md`](threat-modeling-stride.md)
+> - v0.14.0 remediation evidence: [`remediation/v0.14.0.md`](remediation/v0.14.0.md)
+
 This document defines the recommended tech stack, architecture, security approach, threat model, and product requirements for GitStarRecall.
 
 Design reference:
+
 - The HTML/CSS in `rought-UI-design` is a reference only, not a pixel-perfect target.
 - The final UI should incorporate creative improvements while respecting the overall layout intent.
 - Emphasize security and local-first behavior visually and in copy.
@@ -15,6 +32,7 @@ Design reference:
 ## 1) Tech Stack (Recommended)
 
 ### 1.1 Frontend (Web App)
+
 - Framework: Vite + React
 - Language: TypeScript
 - Styling: Tailwind CSS or Panda CSS
@@ -24,6 +42,7 @@ Design reference:
 - Background tasks: Web Workers for embedding and indexing
 
 ### 1.2 Client-Side Storage and Search
+
 - Storage: SQLite WASM (browser) with persistent file storage (OPFS where available)
 - Cache: In-memory LRU for hot queries
 - Vector index: `sqlite-vec` via `sqlite-vec-wasm` (WASM-compatible)
@@ -34,6 +53,7 @@ Design reference:
   - Note: sqlite-vec must be statically compiled into the SQLite WASM build (no dynamic extension loading in WASM).
 
 ### 1.3 Embeddings (Local-First)
+
 - Primary: `@huggingface/transformers` (browser worker runtime)
 - Browser model policy (capability-driven):
   - strong desktop + WebGPU -> `onnx-community/embeddinggemma-300m-ONNX`
@@ -53,6 +73,7 @@ Design reference:
 - Fallback: server embeddings (optional, opt-in)
 
 ### 1.3.1 Retrieval v2 (Query-Time)
+
 - Dense candidate retrieval (`fetchK`) with cosine similarity.
 - Dense confidence gate to decide whether lexical safety-net is needed.
 - Lexical retrieval is conditional (safety-net only when dense confidence is weak).
@@ -61,12 +82,14 @@ Design reference:
 - Strict query/index embedding dimension compatibility checks.
 
 ### 1.4 Backend (Optional Hybrid)
+
 - API layer: Next.js API routes or Fastify
 - OAuth callback handling for GitHub login
 - Provider gateway for LLM calls (optional)
 - Rate limiting and request normalization
 
 ### 1.5 LLM Provider Abstraction
+
 - Remote providers: OpenAI, Anthropic, Gemini, DeepSeek, etc.
 - Local providers: Ollama and LM Studio (optional)
 - Browser provider: WebLLM (feature-flagged, opt-in download consent)
@@ -79,12 +102,14 @@ Design reference:
   - Browser WebLLM: in-browser WebGPU runtime + locally cached model assets
 
 WebLLM model policy:
+
 - Primary: `Llama-3.2-1B-Instruct-q4f16_1-MLC`
 - Fallback: `SmolLM2-360M-Instruct-q4f16_1-MLC`
 - Additional selectable models: Qwen2.5 1.5B, Gemma 2 2B, Hermes 3 Llama 3 3B, Llama 3.1 3B
 - No model download starts before explicit user confirmation in UI
 
 ### 1.6 Local Provider Integration (Ollama, LM Studio)
+
 - Ollama:
   - Default base URL: `http://localhost:11434`
   - Model list and availability: `GET /api/tags`
@@ -100,6 +125,7 @@ WebLLM model policy:
 - CORS note: ensure local endpoints allow browser access or provide a local proxy option if needed.
 
 ### 1.7 GitHub API
+
 - Endpoints:
   - `GET /user/starred` for user stars (paginated)
   - `GET /repos/{owner}/{repo}/readme` for README
@@ -108,7 +134,9 @@ WebLLM model policy:
 - Permissions: read-only access for starred public repositories (`read:user` OAuth scope + public-repo filtering at runtime)
 
 ### 1.8 Cross-Platform Compute Compatibility
+
 Browser-only (default local-first path):
+
 - Windows/macOS/Linux: WebGPU when available; automatic fallback to WASM CPU
 - Browser WebGPU maps to OS-native GPU stack:
   - Windows: Direct3D-based WebGPU backend
@@ -116,16 +144,19 @@ Browser-only (default local-first path):
   - Linux: Vulkan-based WebGPU backend
 
 Optional local runtime path (future enhancement):
+
 - Windows/Linux NVIDIA: CUDA via local runtime (Ollama/LM Studio runtime-managed)
 - macOS Apple Silicon: Metal/MPS-style acceleration via local runtime
 - CPU fallback on all platforms
 
 Browser local LLM path (implemented, feature-flagged):
+
 - WebLLM runs in-browser and uses WebGPU when available.
 - Device recommendation policy selects 1B for strong desktop and 360M for mobile/weak profiles.
 - If WebLLM fails, app retries with 360M and can fallback to other configured providers.
 
 Reference:
+
 - Detailed rollout and tradeoffs: `docs/embedding-acceleration-plan.md`
 
 ---
@@ -133,6 +164,7 @@ Reference:
 ## 2) Architecture
 
 ### 2.1 High-Level Flow
+
 1. User authenticates with GitHub OAuth or provides a PAT.
 2. `/app` auto-navigates first-time users (`repoCount === 0`) to `/app/setup`; returning users see the home dashboard with onboarding progress and workspace guide.
 3. App fetches all starred repositories via GitHub REST API (paginated).
@@ -147,6 +179,7 @@ Reference:
 12. Star sync is user-initiated via `Fetch Stars`; search queries run against the current local index.
 
 ### 2.2 Components
+
 - Public landing + authenticated app shell
 - Setup workspace for first-run indexing
 - Recall workspace: search, filters, results, suggestions, session-aware chat
@@ -164,6 +197,7 @@ Reference:
 - Provider gateway (optional): handles LLM calls and OAuth callback
 
 ### 2.3 Data Model (Simplified)
+
 - Repo
   - id, full_name, name, description, topics, language, html_url
   - stars, forks, updated_at, readme_url
@@ -187,6 +221,7 @@ Reference:
   - auth-hash-scoped settings keys for embedding/runtime preferences and session continuity
 
 ### 2.3.1 Chat Schema Sketch (SQLite)
+
 Example tables for persistence:
 
 ```sql
@@ -211,12 +246,15 @@ CREATE INDEX chat_messages_order_idx ON chat_messages(session_id, created_at, se
 ```
 
 Notes:
+
 - Timestamps use UNIX epoch milliseconds (INTEGER).
 - Message ordering is by `(created_at, sequence)` ascending within a session.
 - UI should show a session list and a selected session thread; users can start new sessions or continue an existing one.
 
 ### 2.3.2 Vector Storage + sqlite-vec-wasm (Implementation Note)
+
 Loading sqlite-vec-wasm (high level):
+
 - Initialize a SQLite WASM build that already includes sqlite-vec (static compile).
 - Create a vector table and insert embeddings as float arrays.
 
@@ -282,6 +320,7 @@ ORDER BY knn.distance ASC;
 ```
 
 Notes:
+
 - `vec0` supports metadata columns for filtering in the same query.
 - Store embeddings as float32 arrays (binary) for speed and size.
 - Prefer `k = N` for KNN queries; `LIMIT N` only works on SQLite 3.41+.
@@ -322,28 +361,34 @@ export function l2Normalize(vec: Float32Array): Float32Array {
 ```
 
 Normalization note:
+
 - If the vector distance metric is cosine similarity, L2-normalize both stored embeddings and query vectors.
 - If the metric is dot-product, normalization may be skipped (or still used for stability).
 - Align normalization with the sqlite-vec distance mode used in your build.
 
 Default distance mode recommendation:
+
 - Use `distance_metric=cosine` on the `vec0` table and L2-normalize embeddings and queries.
 - This preserves semantic similarity behavior for text embeddings and avoids scale sensitivity.
 
 ### 2.3.3 Why HNSW Is Not Used (Browser Compatibility)
+
 - HNSW extensions in SQLite are typically native-first and lack reliable browser WASM builds.
 - `sqlite-vec-wasm` is designed for browser compatibility and avoids backend dependencies.
 - This preserves the local-first, privacy-centric goal while keeping acceptable retrieval quality.
 
 ### 2.3.4 Build Recipe (SQLite WASM + sqlite-vec)
+
 Goal: produce a browser-compatible SQLite WASM bundle with sqlite-vec compiled in.
 
 Prereqs:
+
 - SQLite source tree (full checkout, not amalgamation-only).
 - Emscripten SDK installed and activated.
 - sqlite-vec source (single C file extension).
 
 Steps (high-level, from upstream guidance):
+
 1. Build SQLite WASM from the SQLite source tree:
    - `./configure --enable-all`
    - `make sqlite3.c`
@@ -371,13 +416,16 @@ int sqlite3_wasm_extra_init(const char *z){
 ```
 
 Notes:
+
 - WASM builds cannot dynamically load extensions; compile sqlite-vec in at build time.
 - `sqlite3_vec_init` is the sqlite-vec extension entrypoint.
 
 ### 2.4 Performance Strategy
+
 Designed for 1k+ starred repos, with explicit current-state baseline and target-state upgrades.
 
 Current state (implemented):
+
 - Pagination with concurrency limits.
 - README fetching in batches with backoff on rate limit.
 - Incremental sync using checksum diffs.
@@ -385,12 +433,14 @@ Current state (implemented):
 - Single embedding worker with per-text inference loop and frequent DB persistence.
 
 Proposed state (approved):
+
 - Item 1: micro-batch embeddings in each worker (`8..32`, adaptive).
 - Item 2: checkpointed SQLite persistence (record-count and time-based flush).
 - Item 3: bounded worker pool (`2` default; auto-downshift on pressure).
 - Item 4: explicit backend selector (`webgpu` preferred, `wasm` fallback).
 
 Tradeoffs and controls:
+
 - Higher throughput vs. higher peak memory:
   - Control with capped pool size and adaptive batch size.
 - Less frequent persistence vs. small crash-loss window:
@@ -399,11 +449,13 @@ Tradeoffs and controls:
   - Control with deterministic fallback to WASM + backend diagnostics.
 
 Performance requirements:
+
 - Time to first searchable chunks should improve materially over current baseline.
 - Retrieval quality must remain stable (same model, same normalization contract).
 - No UI freeze during indexing on 1k+ stars.
 
 Reference:
+
 - Full execution design, rollout stages, and benchmark protocol: `docs/embedding-acceleration-plan.md`
 
 ---
@@ -411,6 +463,7 @@ Reference:
 ## 3) Security Details
 
 ### 3.1 Data Handling
+
 - Default: all embeddings and repo content stored locally in SQLite WASM DB
 - No server persistence unless user opts in
 - Provide a "Delete all data" button
@@ -419,6 +472,7 @@ Reference:
 - Checksum uses SHA-256 over canonical repo metadata + README content (empty string if missing)
 
 ### 3.2 Token Handling
+
 - GitHub OAuth tokens stored only in memory by default
 - Provider API keys may use optional WebCrypto (AES-GCM) encryption in account-scoped local storage when configured
 - Never log tokens
@@ -426,22 +480,26 @@ Reference:
 - Use OAuth PKCE and avoid tokens in URLs
 
 ### 3.3 External LLM Usage
+
 - Off by default
 - Explicit consent required before sending repo content
 - If enabled, send only top-K chunks (minimized context)
 
 ### 3.4 Content Safety
+
 - Sanitize all README rendering (avoid XSS)
 - Use CSP headers in hosted version
 - Disallow inline scripts in README rendering
 
 ### 3.5 Rate Limits and Abuse Controls
+
 - Respect GitHub rate limit headers
 - Backoff and retry strategy on 403/429
 - Avoid heavy parallel requests
 - Handle GitHub edge cases: missing README and renamed/deleted repos
 
 ### 3.6 Embedding Runtime and Worker Safety
+
 - Cap worker pool size (default `2`) to prevent local resource exhaustion.
 - Cap micro-batch size and auto-downshift on memory pressure.
 - Keep strict allowlist for model download hosts in CSP `connect-src`.
@@ -450,6 +508,7 @@ Reference:
 - Never transmit embedding input text externally as part of optimization path.
 
 ### 3.7 Actionable Security Findings (Pre-Dev Checklist)
+
 - Add strict CSP (no inline scripts, allow only required origins).
 - Sanitize README rendering with `rehype-sanitize`.
 - Enforce OAuth PKCE flow; never place tokens in URLs.
@@ -468,12 +527,14 @@ Reference:
 ## 4) Threat Model
 
 ### 4.1 Assets
+
 - GitHub tokens (OAuth or PAT)
 - Public repo README content
 - Local embeddings and index
 - User query history
 
 ### 4.2 Threats
+
 1. Token exfiltration via XSS or dependency compromise
 2. Leakage of repository content to external LLM providers
 3. Local provider exposure: sending data to a local endpoint that is not trusted
@@ -486,6 +547,7 @@ Reference:
 10. Backend variability causing silent acceleration fallback or unstable behavior
 
 ### 4.3 Mitigations
+
 1. CSP + strict README sanitization
 2. Explicit opt-in for any LLM provider
 3. Separate toggle for Local providers with clear "local endpoint" disclosure
@@ -499,6 +561,7 @@ Reference:
 11. Backend probe and deterministic fallback from `webgpu` to `wasm`
 
 ### 4.4 Residual Risks
+
 - If user enables external LLMs, repo content leaves the browser
 - If local device is compromised, local storage can be accessed
 - GPU/browser driver variability may still affect acceleration consistency
@@ -508,29 +571,35 @@ Reference:
 ## 5) PRD (Product Requirements Document)
 
 ### 5.1 Problem Statement
+
 Developers star many repositories over time and cannot easily recall them when they remember only functionality or details.
 
 ### 5.2 Goals
+
 - Import all starred repos quickly
 - Provide fast natural language search
 - Keep data local by default
 - Support multiple LLM providers optionally
 
 ### 5.3 Non-Goals
+
 - Replace GitHub global search
 - Multi-user enterprise features in MVP
 
 ### 5.4 Target Users
+
 - Developers with 100+ starred repos
 - Open-source heavy users
 - Individuals who prefer privacy-first tooling
 
 ### 5.5 User Stories
+
 1. "Find the repo I starred for a lightweight vector search library in JS."
 2. "Show me repos I starred about OAuth middleware."
 3. "Suggest repos I starred for scraping or crawling."
 
 ### 5.6 Functional Requirements
+
 - GitHub OAuth or PAT login
 - Fetch all starred repos with pagination
 - Fetch README for each repo
@@ -551,6 +620,7 @@ Developers star many repositories over time and cannot easily recall them when t
 - Clear empty states when a user has no stars or no README content
 
 ### 5.7 Non-Functional Requirements
+
 - Fast: indexing visible progress, partial results within 120 seconds for 1k stars
 - Secure: no token leakage, no data sent without consent
 - Reliable: robust error handling, retry strategy
@@ -558,6 +628,7 @@ Developers star many repositories over time and cannot easily recall them when t
 - Compatible: browser-only functionality on Windows/macOS/Linux with graceful CPU fallback
 
 ### 5.8 Success Metrics
+
 - Time to first results < 120 seconds for 1k stars
 - Query response time < 2 seconds after indexing
 - > 80% success in manual relevance evaluation
@@ -566,6 +637,7 @@ Developers star many repositories over time and cannot easily recall them when t
 - No relevance regression on fixed query-set evaluation
 
 ### 5.9 MVP Scope
+
 - OAuth/PAT login
 - Fetch stars + README
 - Local embeddings + SQLite WASM + `sqlite-vec-wasm`
@@ -576,6 +648,7 @@ Developers star many repositories over time and cannot easily recall them when t
 - MVP: use prebuilt sqlite-vec-wasm bundle for speed of iteration
 
 ### 5.10 Post-MVP Enhancements
+
 - Cross-device sync (opt-in)
 - Repo metadata enrichment (topics, tags)
 - Advanced filters (language, date, stars)
@@ -584,6 +657,7 @@ Developers star many repositories over time and cannot easily recall them when t
 - Production hardening: custom-built SQLite WASM + sqlite-vec bundle with pinned versions
 
 ### 5.11 Migration Checklist (Prebuilt -> Custom Bundle)
+
 - Pin SQLite and sqlite-vec versions (document in repo).
 - Build SQLite WASM with sqlite-vec statically compiled.
 - Verify `vec_version()` matches pinned version.
@@ -592,13 +666,16 @@ Developers star many repositories over time and cannot easily recall them when t
 - Update docs to point to the custom bundle artifact.
 
 ### 5.12 Vector Search Sanity Test (Suggested)
+
 Purpose: validate sqlite-vec behavior after a bundle change.
 
 Test dataset:
+
 - 3 vectors with known neighbors (simple 3D or 5D examples).
 - Use a fixed query vector with known nearest results.
 
 Pseudo-test:
+
 ```sql
 -- Create vec table
 CREATE VIRTUAL TABLE vec_test USING vec0(
@@ -621,9 +698,11 @@ ORDER BY distance ASC;
 ```
 
 Expected:
+
 - The first result is `a` and the second is `b`.
 
 TypeScript harness (browser, pseudo-code):
+
 ```ts
 // Assume sqlite-vec-wasm is already initialized as `db`
 await db.exec(`
@@ -656,23 +735,28 @@ console.assert(rows[0][0] === "a" && rows[1][0] === "b");
 ## 6) Implementation Phases (High Level)
 
 ### Phase 1 - Foundations
+
 - Project scaffolding, UI shell, GitHub auth
 - Stars fetching and pagination
 
 ### Phase 2 - Indexing
+
 - README fetcher and chunker
 - Embedding generation in Web Worker
 - SQLite WASM storage and vector index
 
 ### Phase 3 - Search
+
 - Query UI and retrieval
 - Result ranking and filters
 
 ### Phase 4 - Optional LLM
+
 - Provider abstraction
 - Summaries and suggestions
 
 ### Phase 5 - Embedding Acceleration
+
 - Micro-batch worker API
 - Checkpointed DB persistence
 - Worker pool scheduling
@@ -682,13 +766,16 @@ console.assert(rows[0][0] === "a" && rows[1][0] === "b");
 ---
 
 ## 7) Open Decisions
+
 Resolved decisions:
+
 - Frontend: Vite + React
 - Browser embedding model policy: capability-driven (`embeddinggemma` on strong desktop, MiniLM fallback on mobile/weak/no-WebGPU)
 - Ollama recommended embeddings: `qwen3-embedding:4b`, `qwen3-embedding:0.6b`, `mxbai-embed-large`
 - Local vector strategy: SQLite WASM + `sqlite-vec-wasm`
 
 Active decisions:
+
 - Final default batch-size adaptation policy for low-memory devices
 - Whether to enable worker pool by default on first release or behind feature flag
 - Whether optional local Ollama embedding bridge should remain default-off for all users
@@ -698,6 +785,7 @@ Active decisions:
 ## 8) Implementation Update (2026-02-23)
 
 Implemented architecture deltas:
+
 - Embedding queue is materialized once per run (pending chunk preload) instead of repeated DB polling in the hot loop.
 - Pending chunk SQL joins now use normalized key join (`e.chunk_id = c.id`) with dedicated indexes.
 - Embedding compute and DB writes are decoupled through an in-memory buffer and size-based flush policy.
@@ -710,5 +798,6 @@ Implemented architecture deltas:
   - graceful restart to browser embedding when Ollama fails mid-run
 
 Trust-boundary note:
+
 - Ollama embedding bridge remains inside local trust boundary only; non-local endpoints are rejected.
 - GitHub auth tokens remain browser-local and are not included in embedding payloads.

--- a/docs/tech-stack-architecture-security-prd.md
+++ b/docs/tech-stack-architecture-security-prd.md
@@ -3,10 +3,15 @@
 > **HISTORICAL — pre-implementation planning document. Retained for provenance; not accurate for the
 > shipped system.**
 >
-> This was written before implementation and describes choices that were never shipped — most
-> notably `sqlite-vec` / `sqlite-vec-wasm` for vector search. The shipped app uses sql.js with
-> Float32 vector blobs in ordinary SQLite tables, ranked in-process with exact cosine similarity plus
-> MMR, persisted to OPFS with a scoped localStorage snapshot fallback.
+> This was written before implementation and describes choices that were never shipped. At least three
+> are wrong for the current system, and no section of this document should be assumed accurate:
+>
+> - **`sqlite-vec` / `sqlite-vec-wasm`** for vector search (§1.2, §2.3.2, §2.3.4). The shipped app uses
+>   sql.js with Float32 vector blobs in ordinary SQLite tables, ranked in-process with exact cosine
+>   similarity plus MMR, persisted to OPFS with a scoped localStorage snapshot fallback.
+> - **TanStack Query** for data fetching and caching (§1.1). Not a dependency; never used.
+> - **An optional Next.js or Fastify backend** (§1.4). No such backend exists. The only server-side code
+>   is a single stateless serverless OAuth token-exchange function.
 >
 > For the current system, use these sources instead:
 >

--- a/docs/threat-modeling-stride.md
+++ b/docs/threat-modeling-stride.md
@@ -7,6 +7,7 @@ This document maps risks using the STRIDE model and lists mitigations aligned wi
 ## 1) Scope and Assets
 
 In scope:
+
 - GitHub tokens (OAuth/PAT)
 - Starred public-repo metadata and README content
 - Embeddings and vector index
@@ -21,6 +22,7 @@ In scope:
 - User queries
 
 Out of scope:
+
 - GitHub platform internals
 - Third-party LLM provider infrastructure
 
@@ -29,7 +31,9 @@ Out of scope:
 ## 2) STRIDE Analysis
 
 ### S - Spoofing
+
 Threats:
+
 - Attacker impersonates user in the browser (session spoofing).
 - Malicious site tricks user into pasting PAT into a fake UI.
 - User pastes a header-form or quoted token value and auth flow misinterprets it, leading to avoidable 401s and unsafe retry behavior.
@@ -37,6 +41,7 @@ Threats:
 - Unintended model artifact host access when Browser WebLLM is enabled.
 
 Mitigations:
+
 - Use OAuth PKCE and avoid tokens in URL.
 - Clear separation between landing and login flow.
 - Add warning banner when PAT is used; recommend OAuth.
@@ -47,7 +52,9 @@ Mitigations:
 - Gate Browser WebLLM behind explicit feature flag and user consent-before-download.
 
 ### T - Tampering
+
 Threats:
+
 - Local DB tampering (malicious extensions, XSS).
 - Modified embeddings or vectors change search results.
 - Injected README content leading to unsafe output.
@@ -56,6 +63,7 @@ Threats:
 - Runtime script load blocked by CSP drift (ORT module load failure).
 
 Mitigations:
+
 - Sanitize README rendering.
 - Use CSP + no inline scripts.
 - Validate checksum format and store checksum for integrity checks.
@@ -66,20 +74,25 @@ Mitigations:
 - Add end-to-end embedding count reconciliation (`chunks_pending + embeddings_created`).
 
 ### R - Repudiation
+
 Threats:
+
 - User cannot confirm what data was fetched or sent externally.
 - No record of consent to external LLM usage.
 - No record of Browser WebLLM model-download consent.
 - User cannot confirm which embedding backend was active when results were generated.
 
 Mitigations:
+
 - Store audit metadata locally: last sync time, LLM usage toggle timestamps.
 - Display a “data sent” notice when remote LLMs are enabled.
 - Store and restore per-auth WebLLM consent + model preference locally.
 - Store embedding run metadata: backend, worker pool size, checkpoint policy version, fallback reason.
 
 ### I - Information Disclosure
+
 Threats:
+
 - README content sent to external LLM provider unintentionally.
 - Tokens leaked through logs or URL parameters.
 - Local DB accessed by other scripts via XSS.
@@ -87,6 +100,7 @@ Threats:
 - Local reset leaves browser-cached model/runtime artifacts behind after the user expects a full wipe.
 
 Mitigations:
+
 - External LLM off by default, explicit opt-in.
 - Browser WebLLM download is explicit opt-in; no GitHub token in request payloads.
 - Send only top-K snippets, not full repo content.
@@ -101,7 +115,9 @@ Mitigations:
 - Ollama embedding request payload must not include GitHub tokens or PAT values.
 
 ### D - Denial of Service
+
 Threats:
+
 - GitHub API rate-limits block sync.
 - Large number of stars (1k+) causes UI freeze.
 - Long README content creates memory pressure.
@@ -109,6 +125,7 @@ Threats:
 - WebGPU driver/runtime instability causes repeated failures.
 
 Mitigations:
+
 - Rate limit handling with backoff.
 - Concurrency caps for README fetching.
 - Chunking and truncation of huge README files.
@@ -121,7 +138,9 @@ Mitigations:
 - Discard unreadable legacy token-scoped DB snapshots during one-time scope migration so corrupt historical data does not permanently block login.
 
 ### E - Elevation of Privilege
+
 Threats:
+
 - Over-scoped GitHub token allows repo access beyond need.
 - Local LLM endpoints expose sensitive data to other local services.
 - Browser origin accidentally gains unintended access to privileged local runtime endpoints.
@@ -131,6 +150,7 @@ Threats:
 - Misleading auth troubleshooting guidance nudges users toward creating broader-scope tokens when the real issue is token validity or formatting.
 
 Mitigations:
+
 - Use minimal GitHub scopes or fine-grained PAT.
 - Clearly label local endpoints and require explicit opt-in.
 - Keep browser embedding path default; local Ollama runtime integration remains explicit and isolated.
@@ -144,7 +164,10 @@ Mitigations:
 ## 3) Security Requirements Traceability
 
 Mapped requirements:
-- Local-first storage: SQLite WASM + sqlite-vec.
+
+- Local-first storage: SQLite WASM via sql.js, persisted to OPFS with a scoped localStorage snapshot
+  fallback. Embeddings are Float32 blobs in ordinary tables ranked in-process (exact cosine + MMR);
+  no `sqlite-vec` extension is used.
 - GitHub-account-scoped local persistence for SQLite and settings continuity.
 - Shared GitHub token normalization before in-memory storage/use.
 - OAuth PKCE and PAT fallback with warnings.
@@ -159,6 +182,7 @@ Mapped requirements:
 ---
 
 ## 4) Residual Risk Summary
+
 - External LLM usage still sends data off-device by design.
 - Client device compromise exposes local data.
 
@@ -167,6 +191,7 @@ Mapped requirements:
 ## 5) Privacy Impact Assessment (PIA)
 
 ### 5.1 Data Categories
+
 - GitHub user identity (username, avatar, profile URL)
 - Starred repo metadata and README content
 - Public repo content
@@ -174,27 +199,32 @@ Mapped requirements:
 - Local embeddings and vector index
 
 ### 5.2 Purpose of Processing
+
 - Local-first semantic search over user’s starred repositories
 - Optional LLM-based summaries and recommendations
 - Sync and integrity validation of starred repo data
 
 ### 5.3 Data Storage and Retention
+
 - Stored locally in browser (SQLite WASM + OPFS where available)
 - No server-side retention unless user opts in
 - User can delete all data at any time
 
 ### 5.4 Data Sharing
+
 - None by default
 - Optional sharing with external LLM providers (explicit opt-in only)
 - Optional sharing with local LLM endpoints (explicit opt-in only)
 
 ### 5.5 User Rights and Controls
+
 - Clear toggle for remote/local LLM usage
 - “Clear all data” and “Clear token” actions
 - Visible disclosure when data is sent externally
 - Local data reset also clears WebLLM/model runtime caches where supported
 
 ### 5.6 Risk Assessment
+
 - Low risk for users who keep LLMs off (local-only)
 - Medium risk for users who enable remote LLMs (data leaves device)
 - Mitigated by explicit opt-in and minimal top-K context
@@ -203,6 +233,7 @@ Mapped requirements:
 ---
 
 ## 6) Recommended Tests
+
 - Simulate XSS in README rendering.
 - Token leakage scanning (no tokens in logs).
 - Token normalization coverage for `Bearer ` / `token ` / quoted GitHub token pastes.

--- a/docs/threat-modeling-stride.md
+++ b/docs/threat-modeling-stride.md
@@ -291,3 +291,47 @@ Mitigations:
 - Keep raw GitHub tokens in memory only and derive scoped local keys from the authenticated GitHub account identity rather than persisting the raw value or tying persistence to rotating credentials.
 - Keep 401 remediation focused on token validity/formatting issues before scope expansion.
 - Clear browser runtime/model caches during local data reset.
+
+---
+
+## 9) v0.14.0 Public-Launch Threat Delta (2026-07-28)
+
+Covers the lean remediation program (PRs #46, #47, #54, #55, #56). Per-commit evidence and the list of
+deliberately deferred work: [`remediation/v0.14.0.md`](./remediation/v0.14.0.md).
+
+New/changed components:
+
+- Serverless OAuth exchange endpoint hardened at the request boundary (`api/github/oauth/exchange.js`).
+- Production security headers served from `vercel.json`, and explicit entry-route rewrites replacing the
+  catch-all SPA rewrite.
+- Single-writer storage: a Web Locks exclusive lease per scope (`acquireWriterLease`,
+  `LocalDatabaseWriterLeaseError`), plus a serialized workspace persistence queue.
+- Per-identity scoping extended to chat backups, local diagnostic logs, provider settings, and preferences.
+- Confirmed, category-enumerating local-data deletion with partial-failure reporting.
+- Embedding integrity enforcement: one current embedding per chunk with model/dimension/coverage validation.
+- Lazily loaded authenticated route chunks behind a Suspense boundary.
+
+Threat notes:
+
+| Category | Threat                                                                                                                          | Mitigation                                                                                                                                                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T        | Two tabs on one scope interleave whole-database exports, so the later writer silently discards the earlier one's committed rows | One writing tab per scope via a Web Locks exclusive lease; a second tab is refused writes instead of last-writer-wins. Writes are serialized through a single persistence queue so the newest acknowledged mutation is the durable one |
+| T        | Unbounded or non-JSON request bodies to the exchange endpoint, or a hung upstream call                                          | POST-only, JSON content-type check, 8 KiB body cap returning 413, exact field validation, and an `AbortController` upstream timeout                                                                                                    |
+| I        | A cross-identity read of local data on a shared browser profile                                                                 | Database file/key, chat backups, logs, provider settings, and preferences are all scoped per authenticated GitHub identity; a scoped clear fails closed rather than reporting success                                                  |
+| I        | Diagnostic logs retaining tokens, README text, or query strings                                                                 | Error details are dropped entirely at capture; warning payloads are reduced to an allowlisted set of numeric and boolean fields; entries are capped at 200 and expire after 7 days                                                     |
+| I        | An unknown public path returning a 200 HTML shell, exposing authenticated route structure to crawlers                           | Explicit entry-route rewrites; unknown paths return a real 404, and authenticated routes are absent from the sitemap                                                                                                                   |
+| R        | Deletion reporting success while data survives                                                                                  | Every category is attempted, failures are collected per category and surfaced, sign-out happens only on full success, and OPFS removal failures propagate rather than being swallowed                                                  |
+| E        | A stale or mixed-model vector store producing meaningless similarity scores                                                     | One current embedding per chunk enforced, with model, dimension, and coverage readiness validation, plus a hard query/index dimension guard                                                                                            |
+
+Residual risks accepted in this release:
+
+- The Web Locks lease resolves as available when `navigator.locks` is absent, so a browser without Web
+  Locks does not fail closed for a second writer.
+- `migrateLocalDatabaseScope` still treats OPFS cleanup as best effort, so a stale snapshot can survive
+  the scope-migration path even though `clearAllData` now propagates failures.
+- `clearAllData` swaps the in-memory database before removing persisted bytes, so a failed deletion
+  leaves an empty in-memory view over surviving persisted rows, reported as a partial deletion.
+- The production CSP retains `'unsafe-eval'`, which the in-browser model runtimes require. This is a
+  documented runtime-compatibility trade-off, not a separate ADR.
+- Whether a platform-side rate limit is enabled for `/api/github/oauth/exchange` is not verifiable from
+  this repository; no in-tree limiter was added.

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         "description": "Local-first semantic search for GitHub starred repositories with browser embeddings and optional WebLLM/Ollama generation.",
         "url": "https://git-star-recall.vercel.app/",
         "image": "https://git-star-recall.vercel.app/static/gitstarrecall-logo.png",
-        "softwareVersion": "0.1.0"
+        "softwareVersion": "0.14.0"
       }
     </script>
   </head>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitstarrecall",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.14.0",
   "type": "module",
   "packageManager": "pnpm@11.17.0",
   "engines": {

--- a/scripts/deployment-config.test.mjs
+++ b/scripts/deployment-config.test.mjs
@@ -42,6 +42,7 @@ describe("production deployment configuration", () => {
 
     expect(headers["Content-Security-Policy"]).toContain("default-src 'self'");
     expect(headers["Content-Security-Policy"]).toContain("frame-ancestors 'none'");
+    expect(headers["Content-Security-Policy"]).toContain("frame-src 'none'");
     expect(headers["Content-Security-Policy"]).toContain("worker-src 'self' blob:");
     expect(headers["Content-Security-Policy"]).toContain(
       "connect-src 'self' https: http://localhost:* http://127.0.0.1:*",

--- a/src/App.lazy-route-error.test.tsx
+++ b/src/App.lazy-route-error.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Outlet } from "react-router-dom";
+import App from "./App";
+
+vi.mock("./auth/AuthContext", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./features/theme/ThemeProvider", () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./features/navigation/RequireAuth", () => ({ RequireAuth: () => <Outlet /> }));
+vi.mock("./features/app-shell/AppShell", () => ({
+  AppShell: () => (
+    <div>
+      <p>shell chrome</p>
+      <Outlet />
+    </div>
+  ),
+}));
+vi.mock("./layouts/PublicLayout", () => ({ default: () => <Outlet /> }));
+vi.mock("./pages/auth/AuthCallbackPage", () => ({ default: () => null }));
+vi.mock("./pages/LandingPage", () => ({ default: () => null }));
+vi.mock("./pages/app/LibraryPage", () =>
+  Promise.reject(new Error("simulated route chunk load failure")),
+);
+
+it("keeps the authenticated shell mounted when a lazy route import rejects", async () => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  render(
+    <MemoryRouter initialEntries={["/app/library"]}>
+      <App />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByRole("alert")).toHaveTextContent("Page failed to load");
+  expect(screen.getByRole("button", { name: "Reload page" })).toBeInTheDocument();
+  expect(screen.getByText("shell chrome")).toBeInTheDocument();
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});

--- a/src/App.suspense.test.tsx
+++ b/src/App.suspense.test.tsx
@@ -23,10 +23,10 @@ vi.mock("./pages/auth/AuthCallbackPage", () => ({ default: () => null }));
 vi.mock("./pages/LandingPage", () => ({ default: () => null }));
 vi.mock("./pages/app/AppHomePage", () => ({ default: () => <p>home page</p> }));
 vi.mock("./pages/app/LibraryPage", () => ({ default: () => <p>library page</p> }));
-vi.mock("./pages/app/RecallPage", () => ({ default: () => null }));
 vi.mock("./pages/app/SessionsPage", () => ({ default: () => null }));
-vi.mock("./pages/app/SettingsPage", () => ({ default: () => null }));
-vi.mock("./pages/app/SetupPage", () => ({ default: () => null }));
+vi.mock("./pages/UsagePage", () => ({
+  default: ({ view }: { view: string }) => <p>usage view: {view}</p>,
+}));
 
 describe("App authenticated route suspense", () => {
   it("announces an accessible fallback while a lazy page resolves, then renders the page", async () => {
@@ -57,5 +57,19 @@ describe("App authenticated route suspense", () => {
 
     await waitFor(() => expect(screen.getByText("home page")).toBeInTheDocument());
     expect(screen.getByText("shell chrome")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["/app/setup", "setup"],
+    ["/app/recall", "recall"],
+    ["/app/settings", "settings"],
+  ])("loads UsagePage directly for %s", async (path, view) => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText(`usage view: ${view}`)).toBeInTheDocument());
   });
 });

--- a/src/App.suspense.test.tsx
+++ b/src/App.suspense.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Outlet } from "react-router-dom";
+import App from "./App";
+
+vi.mock("./auth/AuthContext", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./features/theme/ThemeProvider", () => ({
+  ThemeProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./features/navigation/RequireAuth", () => ({ RequireAuth: () => <Outlet /> }));
+vi.mock("./features/app-shell/AppShell", () => ({
+  AppShell: () => (
+    <div>
+      <p>shell chrome</p>
+      <Outlet />
+    </div>
+  ),
+}));
+vi.mock("./layouts/PublicLayout", () => ({ default: () => <Outlet /> }));
+vi.mock("./pages/auth/AuthCallbackPage", () => ({ default: () => null }));
+vi.mock("./pages/LandingPage", () => ({ default: () => null }));
+vi.mock("./pages/app/AppHomePage", () => ({ default: () => <p>home page</p> }));
+vi.mock("./pages/app/LibraryPage", () => ({ default: () => <p>library page</p> }));
+vi.mock("./pages/app/RecallPage", () => ({ default: () => null }));
+vi.mock("./pages/app/SessionsPage", () => ({ default: () => null }));
+vi.mock("./pages/app/SettingsPage", () => ({ default: () => null }));
+vi.mock("./pages/app/SetupPage", () => ({ default: () => null }));
+
+describe("App authenticated route suspense", () => {
+  it("announces an accessible fallback while a lazy page resolves, then renders the page", async () => {
+    render(
+      <MemoryRouter initialEntries={["/app/library"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent("Loading page");
+
+    await waitFor(() => expect(screen.getByText("library page")).toBeInTheDocument());
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("keeps the shell chrome mounted while the page chunk is pending", async () => {
+    render(
+      <MemoryRouter initialEntries={["/app"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    // The boundary sits at the outlet, so the shell renders alongside the fallback.
+    expect(screen.getByText("shell chrome")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText("home page")).toBeInTheDocument());
+    expect(screen.getByText("shell chrome")).toBeInTheDocument();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, type ReactNode } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider } from "./auth/AuthContext";
+import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 import { ThemeProvider } from "./features/theme/ThemeProvider";
 import { RequireAuth } from "./features/navigation/RequireAuth";
 import { AppShell } from "./features/app-shell/AppShell";
@@ -13,10 +14,8 @@ import NotFoundPage from "./pages/NotFoundPage";
 // callback routes do not pay for them. `/` and `/auth/callback` stay eager.
 const AppHomePage = lazy(() => import("./pages/app/AppHomePage"));
 const LibraryPage = lazy(() => import("./pages/app/LibraryPage"));
-const RecallPage = lazy(() => import("./pages/app/RecallPage"));
 const SessionsPage = lazy(() => import("./pages/app/SessionsPage"));
-const SettingsPage = lazy(() => import("./pages/app/SettingsPage"));
-const SetupPage = lazy(() => import("./pages/app/SetupPage"));
+const UsagePage = lazy(() => import("./pages/UsagePage"));
 
 function RouteFallback() {
   return (
@@ -34,8 +33,18 @@ function RouteFallback() {
  * Boundary sits at the outlet rather than around `AppShell`, so the shell chrome
  * stays rendered while a page chunk resolves.
  */
+function SuspendedRoute({ children }: { children: ReactNode }) {
+  const location = useLocation();
+
+  return (
+    <RouteErrorBoundary key={location.pathname}>
+      <Suspense fallback={<RouteFallback />}>{children}</Suspense>
+    </RouteErrorBoundary>
+  );
+}
+
 function suspended(page: ReactNode): ReactNode {
-  return <Suspense fallback={<RouteFallback />}>{page}</Suspense>;
+  return <SuspendedRoute>{page}</SuspendedRoute>;
 }
 
 export default function App() {
@@ -51,11 +60,11 @@ export default function App() {
           <Route element={<RequireAuth />}>
             <Route path="/app" element={<AppShell />}>
               <Route index element={suspended(<AppHomePage />)} />
-              <Route path="setup" element={suspended(<SetupPage />)} />
-              <Route path="recall" element={suspended(<RecallPage />)} />
+              <Route path="setup" element={suspended(<UsagePage view="setup" />)} />
+              <Route path="recall" element={suspended(<UsagePage view="recall" />)} />
               <Route path="library" element={suspended(<LibraryPage />)} />
               <Route path="sessions" element={suspended(<SessionsPage />)} />
-              <Route path="settings" element={suspended(<SettingsPage />)} />
+              <Route path="settings" element={suspended(<UsagePage view="settings" />)} />
             </Route>
           </Route>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Suspense, lazy, type ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
 import { AuthProvider } from "./auth/AuthContext";
 import { ThemeProvider } from "./features/theme/ThemeProvider";
@@ -5,14 +6,37 @@ import { RequireAuth } from "./features/navigation/RequireAuth";
 import { AppShell } from "./features/app-shell/AppShell";
 import PublicLayout from "./layouts/PublicLayout";
 import AuthCallbackPage from "./pages/auth/AuthCallbackPage";
-import AppHomePage from "./pages/app/AppHomePage";
-import LibraryPage from "./pages/app/LibraryPage";
-import RecallPage from "./pages/app/RecallPage";
-import SessionsPage from "./pages/app/SessionsPage";
-import SettingsPage from "./pages/app/SettingsPage";
-import SetupPage from "./pages/app/SetupPage";
 import LandingPage from "./pages/LandingPage";
 import NotFoundPage from "./pages/NotFoundPage";
+
+// Authenticated pages load on demand so the unauthenticated landing and OAuth
+// callback routes do not pay for them. `/` and `/auth/callback` stay eager.
+const AppHomePage = lazy(() => import("./pages/app/AppHomePage"));
+const LibraryPage = lazy(() => import("./pages/app/LibraryPage"));
+const RecallPage = lazy(() => import("./pages/app/RecallPage"));
+const SessionsPage = lazy(() => import("./pages/app/SessionsPage"));
+const SettingsPage = lazy(() => import("./pages/app/SettingsPage"));
+const SetupPage = lazy(() => import("./pages/app/SetupPage"));
+
+function RouteFallback() {
+  return (
+    <div role="status" aria-live="polite" className="flex min-h-[50vh] items-center justify-center">
+      <div
+        aria-hidden="true"
+        className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"
+      />
+      <span className="sr-only">Loading page</span>
+    </div>
+  );
+}
+
+/**
+ * Boundary sits at the outlet rather than around `AppShell`, so the shell chrome
+ * stays rendered while a page chunk resolves.
+ */
+function suspended(page: ReactNode): ReactNode {
+  return <Suspense fallback={<RouteFallback />}>{page}</Suspense>;
+}
 
 export default function App() {
   return (
@@ -26,12 +50,12 @@ export default function App() {
 
           <Route element={<RequireAuth />}>
             <Route path="/app" element={<AppShell />}>
-              <Route index element={<AppHomePage />} />
-              <Route path="setup" element={<SetupPage />} />
-              <Route path="recall" element={<RecallPage />} />
-              <Route path="library" element={<LibraryPage />} />
-              <Route path="sessions" element={<SessionsPage />} />
-              <Route path="settings" element={<SettingsPage />} />
+              <Route index element={suspended(<AppHomePage />)} />
+              <Route path="setup" element={suspended(<SetupPage />)} />
+              <Route path="recall" element={suspended(<RecallPage />)} />
+              <Route path="library" element={suspended(<LibraryPage />)} />
+              <Route path="sessions" element={suspended(<SessionsPage />)} />
+              <Route path="settings" element={suspended(<SettingsPage />)} />
             </Route>
           </Route>
 

--- a/src/components/RouteErrorBoundary.test.tsx
+++ b/src/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RouteErrorBoundary } from "./RouteErrorBoundary";
+
+function BrokenPage(): never {
+  throw new Error("page render failed");
+}
+
+describe("RouteErrorBoundary", () => {
+  it("shows an accessible failure state and runs the reload recovery action", () => {
+    const onReload = vi.fn();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <RouteErrorBoundary onReload={onReload}>
+        <BrokenPage />
+      </RouteErrorBoundary>,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Page failed to load");
+    expect(alert).toHaveTextContent("reload to fetch the latest version");
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload page" }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ReactNode } from "react";
+import { Button } from "./ui/button";
+
+type RouteErrorBoundaryProps = {
+  children: ReactNode;
+  onReload?: () => void;
+};
+
+type RouteErrorBoundaryState = {
+  hasError: boolean;
+};
+
+function reloadPage() {
+  window.location.reload();
+}
+
+export class RouteErrorBoundary extends Component<
+  RouteErrorBoundaryProps,
+  RouteErrorBoundaryState
+> {
+  state: RouteErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): RouteErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-[50vh] items-center justify-center px-4">
+          <div
+            role="alert"
+            className="max-w-md space-y-4 rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-center"
+          >
+            <div className="space-y-2">
+              <h1 className="text-lg font-semibold">Page failed to load</h1>
+              <p className="text-sm text-muted-foreground">
+                Check your connection, then reload to fetch the latest version of this page.
+              </p>
+            </div>
+            <Button type="button" onClick={this.props.onReload ?? reloadPage}>
+              Reload page
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.8.1/dist/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' https: data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:*; frame-src https://www.youtube.com https://player.vimeo.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.8.1/dist/; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' https: data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:*; frame-src 'none'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "no-referrer" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,8 @@ const BASE_CSP_DIRECTIVES = [
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com data:",
   "img-src 'self' https: data:",
-  "frame-src https://www.youtube.com https://player.vimeo.com",
+  // No surface embeds a frame. Keep this at 'none' and align vercel.json if that ever changes.
+  "frame-src 'none'",
   "worker-src 'self' blob:",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
## Summary

- Lazy-load authenticated route pages behind an accessible Suspense boundary while keeping public routes eager.
- Align v0.14.0 package and JSON-LD metadata, environment guidance, current setup docs, and historical-document status.
- Add a concise remediation evidence record with implemented, deferred, and externally unverifiable items separated.

## Finding coverage

Lean PR 6 release slice: bundle entry loading, current documentation, release metadata, and evidence closure.

## Before / after proof

- Authenticated page modules were eager; they now produce separate chunks while the AppShell stays visible during loading.
- Main entry JavaScript: 6,966,375 raw / 2,425,690 gzip bytes to 523,958 raw / 159,652 gzip bytes.
- Largest JavaScript chunk: 6,966,375 raw to 6,192,104 raw; total JavaScript remains within the existing fixed budget.

## Validation

- pnpm run ci: passed (606 tests; changed-line coverage 100%; production build; all bundle budgets; Chromium 12/12).
- git diff --check: passed.
- No dependency, lockfile, bundle-policy, storage/privacy, or intentional visual-design change.

## Migration / rollback

- No stored-data migration. Revert the independent merge commit to restore eager route imports and prior documentation.

## UI / security / performance

- Only new visible state is the accessible authenticated-page loading spinner; shell chrome remains rendered.
- No security-boundary change.
- Release documentation identifies residual risks and external Vercel configuration that cannot be proven from source.

## Deferred work

No multi-tab coordinator, OPFS VFS migration, broad decomposition, ranking worker, 50k benchmark suite, hard 40% target, nightly browser matrix, paid firewall mandate, or broad document rewrite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated app pages now load on demand, with an accessible loading indicator while content appears.
  * Added configuration options for GitHub OAuth redirect handling and durable database checkpoints.
  * Updated release metadata to version 0.14.0.

* **Documentation**
  * Clarified local OAuth setup, supported development workflows, prerequisites, storage behavior, privacy safeguards, and current architecture.
  * Added public-launch remediation and release documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->